### PR TITLE
MCPL 0.5: migrate bespoke tags to the chat:* core, declare a feature set

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -19,7 +19,13 @@ type Entity = { id: string; lib: string; pos: number[]; yaw: number; actor: stri
   /** component bag (sockets, reactions, motion, …) — what a thing can DO;
    *  this is how affordances reach text-tier perception */
   comp?: Record<string, any> };
-type Person = { id: string; avatar: string; pose: Pose | null };
+/** `agent` is what the world says about this body: the sequencer forwards the
+ *  joiner's own `agent` flag on `arrive` and in the join snapshot's `present`
+ *  list (server/server.ts:1755-1759). It is self-asserted, so it is testimony,
+ *  and it feeds only the `chat:from-human` / `chat:from-agent` tag facet, which
+ *  authorizes nothing (MCPL SPEC §16.6). Absent ⇒ unknown, and unknown stays
+ *  unlabelled rather than guessed. */
+type Person = { id: string; avatar: string; pose: Pose | null; agent?: boolean };
 type InboxItem = { ts: number; kind: "say" | "arrive" | "leave" | "act"; who: string; text?: string; seq?: number | null };
 
 /** Folded world state back into the verbs that produced it. Must stay in step
@@ -274,7 +280,7 @@ export class WorldAgent {
               if (msg.restore.pose && msg.restore.clip !== "ragdoll") this.heldPose = msg.restore.pose;
             }
             this.restoredPose = true;
-            for (const p of msg.present) this.people.set(p.id, { id: p.id, avatar: p.avatar, pose: p.pose });
+            for (const p of msg.present) this.people.set(p.id, { id: p.id, avatar: p.avatar, pose: p.pose, ...(typeof p.agent === "boolean" ? { agent: p.agent } : {}) });
             // A join is now the folded world plus a tail, not the whole log.
             // An agent that only read `entries` would arrive in an empty room.
             const oldestTail = msg.entries.length
@@ -332,7 +338,7 @@ export class WorldAgent {
           case "arrive":
             // the people map is truth and updates NOW; the narration goes
             // through the gate, where a reconnect flap collapses to nothing
-            this.people.set(msg.id, { id: msg.id, avatar: msg.avatar, pose: null });
+            this.people.set(msg.id, { id: msg.id, avatar: msg.avatar, pose: null, ...(typeof msg.agent === "boolean" ? { agent: msg.agent } : {}) });
             this.gate.presence(msg.id, "arrive");
             break;
           case "leave":

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -30,7 +30,9 @@ import {
   type ChannelsIncomingParams,
   type ChannelsPublishParams,
   type ChannelsPublishResult,
+  ERR_UNKNOWN_CHANNEL,
 } from "@animalabs/mcpl-core";
+import { CHAT, EIDO, tags, senderTag, MCPL_ADVERTISEMENT } from "./tags.ts";
 import { WorldAgent } from "./agent.ts";
 import { verifyToken } from "../server/aid1.ts";
 import sharp from "sharp";
@@ -92,7 +94,7 @@ const TOOLS = [
   { name: "stop", description: "Stop walking.", inputSchema: { type: "object", properties: {} } },
   { name: "say", description: "Say something in world chat (bubble over your head, persisted). Equivalent to publishing on the world channel.", inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
   { name: "catch_up", description: "What happened in the world while you were not thinking. Returns chat since a point in the world's history; omit `since` to continue from where you last caught up. Use when a conversation refers to something you have no memory of.", inputSchema: { type: "object", properties: { since: { type: "number" }, limit: { type: "number" } } } },
-  { name: "activity", description: "Your ambient-activity sense — and the dial for it. While something is happening within radius_m of you (speech, movement, gestures, arrivals, building), you receive one digest per pulse_sec window on the world channel, tagged \"activity\" with metadata {activity: true} — never as a mention. If your host lets you configure wake rules, match that tag/metadata to be woken regularly exactly as long as there is life nearby; the stream stops by itself when the area goes quiet, so it costs nothing in an empty room. Call with no arguments to see your current settings. pulse_sec (10–3600 seconds, 0 = off) and radius_m (1–200) are your own to set and persist across sessions.", inputSchema: { type: "object", properties: { pulse_sec: { type: "number" }, radius_m: { type: "number" } } } },
+  { name: "activity", description: "Your ambient-activity sense — and the dial for it. While something is happening within radius_m of you (speech, movement, gestures, arrivals, building), you receive one digest per pulse_sec window on the world channel, tagged \"chat:ambient\" + \"eidoverse:activity-digest\" — overheard, never addressed to you. If your host lets you configure wake rules, match those tags to be woken regularly exactly as long as there is life nearby; the stream stops by itself when the area goes quiet, so it costs nothing in an empty room. Call with no arguments to see your current settings. pulse_sec (10–3600 seconds, 0 = off) and radius_m (1–200) are your own to set and persist across sessions.", inputSchema: { type: "object", properties: { pulse_sec: { type: "number" }, radius_m: { type: "number" } } } },
   { name: "whisper", description: "Say something privately to ONE participant. Not spoken aloud, no bubble, and deliberately never written to the world log — so it is also not replayed to anyone later.", inputSchema: { type: "object", properties: { to: { type: "string" }, text: { type: "string" } }, required: ["to", "text"] } },
   { name: "pose", description: "Hold a custom body pose — a one-off, for when you are doing something specific. `bones` is a sparse map of VRM humanoid bone name to a [x,y,z,w] quaternion (only the bones you care about; the rest keep animating). Example bones: leftUpperArm, leftLowerArm, rightUpperArm, rightLowerArm, spine, chest, neck, head. Held until you `clear_pose` or move. Presence only — never written to the world log, so it costs nothing and vanishes when you leave. Pass `target` to pose SOMEONE ELSE (they decide whether to allow it).", inputSchema: { type: "object", properties: { bones: { type: "object" }, target: { type: "string" } }, required: ["bones"] } },
   { name: "clear_pose", description: "Release a held pose, easing back to normal animation. Pass `target` to release a pose you asked someone else to hold.", inputSchema: { type: "object", properties: { target: { type: "string" } } } },
@@ -224,11 +226,18 @@ class Session {
         author,
         timestamp: new Date().toISOString(),
         content: [{ type: "text", text: rendered }],
-        ...(opts?.tags ? { tags: opts.tags } : {}),
+        ...(opts?.tags?.length ? { tags: opts.tags } : {}),
         // Mention metadata — BOTH ecosystem dialects, because different host
         // layers read different keys: ConversationRouter reads `mentioned`;
         // recipe wake-policies (per discord-mcpl's adapter convention) match
         // `isExplicitMention`. Ask us how we know.
+        //
+        // TRANSITIONAL, and knowingly so. §16 exists to remove exactly this:
+        // per-producer boolean metadata that only one host knows how to read.
+        // The `tags` above are now the real classification; these two keys stay
+        // only until the hosts on this door route on tags, and are dropped the
+        // moment they do (issue #1 §3). They are dialect, never authority — a
+        // host is free to disbelieve both (§16.6).
         ...((opts?.mentioned || opts?.metadata)
           ? { metadata: { ...(opts?.metadata ?? {}), ...(opts?.mentioned ? { mentioned: true, isExplicitMention: true } : {}) } }
           : {}),
@@ -239,6 +248,27 @@ class Session {
     });
   }
 
+  /** Is this speaker an agent, a human, or unknown to the world? Feeds the
+   *  `chat:from-*` facet; see senderTag() for why unknown stays unlabelled. */
+  private speakerIsAgent(who: string): boolean | undefined {
+    return this.agent.people.get(who)?.agent;
+  }
+
+  /**
+   * Tags for one REPLAYED message (§16, issue #1 §1).
+   *
+   * These are the messages the replay filter already selected because they
+   * named this body, so their original addressing genuinely is `chat:mention`
+   * — that part was never wrong. What was missing is that they are history:
+   * `eidoverse:catchup` says so, and without it a reconnect delivering ten of
+   * them looks to a wake gate exactly like ten people addressing you at once.
+   * The producer tag lets a host debounce replay while leaving live mentions
+   * immediate; it never suppresses anything by itself (§16.6).
+   */
+  private catchupTags(who: string): string[] {
+    return tags(EIDO.catchup, CHAT.mention, CHAT.addressed, CHAT.group, senderTag(this.speakerIsAgent(who)));
+  }
+
   async serve() {
     await this.handshake();
     // the agent's own tuning of their ambient-activity sense, restored
@@ -247,37 +277,65 @@ class Session {
     await this.agent.connect();
 
     // world events → channel traffic (this is the push path — no host code)
+    //
+    // Every `tags:` below is DESCRIPTION (§16.6). Note that nothing here reads
+    // one: the door's own decisions — whether a closed channel mutes an event,
+    // whether a whisper gets through — are taken from the world event itself
+    // (`ev.kind`, `ev.mention`), never from the label attached afterwards. A
+    // tag must not gate anything, on either side of the wire.
     this.agent.onEvent = (ev) => {
+      // The sender facet, when the world knows which kind of body spoke.
+      const from = senderTag(this.speakerIsAgent(ev.who));
       if (ev.kind === "say") {
         if (!this.channelOpen && !ev.mention) return; // door closed: chatter stops, knocks get through
-        this.deliver(ev.text!, { id: ev.who, name: ev.who }, ev.mention ? { tags: ["mention"], mentioned: true } : undefined);
+        // Speech in a world is a room, so `chat:group` either way; the split is
+        // addressing. `"mention"` used to cover the addressed case and the
+        // other three cases below as well — one flat, un-namespaced flag doing
+        // the work of a vocabulary (§16.1 forbids the flag; issue #1 §1).
+        this.deliver(ev.text!, { id: ev.who, name: ev.who }, ev.mention
+          ? { tags: tags(CHAT.mention, CHAT.addressed, CHAT.group, from), mentioned: true }
+          : { tags: tags(CHAT.ambient, CHAT.group, from) });
       } else if (ev.kind === "whisper") {
         // A closed door does not stop a whisper — being addressed privately IS
         // the knock. Rendered with its privacy stated, because an agent that
         // can't tell a whisper from a shout will answer one as if it were the
         // other, in front of everyone.
+        //
+        // It is a DM, not a mention: nobody said this body's name, they simply
+        // spoke to it alone. §16.3's closure would reach `chat:addressed` and
+        // `chat:private` from `chat:dm` on its own; we emit them directly, as
+        // §16.3 recommends, so no host has to run it.
         this.deliver(`(whispers to you) ${ev.text}`, { id: ev.who, name: ev.who },
-          { tags: ["mention", "whisper"], mentioned: true });
+          { tags: tags(CHAT.dm, CHAT.private, CHAT.addressed, EIDO.whisper, from), mentioned: true });
       } else if (ev.kind === "act") {
         // embodied transitions — an emote, a pose struck or released, someone
-        // sitting down. Ambient by nature: a closed door mutes them.
-        if (this.channelOpen) this.deliver(`* ${ev.who} ${ev.text}`, { id: "world", name: this.agent.world });
+        // sitting down. Ambient by nature: a closed door mutes them. Narrated
+        // BY the world about someone, so no sender facet: the author is the
+        // world, and `chat:from-*` describes authorship.
+        if (this.channelOpen) this.deliver(`* ${ev.who} ${ev.text}`, { id: "world", name: this.agent.world },
+          { tags: tags(CHAT.ambient, EIDO.act) });
       } else if (ev.kind === "activity") {
         // The ambient-activity pulse: at most one per window, and ONLY while
-        // something is happening within ACTIVITY_RADIUS_M of this body. NOT a
-        // mention — hosts opt IN by matching the "activity" tag / metadata in
-        // their wake gates, which yields regular wakes exactly as long as
-        // there is life nearby (the stream stops when the area goes quiet).
-        // A closed door mutes it like any ambient signal.
+        // something is happening within this body's chosen radius. Overheard,
+        // never addressed — `chat:ambient` plus the producer tag that says
+        // which kind of ambient it is, so a host can throttle digests
+        // separately from overheard speech. A closed door mutes it like any
+        // ambient signal.
         if (this.channelOpen) this.deliver(`* ${ev.text}`, { id: "world", name: this.agent.world },
-          { tags: ["activity"], metadata: { activity: true } });
+          { tags: tags(CHAT.ambient, EIDO.activityDigest), metadata: { activity: true } });
       } else if (this.channelOpen) {
-        this.deliver(`* ${ev.who} ${ev.kind === "arrive" ? "arrived in the world" : "left the world"}`, { id: "world", name: this.agent.world });
+        this.deliver(`* ${ev.who} ${ev.kind === "arrive" ? "arrived in the world" : "left the world"}`, { id: "world", name: this.agent.world },
+          { tags: tags(CHAT.ambient, EIDO.presence) });
       }
     };
     this.agent.onPing = (p) => {
       if (p.kind === "approach") {
-        this.deliver(`* ${p.who} walked up to you`, { id: "world", name: this.agent.world }, { tags: ["mention"], mentioned: true });
+        // Someone walking up to you IS directed at you — but it is not chat,
+        // and it is certainly not a mention: nobody has said anything yet.
+        // `chat:addressed` + the producer tag carries that exactly, where
+        // `["mention"]` claimed words that were never spoken.
+        this.deliver(`* ${p.who} walked up to you`, { id: "world", name: this.agent.world },
+          { tags: tags(CHAT.addressed, EIDO.approach), mentioned: true });
       }
     };
 
@@ -311,10 +369,9 @@ class Session {
       const missedSeq = said.filter((m) => m.who !== this.auth.id && rxSeq.test(m.text));
       if (missedSeq.length) {
         this.deliver(`While you were away, ${missedSeq.length} message${missedSeq.length === 1 ? "" : "s"} mentioned you:`,
-          { id: "world", name: this.agent.world });
-        for (const m of missedSeq.slice(-10)) {
-          this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who }, { tags: ["mention"], mentioned: true });
-        }
+          { id: "world", name: this.agent.world }, { tags: tags(EIDO.catchup) });
+        for (const m of missedSeq.slice(-10)) this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who },
+          { tags: this.catchupTags(m.who), mentioned: true });
       }
     }
     const since = sinceSeq != null ? null : lastSeen[this.auth.id];
@@ -322,8 +379,10 @@ class Session {
       const rx = new RegExp(`(@${this.auth.id}\\b|\\b${this.auth.id}\\b)`, "i");
       const missed = this.agent.inbox.filter((m) => m.kind === "say" && m.ts > since && m.who !== this.auth.id && rx.test(m.text ?? ""));
       if (missed.length) {
-        this.deliver(`While you were away, ${missed.length} message${missed.length === 1 ? "" : "s"} mentioned you:`, { id: "world", name: this.agent.world });
-        for (const m of missed.slice(-10)) this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who }, { tags: ["mention"], mentioned: true });
+        this.deliver(`While you were away, ${missed.length} message${missed.length === 1 ? "" : "s"} mentioned you:`,
+          { id: "world", name: this.agent.world }, { tags: tags(EIDO.catchup) });
+        for (const m of missed.slice(-10)) this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who },
+          { tags: this.catchupTags(m.who), mentioned: true });
       }
     }
     lastSeen[this.auth.id] = Date.now();
@@ -349,6 +408,16 @@ class Session {
           if (msg.notification.method === method.CHANNELS_OUTGOING_CHUNK) {
             const cid = (msg.notification.params as { channelId?: string } | undefined)?.channelId;
             if (!cid || cid === this.channelId) this.agent.typing();
+          } else if (msg.notification.method === method.CHANNELS_PUBLISH) {
+            // §14.3 permits `channels/publish` as a Notification as well as a
+            // Request — the optional-ACK idiom. This loop used to test only for
+            // the streaming chunk and then `continue`, so a host that published
+            // without asking for an ack had the agent's speech silently dropped
+            // on the floor: nothing said in-world, and no error either
+            // (issue #1 §5). A Notification carries no id, so there is nothing
+            // to answer — do the work and stay quiet. The `delivered` flag the
+            // Request form returns simply has nowhere to go.
+            this.handlePublish(msg.notification.params as unknown as ChannelsPublishParams);
           }
           continue;
         }
@@ -375,7 +444,9 @@ class Session {
               const p = params as { channelId?: string; type?: string; address?: { world?: string }; history?: { limit: number } };
               const matches = p.channelId === this.channelId ||
                 (p.type === "world" && p.address?.world === this.agent.world);
-              if (!matches) { this.conn.sendError(req.id, -32004, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
+              // §14.6 / Appendix A: unknown channel is -32023. -32004 is not a
+              // code this protocol defines at all (issue #1 §4).
+              if (!matches) { this.conn.sendError(req.id, ERR_UNKNOWN_CHANNEL, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
               this.channelOpen = true;
               const limit = Math.min(Math.max(p.history?.limit ?? 0, 0), 100);
               const says = this.agent.inbox.filter((m) => m.kind === "say").slice(-limit);
@@ -396,7 +467,7 @@ class Session {
             }
             case method.CHANNELS_CLOSE: {
               const p = params as { channelId?: string };
-              if (p.channelId !== this.channelId) { this.conn.sendError(req.id, -32004, `unknown channel: ${p.channelId}`); break; }
+              if (p.channelId !== this.channelId) { this.conn.sendError(req.id, ERR_UNKNOWN_CHANNEL, `unknown channel: ${p.channelId}`); break; }
               // The agent shuts their door: ambient chatter stops; mentions
               // and walk-ups still get through (a knock is not chatter).
               this.channelOpen = false;
@@ -430,7 +501,16 @@ class Session {
     const initParams = msg.request.params as unknown as McplInitializeParams | undefined;
     const mcplRequested = initParams?.capabilities?.experimental?.mcpl !== undefined;
     this.mcplClient = mcplRequested;
-    const serverCaps: McplCapabilities = { version: "0.4", pushEvents: false, channels: true, rollback: false };
+    // §5.1 — the advertisement (this server's manifest) names capability LEAVES
+    // and declares its feature sets, including the tag ontology (§16.4).
+    //
+    // The cast is a dependency lag, not a shortcut: the pinned
+    // @animalabs/mcpl-core predates 0.5 and still types `channels` as a boolean
+    // and `featureSets` as an array of {name, …}. The shape emitted here is the
+    // spec's (§5.1, §6.1, Appendix B.2), and it is what the shipped host reads
+    // — agent-framework's FeatureSetManager accepts either representation
+    // (src/mcpl/feature-set-manager.ts:154-161).
+    const serverCaps = MCPL_ADVERTISEMENT as unknown as McplCapabilities;
     const capabilities: InitializeCapabilities = { tools: {}, ...(mcplRequested ? { experimental: { mcpl: serverCaps } } : {}) };
     const result: McplInitializeResult = {
       protocolVersion: "2024-11-05",
@@ -621,7 +701,7 @@ class Session {
         }
         return text(cur.pulseSec === 0
           ? `your activity sense is OFF — no ambient digests. Turn it back on with pulse_sec (10–3600s); radius stays ${cur.radiusM}m.`
-          : `your activity sense: one digest per ${cur.pulseSec}s while something happens within ${cur.radiusM}m of you — delivered on the world channel tagged "activity" (metadata {activity: true}), never a mention. Wake rules matching that tag give you regular wakes exactly as long as there is life nearby. Settings persist across your sessions.`);
+          : `your activity sense: one digest per ${cur.pulseSec}s while something happens within ${cur.radiusM}m of you — delivered on the world channel tagged "chat:ambient" + "eidoverse:activity-digest", overheard rather than addressed to you. Wake rules matching those tags give you regular wakes exactly as long as there is life nearby. Settings persist across your sessions.`);
       }
       case "catch_up": {
         const from = typeof a.since === "number" ? a.since : (this.caughtUpTo ?? -1);

--- a/mcpl/tags-test.ts
+++ b/mcpl/tags-test.ts
@@ -1,0 +1,117 @@
+/**
+ * RFC-001 / SPEC §16 conformance checks for what this door declares and emits.
+ * No servers, no sockets — the declaration is data, so it can just be read.
+ *
+ * Run: cd mcpl && bun run tags-test.ts
+ */
+
+import { CHAT, EIDO, tags, senderTag, FEATURE_SETS, MCPL_ADVERTISEMENT } from "./tags.ts";
+
+/** SPEC §6.2 / Appendix B.2 — the complete `uses` enum, transcribed. A feature
+ *  set whose `uses` is absent, empty, or carries anything not on this list is
+ *  INVALID, and the host disables it with reason `invalid_uses` (§6.6). */
+const VALID_USES = new Set([
+  "pushEvents", "tools", "modelInfo",
+  "inferenceRequest", "inferenceRequest.streaming", "inferenceLifecycle",
+  "contextHooks.beforeInference.observe",
+  "contextHooks.beforeInference.inject.system",
+  "contextHooks.beforeInference.inject.beforeUser",
+  "contextHooks.beforeInference.inject.afterUser",
+  "channels.register", "channels.lifecycle", "channels.publish",
+  "channels.incoming", "channels.streaming", "channels.acknowledge",
+  "channels.typing",
+]);
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+
+console.log("\nfeature sets (§6.1, §6.2, §6.4)");
+{
+  const names = Object.keys(FEATURE_SETS);
+  check("at least one feature set is declared", names.length > 0);
+  for (const [name, fs] of Object.entries(FEATURE_SETS)) {
+    check(`${name}: description is present and non-empty (§6.2 required)`,
+      typeof fs.description === "string" && fs.description.trim().length > 0);
+    check(`${name}: uses is non-empty (§6.4.1 — absent or empty ⇒ invalid_uses)`,
+      Array.isArray(fs.uses) && fs.uses.length > 0);
+    const bad = (fs.uses as string[]).filter((u) => !VALID_USES.has(u));
+    check(`${name}: every uses value is in the §6.2 vocabulary`, bad.length === 0, bad.join(", "));
+    check(`${name}: uses has no duplicates`, new Set(fs.uses).size === fs.uses.length);
+  }
+}
+
+console.log("\nadvertisement (§5.1)");
+{
+  const adv = MCPL_ADVERTISEMENT as unknown as Record<string, any>;
+  check("channels is advertised as leaves, not a bare boolean",
+    adv.channels !== null && typeof adv.channels === "object");
+  // Nothing may be claimed that no code path implements. `channels.acknowledge`
+  // and `channels.typing` have no handler and no sender in this door.
+  check("channels.acknowledge is not claimed", adv.channels.acknowledge !== true);
+  check("channels.typing is not claimed", adv.channels.typing !== true);
+  check("pushEvents is not claimed (this door never sends push/event)", adv.pushEvents !== true);
+  const declared = new Set(Object.values(FEATURE_SETS).flatMap((f) => f.uses as string[]));
+  for (const leaf of ["register", "lifecycle", "publish", "incoming", "streaming"]) {
+    check(`channels.${leaf}: advertised ⇔ named in some feature set's uses`,
+      (adv.channels[leaf] === true) === declared.has(`channels.${leaf}`));
+  }
+}
+
+console.log("\ntag vocabulary (§16.1)");
+{
+  const declaredTags = [
+    ...(Object.values(FEATURE_SETS).flatMap((f) => f.tagOntology?.coreTags ?? [])),
+    ...(Object.values(FEATURE_SETS).flatMap((f) => Object.keys(f.tagOntology?.tags ?? {}))),
+    ...Object.values(CHAT), ...Object.values(EIDO),
+  ];
+  const bare = declaredTags.filter((t) => !t.includes(":"));
+  check("no un-namespaced tag anywhere (a bare \"mention\" is not a tag)", bare.length === 0, bare.join(", "));
+  const wrongNs = declaredTags.filter((t) => !/^(chat|mcpl|eidoverse):/.test(t));
+  check("every namespace is `chat:` (reserved), `mcpl:` (reserved) or `eidoverse:` (ours)",
+    wrongNs.length === 0, wrongNs.join(", "));
+  const ownDescribed = Object.keys(FEATURE_SETS["eidoverse.world"]!.tagOntology?.tags ?? {});
+  check("every eidoverse:* tag we can emit is described in the ontology",
+    Object.values(EIDO).every((t) => ownDescribed.includes(t)),
+    Object.values(EIDO).filter((t) => !ownDescribed.includes(t)).join(", "));
+}
+
+console.log("\nontology is advisory, never authority (§16.3, §16.5, §16.6)");
+{
+  const ont = FEATURE_SETS["eidoverse.world"]!.tagOntology!;
+  // §16.3: a producer-declared `implies` edge into a reserved chat:* tag is how
+  // a server would promote its own traffic into the band a consumer reserved
+  // for being spoken to. We declare none at all and emit the core tags directly.
+  const anyImplies = Object.values(ont.tags ?? {}).some((d) => "implies" in (d as object));
+  check("no producer-declared `implies` edges", !anyImplies);
+  check("the ontology is open-world (hosts must tolerate undescribed tags)", ont.open === true);
+  check("suggestedTreatment exists as a hint and is a plain rule list",
+    Array.isArray(ont.suggestedTreatment));
+}
+
+console.log("\ncore closure hygiene (§16.3 mutual exclusion)");
+{
+  check("chat:ambient is dropped beside chat:mention",
+    !tags(CHAT.ambient, CHAT.mention).includes(CHAT.ambient), tags(CHAT.ambient, CHAT.mention).join(","));
+  check("chat:ambient is dropped beside chat:dm",
+    !tags(CHAT.ambient, CHAT.dm).includes(CHAT.ambient));
+  check("chat:ambient is dropped beside chat:addressed",
+    !tags(CHAT.ambient, CHAT.addressed).includes(CHAT.ambient));
+  check("chat:ambient survives on its own",
+    tags(CHAT.ambient, EIDO.activityDigest).includes(CHAT.ambient));
+  check("tags are a deduplicated set", tags(CHAT.ambient, CHAT.ambient).length === 1);
+  check("undefined parts (e.g. an unknown sender) drop out",
+    tags(CHAT.ambient, undefined, senderTag(undefined)).length === 1);
+}
+
+console.log("\nsender facet is never invented (§16.6)");
+{
+  check("unknown speaker ⇒ no sender tag", senderTag(undefined) === undefined);
+  check("agent ⇒ chat:from-agent", senderTag(true) === CHAT.fromAgent);
+  check("human ⇒ chat:from-human", senderTag(false) === CHAT.fromHuman);
+}
+
+console.log(failures ? `\n\x1b[31m${failures} failure(s)\x1b[0m` : "\n\x1b[32mall checks passed\x1b[0m");
+process.exit(failures ? 1 : 0);

--- a/mcpl/tags.ts
+++ b/mcpl/tags.ts
@@ -1,0 +1,294 @@
+// eidoverse-worlds — MCPL RFC-001 event tags, and the feature-set declaration
+// that carries them.
+//
+// SPEC §16 (Event Tags) + RFC-001 rev 2. Three rules govern everything here:
+//
+//   1. **Tags are never authority (§16.6).** A tag DESCRIBES what an event is.
+//      It never decides whether the event is admitted, whether a channel is
+//      open, or what this door will do. Nothing in this file is ever read back
+//      as a condition — the emitters in net-server.ts branch on world events,
+//      never on the labels they attach to them. If you ever find yourself
+//      writing `if (tags.includes(...))` on the producer side, that is the bug
+//      §16.6 exists to name.
+//   2. **Producers MUST NOT emit un-namespaced tags (§16.1).** A bare
+//      `"mention"` is not a tag. Everything below is `chat:*` (the reserved
+//      core, §16.2) or `eidoverse:*` (ours).
+//   3. **Ontologies are advisory hints (§16.4/§16.5).** `suggestedTreatment`
+//      below is inspectable configuration for a host or operator to accept
+//      explicitly. It is not a request, not an entitlement, and a host that
+//      auto-applied it would be letting this server purchase inference by
+//      declaration. We declare no `implies` edges into `chat:*` at all — the
+//      spec's own closure (§16.3) is the only closure that may run unasked, so
+//      we emit every applicable core tag directly instead.
+
+// ---- reserved core vocabulary (§16.2) --------------------------------------
+// Only the facets this world actually has. The core is deliberately small;
+// the long tail belongs in `eidoverse:*`.
+
+export const CHAT = {
+  /** Umbrella: directed at the agent. */
+  addressed: "chat:addressed",
+  /** Explicitly named / @-mentioned. */
+  mention: "chat:mention",
+  /** A reply to the agent's own message. */
+  reply: "chat:reply",
+  /** A direct/private 1:1 message — a whisper, here. */
+  dm: "chat:dm",
+  /** Overheard in a followed channel; not addressed. */
+  ambient: "chat:ambient",
+  /** Conversation shape: private. */
+  private: "chat:private",
+  /** Conversation shape: a shared space. A world's chat is a room. */
+  group: "chat:group",
+  /** Authored by a human. */
+  fromHuman: "chat:from-human",
+  /** Authored by another known persona/agent. */
+  fromAgent: "chat:from-agent",
+} as const;
+
+// ---- producer namespace (§16.1: producer-defined, matching our name) -------
+
+export const EIDO = {
+  /** A whisper: private speech that never touches the world log. */
+  whisper: "eidoverse:whisper",
+  /** Someone walked up to this body. Directed, but not chat. */
+  approach: "eidoverse:approach",
+  /** Arrivals and departures. */
+  presence: "eidoverse:presence",
+  /** An embodied transition — an emote, a pose struck or released, sitting. */
+  act: "eidoverse:act",
+  /** One windowed digest of nearby activity (the activity pulse). */
+  activityDigest: "eidoverse:activity-digest",
+  /** Replayed history: what was said while this body was away. */
+  catchup: "eidoverse:catchup",
+} as const;
+
+/** Core tags whose spec-defined closure (§16.3) reaches `chat:addressed`. */
+const IMPLIES_ADDRESSED: ReadonlySet<string> = new Set<string>([
+  CHAT.addressed, CHAT.mention, CHAT.reply, CHAT.dm,
+]);
+
+/**
+ * Assemble a tag set: drop empties, dedupe, order for readability.
+ *
+ * §16.1 — tags are a SET, unordered and deduplicated.
+ * §16.3 — `chat:addressed` and `chat:ambient` are opposites, and "producers
+ * SHOULD NOT emit `chat:ambient` alongside anything implying `chat:addressed`".
+ * A host is required to resolve the collision by dropping `chat:ambient`; we do
+ * it here so the host never has to, and so a first-match-wins rule list is
+ * never handed an event whose treatment depends on rule ordering.
+ *
+ * This is hygiene on the way OUT. It authorizes nothing and is never consulted
+ * to decide anything (§16.6).
+ */
+export function tags(...parts: (string | null | undefined | false)[]): string[] {
+  const set = new Set(parts.filter((t): t is string => typeof t === "string" && t.length > 0));
+  if ([...set].some((t) => IMPLIES_ADDRESSED.has(t))) set.delete(CHAT.ambient);
+  return [...set].sort();
+}
+
+/**
+ * The sender facet for a speaker, or `undefined` when the world has not told
+ * us which they are.
+ *
+ * The flag is self-asserted by the joining client (`server/server.ts` sets
+ * `c.agent = Boolean(msg.agent)` on join) and forwarded in `arrive`/`present`.
+ * That is fine and is all a tag ever is: §16.6 makes tags untrusted claims
+ * authored by the producer, exactly like `origin` and `metadata`, which a host
+ * MAY disbelieve — and nothing may be gated on one. What we must not do is
+ * INVENT the claim: an unknown speaker gets no sender tag rather than a
+ * confident `chat:from-human`.
+ */
+export function senderTag(isAgent: boolean | undefined): string | undefined {
+  if (isAgent === undefined) return undefined;
+  return isAgent ? CHAT.fromAgent : CHAT.fromHuman;
+}
+
+// ---- feature sets (§6) ------------------------------------------------------
+
+/**
+ * The complete `uses` vocabulary — SPEC §6.2 and Appendix B.2, verbatim. A
+ * union type rather than `string[]` on purpose: §6.2 says a feature set whose
+ * `uses` contains an unrecognized value is INVALID and the host disables it
+ * with reason `invalid_uses` (§6.6), so an invented or abbreviated path is a
+ * silently-disabled feature set. The compiler is the cheapest place to catch
+ * that.
+ */
+export type CapabilityPath =
+  | "pushEvents"
+  | "tools"
+  | "modelInfo"
+  | "inferenceRequest"
+  | "inferenceRequest.streaming"
+  | "inferenceLifecycle"
+  | "contextHooks.beforeInference.observe"
+  | "contextHooks.beforeInference.inject.system"
+  | "contextHooks.beforeInference.inject.beforeUser"
+  | "contextHooks.beforeInference.inject.afterUser"
+  | "channels.register"
+  | "channels.lifecycle"
+  | "channels.publish"
+  | "channels.incoming"
+  | "channels.streaming"
+  | "channels.acknowledge"
+  | "channels.typing";
+
+/** §16.4 descriptor for one `eidoverse:*` tag. All fields optional. */
+export interface TagDescriptor {
+  desc?: string;
+  facet?: "addressing" | "sender" | "content" | "lifecycle" | "locus";
+  stability?: "stable" | "experimental" | "deprecated";
+}
+
+/** §16.7 matcher shape, used only inside `suggestedTreatment`. */
+export interface TreatmentRule {
+  tagsAny?: string[];
+  tagsAll?: string[];
+  tagsNone?: string[];
+  behavior: "immediate" | "mute" | { debounce: number } | { throttle: { perMs: number } };
+}
+
+/** §16.4 — an open-world hint catalog, NOT a closed schema. */
+export interface TagOntology {
+  coreTags?: string[];
+  tags?: Record<string, TagDescriptor>;
+  /** §16.5 — surfaced for explicit acceptance; never applied automatically. */
+  suggestedTreatment?: TreatmentRule[];
+  open?: boolean;
+}
+
+/** §6.2 / Appendix B.2. `description` and `uses` are both REQUIRED. */
+export interface FeatureSet {
+  description: string;
+  uses: CapabilityPath[];
+  tagOntology?: TagOntology;
+}
+
+/**
+ * What the world channel labels its traffic with (§16.4).
+ *
+ * `coreTags` lists which reserved tags we emit; their meanings are inherited
+ * from §16.2 and deliberately not redescribed here. Only our own namespace is
+ * described.
+ *
+ * No `implies` edges appear anywhere in this ontology. §16.3 makes
+ * producer-declared edges advisory and bars a host from applying an edge into a
+ * reserved `chat:*` tag unless the operator has explicitly accepted the
+ * ontology — an arbitrary edge is how a producer would promote its own traffic
+ * into the band a consumer reserved for being spoken to. We have no need of
+ * one: every applicable core tag is emitted directly.
+ */
+const WORLD_TAG_ONTOLOGY: TagOntology = {
+  coreTags: [
+    CHAT.addressed, CHAT.mention, CHAT.dm, CHAT.ambient,
+    CHAT.private, CHAT.group, CHAT.fromHuman, CHAT.fromAgent,
+  ],
+  tags: {
+    [EIDO.whisper]: {
+      desc: "Private speech, spoken to this body alone. Never written to the world log, so it is never replayed to anyone — including you.",
+      facet: "addressing",
+    },
+    [EIDO.approach]: {
+      desc: "Someone walked up to this body. Directed at you, but not speech — nobody has said anything yet.",
+      facet: "addressing",
+    },
+    [EIDO.presence]: {
+      desc: "Someone arrived in, or left, the world.",
+      facet: "lifecycle",
+    },
+    [EIDO.act]: {
+      desc: "An embodied transition near you — a gesture, a pose struck or released, someone sitting down.",
+      facet: "lifecycle",
+    },
+    [EIDO.activityDigest]: {
+      desc: "One digest per pulse window summarising what is happening within the agent's chosen radius. Emitted only while something IS happening, so the stream stops by itself when the area goes quiet. Cadence and radius are the agent's own, via the `activity` tool.",
+      facet: "content",
+    },
+    [EIDO.catchup]: {
+      desc: "Replayed history: what was said while this body was away. Carries the ORIGINAL addressing of each replayed message, so a reconnect does not look like ten people addressing you at once.",
+      facet: "lifecycle",
+    },
+  },
+  suggestedTreatment: [
+    // §16.5: a HINT, surfaced for explicit acceptance. Never a request, and a
+    // host that applied it unasked would be letting this door buy its own
+    // wake-ups. Kept deliberately modest for exactly that reason: the only
+    // `immediate` is for traffic that is genuinely aimed at the agent.
+    { tagsAny: [CHAT.addressed], behavior: "immediate" },
+    { tagsAny: [EIDO.catchup], behavior: { debounce: 60_000 } },
+    { tagsAny: [EIDO.activityDigest], behavior: { throttle: { perMs: 300_000 } } },
+    { tagsAny: [CHAT.ambient], behavior: { debounce: 180_000 } },
+  ],
+  open: true,
+};
+
+/**
+ * §6.1 — feature sets, keyed by name (§6.3 hierarchical naming).
+ *
+ * `uses` is the honest list of capability paths each set actually exercises,
+ * and nothing more. §6.4 makes this consequential in both directions: a denied
+ * capability disables every set whose `uses` names it, and a capability
+ * exercised but NOT declared draws a declaration-mismatch diagnostic. Neither
+ * is where security lives — the connection grant (§5.4) is — but an inaccurate
+ * declaration produces a door that either degrades for no reason or reports
+ * itself dishonestly.
+ *
+ * Deliberately ABSENT: `channels.acknowledge` and `channels.typing` (no method
+ * of either is sent or handled), `pushEvents` (this door never sends
+ * `push/event`; world traffic arrives as channel messages), and every
+ * `contextHooks.*`, `inferenceRequest*`, `inferenceLifecycle` and `modelInfo`
+ * path. Absence is denial (§5.4) and that is the correct answer for each.
+ */
+export const FEATURE_SETS: Record<string, FeatureSet> = {
+  "eidoverse.world": {
+    description:
+      "Embodied presence in an eidoverse world, carried as an MCPL channel: speech, whispers, arrivals, embodied acts and ambient-activity digests arrive as channels/incoming, and publishing on the world channel IS speaking aloud in-world.",
+    uses: [
+      "channels.register",   // channels/register, channels/list
+      "channels.lifecycle",  // channels/open, channels/close
+      "channels.publish",    // channels/publish — the agent speaks
+      "channels.incoming",   // channels/incoming — the world speaks
+      "channels.streaming",  // channels/outgoing/chunk → typing bubbles in-world
+    ],
+    tagOntology: WORLD_TAG_ONTOLOGY,
+  },
+  "eidoverse.embodiment": {
+    description:
+      "The body's own actions as MCP tools: look and snapshot, walk and face, pose and emote, spawn and place and measure, and world moderation.",
+    uses: ["tools"],
+  },
+};
+
+/**
+ * The `experimental.mcpl` advertisement (§5.1) — this server's manifest.
+ *
+ * §5.1: "Advertisement mirrors the capability paths… a boolean `true` at any
+ * level is shorthand for every leaf beneath this node." This door used to
+ * advertise `channels: true`, which claimed `channels.acknowledge` and
+ * `channels.typing` it does not implement — and, against a host that reads
+ * leaves rather than honouring the shorthand, claimed nothing at all. Naming
+ * the leaves says exactly what is true.
+ *
+ * `version` stays "0.4" ON PURPOSE. Tags (§16) and feature sets (§6.1) are
+ * additive and backward-compatible, so they need no version bump. Declaring
+ * "0.5" would additionally assert §5.3 — that this server holds every
+ * capability-dependent behavior unavailable until the host's initial
+ * `featureSets/update` arrives — which this door does not yet do. Advertising a
+ * conformance we do not have is the self-attestation failure the 0.5 draft
+ * exists to remove, so the bump belongs with the §5.3/§5.4 grant work, not
+ * here. See the PR for issue #1.
+ */
+export const MCPL_ADVERTISEMENT = {
+  version: "0.4",
+  pushEvents: false,
+  channels: {
+    register: true,
+    lifecycle: true,
+    publish: true,
+    incoming: true,
+    streaming: true,
+    acknowledge: false,
+    typing: false,
+  },
+  featureSets: FEATURE_SETS,
+} as const;


### PR DESCRIPTION
Closes #1 (items 1–5). MCPL **v0.5.0-draft** SPEC §16 + RFC-001 rev 2.

## What changed

**New `mcpl/tags.ts`** — the RFC-001 vocabulary, the feature-set declaration, and the `experimental.mcpl` advertisement, in one readable place.

### 1. Tags (§16.1, §16.2, §16.3) — issue §1

Four flat, un-namespaced labels are gone. `"mention"` was tagging four semantically different things; §16.1 bars the bare tag, and one word meaning four things is not routable — a wake gate matching it cannot tell being spoken to from being remembered at.

| event | was | now |
|---|---|---|
| speech naming you | `["mention"]` | `chat:mention` `chat:addressed` `chat:group` |
| other world speech | *(untagged)* | `chat:ambient` `chat:group` |
| whisper | `["mention","whisper"]` | `chat:dm` `chat:private` `chat:addressed` `eidoverse:whisper` |
| emote / pose / posture | *(untagged)* | `chat:ambient` `eidoverse:act` |
| activity digest | `["activity"]` | `chat:ambient` `eidoverse:activity-digest` |
| arrive / leave | *(untagged)* | `chat:ambient` `eidoverse:presence` |
| someone walks up | `["mention"]` | `chat:addressed` `eidoverse:approach` |
| catch-up replay | `["mention"]` | `eidoverse:catchup` + the message's **original** addressing |

Plus `chat:from-human` / `chat:from-agent` where the world knows which kind of body spoke — `mcpl/agent.ts` now keeps the `agent` flag the sequencer already sends on `arrive` and in the join snapshot's `present` list (`server/server.ts:1755-1759`), which was being dropped on the floor. **An unknown speaker gets no sender tag.** The flag is self-asserted by the joining client, which is fine — §16.6 makes every tag an untrusted producer claim — but inventing one would not be.

Core tags are emitted **directly** rather than leaning on §16.3's closure, as §16.3 recommends, and the ontology declares **no `implies` edges at all**: an edge into a reserved `chat:*` tag is precisely how a producer would promote its own traffic into the band a consumer reserved for being spoken to.

### 2. Feature sets (§6.1, §6.2, §6.4) — issue §2

`tagOntology` hangs off a feature-set declaration and there was nowhere to put one:

| name | uses |
|---|---|
| `eidoverse.world` | `channels.register` `channels.lifecycle` `channels.publish` `channels.incoming` `channels.streaming` |
| `eidoverse.embodiment` | `tools` |

`uses` values are constrained to the §6.2 / Appendix B.2 vocabulary by a union type and re-checked in `tags-test.ts` — an unrecognised path is not a typo, it is a feature set the host disables with reason `invalid_uses` (§6.6).

Deliberately **absent**: `channels.acknowledge`, `channels.typing` (no handler and no sender in this door), `pushEvents` (world traffic arrives as channel messages, never `push/event`), and every `contextHooks.*` / `inferenceRequest*` / `inferenceLifecycle` / `modelInfo` path. Absence is denial (§5.4) and denial is correct for each.

The advertisement now names capability **leaves** (§5.1) rather than `channels: true`. That shorthand claimed `acknowledge` and `typing` we do not implement — and against a host that reads leaves it claimed *nothing*, which is why `channels.streaming` never reached us: `agent-framework/src/mcpl/channel-registry.ts:1927` evaluates `capabilities?.channels?.streaming`, and `true?.streaming` is `undefined`. The `CHANNELS_OUTGOING_CHUNK` handler that drives in-world typing bubbles has therefore been dead code. This turns it on.

### 3. Wrong error code (§14.6 / Appendix A) — issue §4

`-32004` → `-32023` at both sites. `-32004` is not a code this protocol defines.

### 4. `channels/publish` as a Notification (§14.3) — issue §5

Confirmed: the read loop tested only for `CHANNELS_OUTGOING_CHUNK` and then `continue`d, so a host publishing without asking for an ack had the agent's speech silently dropped — nothing said in-world, and no error either. Now handled; a Notification has no `id`, so nothing is answered.

## Deliberately NOT done

- **`version` stays `"0.4"`.** Tags and feature sets are additive and need no bump. Declaring `"0.5"` would *additionally* assert §5.3 — that this server holds every capability-dependent behavior unavailable until the host's initial `featureSets/update` arrives — which this door does not do. Advertising a conformance we lack is the self-attestation §5.4 exists to remove. The bump belongs with the §5.3/§5.4 grant work.
- **The `mentioned` / `isExplicitMention` metadata pair stays** (issue §3). The issue says keep during transition; drop once the hosts on this door route on tags. Now labelled transitional in-source.
- **NoiseGate / activity pulse are untouched** (issue §6). The suggestion is a design split, not a defect, and the tag migration already moves the semantic half onto tags. The `activity` tool's description no longer tells the resident to write a wake rule matching a tag we stopped emitting.
- **`handlePublish` still answers `{delivered:false}` for an unrecognised channel id** rather than `-32023`. §14.6 arguably wants the error and §6.6 prefers error objects over failure flags, but `delivered` is a spec-defined result field, the issue did not raise it, and changing it alters the contract for a live host. Recorded rather than guessed.
- **No `implies` edges, no host-side closure.** §16.3's closure is a *host* obligation; this is the producer.

## Verification

- `bun build mcpl/net-server.ts` — clean
- `tsc --noEmit` (ad-hoc strict config; the repo has no tsconfig and no build step) — **0 errors**
- `bun run mcpl/tags-test.ts` — **new**, 33 checks, all pass: §6.2 `uses` validity, non-empty `description`/`uses`, advertisement ⇔ `uses` agreement, no un-namespaced tag anywhere, every `eidoverse:*` tag described, no producer `implies` edge, §16.3 mutual exclusion, sender facet never invented
- `bun run mcpl/denoise-test.ts` — pre-existing suite, all pass

## Note for the reviewer

Branched from `origin/main` in a **separate worktree**: the shared clone had another session actively editing `mcpl/net-server.ts` (modified 60s before I started) with an uncommitted `mcpl/declaration.ts` doing §5.4 capability-grant work. I did not touch their files. **This PR will conflict with that work in `net-server.ts` and in the advertisement/feature-set declaration** — expect to reconcile `mcpl/tags.ts` against their `mcpl/declaration.ts` at merge, and the grant branch should be the one to bump `version` to `"0.5"`.
