### PR TITLE
MCPL 0.5: §17 manifest for the door (eidoverse#2)

### DIFF
--- a/mcpl/manifest-test.ts
+++ b/mcpl/manifest-test.ts
@@ -1,0 +1,41 @@
+/**
+ * §17.2 digest conformance for the eidoverse door, against the frozen
+ * 25-vector corpus (vendored byte-for-byte from mcpl main).
+ *
+ * Run: cd mcpl && bun run manifest-test.ts
+ */
+import { canonicalManifestJson, manifestRevision, ManifestDigestError, MANIFEST_WITH_REVISION, ManifestAnnouncer } from "./manifest.ts";
+import vectors from "./vectors/manifest-digest-vectors.json";
+
+let pass = 0, fail = 0;
+const bad = (name: string, msg: string) => { fail++; console.error(`not ok ${name}: ${msg}`); };
+
+for (const v of (vectors as any).vectors) {
+  try {
+    const canonical = canonicalManifestJson(v.input);
+    if (v.expectError) { bad(v.name, `expected ${v.expectError}, digested`); continue; }
+    if (canonical !== v.canonicalJson) { bad(v.name, `canonical mismatch`); continue; }
+    const rev = manifestRevision(v.input);
+    if (rev !== v.digest) { bad(v.name, `digest mismatch: ${rev}`); continue; }
+    pass++;
+  } catch (e) {
+    if (v.expectError && e instanceof ManifestDigestError && e.code === v.expectError) { pass++; continue; }
+    bad(v.name, `unexpected ${e instanceof ManifestDigestError ? e.code : e}`);
+  }
+}
+
+// Own manifest: conforming, stable, self-consistent.
+const own = MANIFEST_WITH_REVISION;
+const rev1 = manifestRevision(own);
+const rev2 = manifestRevision({ ...own, revision: "sha256:WRONG" });
+if (rev1 !== rev2) bad("own-manifest-revision-self-excluding", `${rev1} !== ${rev2}`); else pass++;
+if (own.revision !== rev1) bad("own-manifest-carries-its-digest", `${own.revision} !== ${rev1}`); else pass++;
+
+// Announcer: seeded from initialize ⇒ silent while the surface is static.
+let sent = 0;
+const ann = new ManifestAnnouncer(() => { sent++; });
+if (ann.announceIfChanged(["capabilities"]) || sent !== 0) bad("announcer-static-silence", `announced ${sent}`); else pass++;
+
+console.log(`# pass ${pass}`);
+console.log(`# fail ${fail}`);
+if (fail > 0) process.exit(1);

--- a/mcpl/manifest.ts
+++ b/mcpl/manifest.ts
@@ -1,0 +1,226 @@
+/**
+ * §17 server side for the eidoverse door (RFC-003 / SPEC 0.5, eidoverse#2).
+ *
+ * The canonical content digest (§17.2), the complete-manifest answer
+ * (§17.4), and the per-connection announcement seed (§17 impl note: seed
+ * last-announced from the initialize handshake, or a fresh connection fires
+ * a redundant announce for a manifest initialize already carried).
+ *
+ * Digest rules exactly as adjudicated in the frozen 25-vector corpus
+ * (mcpl main `2cdc7fb`+`a77be49` lineage — see conformance/README there):
+ *  - revision = "sha256:" + base64url_unpadded(SHA-256(JCS(manifest minus
+ *    root revision)));
+ *  - JCS: member names sorted by UTF-16 code units, ES6 string escapes,
+ *    ES6 Number::toString;
+ *  - set semantics (sort by UTF-8 bytes + dedupe) ONLY for the three set
+ *    paths in the object-keyed shape, ONLY when the array is all-strings;
+ *    anything else — wrong-typed fields, mixed arrays, the array
+ *    featureSets shape — is hashed VERBATIM (totality; validation is where
+ *    non-conformance fails, never the digest);
+ *  - the sole refusal is identifier_charset on the enumerated identifier
+ *    positions, and only in the conforming all-string shape.
+ *
+ * This server's declared surface (declaration.ts) is compile-time static,
+ * so mcpl/manifestChanged has no live trigger today. The announce helper
+ * exists and is wired anyway (the dog-mcp pattern): a future mutating site
+ * calls `announceIfChanged` and the plumbing already works, instead of a
+ * dead code path being invented under pressure later.
+ */
+
+import { createHash } from "node:crypto";
+import { MCPL_ADVERTISEMENT } from "./declaration.ts";
+
+// ── JCS (RFC 8785) ──────────────────────────────────────────────────────────
+
+const SHORT_ESCAPES: Record<number, string> = {
+  0x08: "\\b", 0x09: "\\t", 0x0a: "\\n", 0x0c: "\\f", 0x0d: "\\r",
+  0x22: '\\"', 0x5c: "\\\\",
+};
+
+function jcsString(s: string): string {
+  let out = '"';
+  for (const ch of s) {
+    const cp = ch.codePointAt(0)!;
+    if (cp in SHORT_ESCAPES) out += SHORT_ESCAPES[cp];
+    else if (cp < 0x20) out += "\\u" + cp.toString(16).padStart(4, "0");
+    else out += ch;
+  }
+  return out + '"';
+}
+
+function jcsNumber(x: number): string {
+  if (!Number.isFinite(x)) throw new ManifestDigestError("non_finite_number", String(x));
+  // ES6 Number::toString IS JavaScript's String(x) — the one serializer
+  // RFC 8785 §3.2.2.3 defers to. (-0 → "0" via the x===0 identity.)
+  return x === 0 ? "0" : String(x);
+}
+
+function utf16Key(s: string): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < s.length; i++) out.push(s.charCodeAt(i));
+  return out;
+}
+
+function compareUtf16(a: string, b: string): number {
+  const x = utf16Key(a), y = utf16Key(b);
+  const n = Math.min(x.length, y.length);
+  for (let i = 0; i < n; i++) if (x[i] !== y[i]) return x[i] - y[i];
+  return x.length - y.length;
+}
+
+function compareUtf8(a: string, b: string): number {
+  const enc = new TextEncoder();
+  const x = enc.encode(a), y = enc.encode(b);
+  const n = Math.min(x.length, y.length);
+  for (let i = 0; i < n; i++) if (x[i] !== y[i]) return x[i] - y[i];
+  return x.length - y.length;
+}
+
+function jcs(value: unknown): string {
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (value === null) return "null";
+  if (typeof value === "string") return jcsString(value);
+  if (typeof value === "number") return jcsNumber(value);
+  if (Array.isArray(value)) return "[" + value.map(jcs).join(",") + "]";
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort(compareUtf16); // RFC 8785 §3.2.3
+    return "{" + keys.map((k) => jcsString(k) + ":" + jcs(obj[k])).join(",") + "}";
+  }
+  throw new ManifestDigestError("unserializable", typeof value);
+}
+
+// ── §17.2 normalization ─────────────────────────────────────────────────────
+
+export class ManifestDigestError extends Error {
+  constructor(public readonly code: string, detail: string) {
+    super(`${code}: ${detail}`);
+  }
+}
+
+const IDENT_RE = /^[A-Za-z0-9._:*-]+$/;
+
+/** Set-valued paths, object-keyed shape only ("*" = any member name). */
+const SET_PATHS = [
+  ["featureSets", "*", "uses"],
+  ["featureSets", "*", "tagOntology", "coreTags"],
+  ["featureSets", "*", "tagOntology", "tags", "*", "implies"],
+];
+
+const ROOT_NON_CAPABILITY = new Set(["version", "revision", "featureSets"]);
+
+/** Identifier positions, mirroring the vector corpus's identifierPositions:
+ *  "#key" = the object's member names at that path, "[]" = array elements.
+ *  Capability member names at EVERY depth are covered by the isCapMember
+ *  branch in normalize(); these are the featureSets-subtree positions. */
+const IDENT_PATHS = [
+  ["featureSets", "#key"],
+  ["featureSets", "*", "uses", "[]"],
+  ["featureSets", "*", "tagOntology", "coreTags", "[]"],
+  ["featureSets", "*", "tagOntology", "tags", "#key"],
+  ["featureSets", "*", "tagOntology", "tags", "*", "implies", "[]"],
+  ["featureSets", "*", "tagOntology", "keyed", "#key"],
+  ["featureSets", "*", "tagOntology", "keyed", "*", "values", "[]"],
+  ["featureSets", "*", "tagOntology", "suggestedTreatment", "*", "tagsAny", "[]"],
+  ["featureSets", "*", "tagOntology", "suggestedTreatment", "*", "tagsAll", "[]"],
+  ["featureSets", "*", "tagOntology", "suggestedTreatment", "*", "tagsNone", "[]"],
+  ["featureSets", "*", "tagOntology", "tags", "*", "facet"],
+];
+
+function pathMatches(path: string[], pattern: string[]): boolean {
+  if (path.length !== pattern.length) return false;
+  // "*" is a dict-key wildcard; list indices are recorded as "[i]" and never
+  // match it (the array-form featureSets shape hashes verbatim).
+  return pattern.every((want, i) => (want === "*" ? path[i] !== "[i]" : want === path[i]));
+}
+
+const isIdentPath = (p: string[]) => IDENT_PATHS.some((pat) => pathMatches(p, pat));
+
+function checkIdent(v: unknown, where: string): void {
+  if (typeof v !== "string" || !IDENT_RE.test(v)) {
+    throw new ManifestDigestError("identifier_charset", `${where} = ${JSON.stringify(v)}`);
+  }
+}
+
+function normalize(value: unknown, path: string[]): unknown {
+  if (Array.isArray(value)) {
+    const items = value.map((v) => normalize(v, [...path, "[i]"]));
+    const allStrings = items.every((it) => typeof it === "string");
+    // Totality: set semantics AND identifier checks only for the conforming
+    // all-string shape; a mixed array is left verbatim for JCS.
+    if (allStrings && isIdentPath([...path, "[]"])) {
+      for (const it of items) checkIdent(it, path.join(".") + "[]");
+    }
+    if (allStrings && SET_PATHS.some((p) => pathMatches(path, p))) {
+      return [...new Set(items as string[])].sort(compareUtf8);
+    }
+    return items;
+  }
+  if (typeof value === "string" && isIdentPath(path)) {
+    checkIdent(value, path.join("."));
+    return value;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      // Capability member names at EVERY depth (the recursive-walk rule):
+      // everything outside the featureSets/version/revision root members.
+      const inCapSubtree = path.length === 0 ? !ROOT_NON_CAPABILITY.has(k) : !ROOT_NON_CAPABILITY.has(path[0]);
+      if (inCapSubtree || isIdentPath([...path, "#key"])) checkIdent(k, [...path, k].join("."));
+      out[k] = normalize(v, [...path, k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+// ── Public surface ──────────────────────────────────────────────────────────
+
+/** Canonical JCS string of a manifest, root `revision` stripped (§17.2). */
+export function canonicalManifestJson(manifest: Record<string, unknown>): string {
+  const { revision: _dropped, ...rest } = manifest;
+  return jcs(normalize(rest, []));
+}
+
+/** `sha256:` + base64url-unpadded digest of the canonical bytes. */
+export function manifestRevision(manifest: Record<string, unknown>): string {
+  const canonical = canonicalManifestJson(manifest);
+  const b64 = createHash("sha256").update(canonical, "utf8").digest("base64");
+  return "sha256:" + b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** The complete current manifest WITH its content-derived revision — what
+ *  both `initialize` (§5.1) and `mcpl/manifest` (§17.4) present. Computed
+ *  once: the declared surface is compile-time static. */
+export const MANIFEST_WITH_REVISION: Record<string, unknown> = (() => {
+  const base = MCPL_ADVERTISEMENT as unknown as Record<string, unknown>;
+  return { ...base, revision: manifestRevision(base) };
+})();
+
+/**
+ * Per-connection announcement seed + trigger (§17 impl note). Seeded from
+ * the initialize handshake so a fresh connection never fires a redundant
+ * announce; a future surface-mutating site calls `announceIfChanged` and
+ * the notification goes out only when the CURRENT revision differs from
+ * the last one this connection was told.
+ */
+export class ManifestAnnouncer {
+  private lastAnnounced: string;
+  constructor(
+    private readonly send: (params: { revision: string; domains: string[] }) => void,
+    seedRevision: string = MANIFEST_WITH_REVISION.revision as string,
+  ) {
+    this.lastAnnounced = seedRevision;
+  }
+  /** Announce iff the current manifest revision differs from the seed/last.
+   *  Domains are derived by the CALLER of the mutation (it knows what it
+   *  changed); the notification carries no payload either way (§17.3). */
+  announceIfChanged(domains: Array<"capabilities" | "featureSets" | "tagOntology">): boolean {
+    const current = manifestRevision(MCPL_ADVERTISEMENT as unknown as Record<string, unknown>);
+    if (current === this.lastAnnounced) return false;
+    this.lastAnnounced = current;
+    this.send({ revision: current, domains });
+    return true;
+  }
+}

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -35,6 +35,7 @@ import {
   CHAT, EIDO, CAP, tags, capabilityMatches, MCPL_ADVERTISEMENT, FEATURE_SETS,
 } from "./declaration.ts";
 import { WorldAgent } from "./agent.ts";
+import { MANIFEST_WITH_REVISION, ManifestAnnouncer } from "./manifest.ts";
 import { verifyToken } from "../server/aid1.ts";
 import sharp from "sharp";
 
@@ -182,6 +183,9 @@ class Session {
   private conn: McplConnection;
   private agent: WorldAgent;
   private channelId: string;
+  /** §17 announcer, seeded at handshake; silent while the declared
+   *  surface stays static. */
+  private manifestAnnouncer: ManifestAnnouncer | null = null;
   private channelOpen = true;
   /** Did the client declare capabilities.experimental.mcpl at initialize?
    *  Plain-MCP hosts (llmcord, Claude Code, …) get tools ONLY: no
@@ -486,6 +490,12 @@ class Session {
             case "tools/call":
               this.conn.sendResponse(req.id, await this.handleTool(String(params.name), (params.arguments ?? {}) as Record<string, any>));
               break;
+            case "mcpl/manifest":
+              // §17.4: the complete current manifest, never a delta, same
+              // shape and same snapshot as initialize. Not gated on any
+              // capability path (§17.3-adjacent: fetch is host-initiated).
+              this.conn.sendResponse(req.id, MANIFEST_WITH_REVISION);
+              break;
             case method.CHANNELS_LIST:
               this.conn.sendResponse(req.id, { channels: this.channelDescriptors() });
               break;
@@ -555,10 +565,11 @@ class Session {
     const mcplRequested = hostMcpl !== undefined;
     this.mcplClient = mcplRequested;
     this.hostMcplVersion = typeof hostMcpl?.version === "string" ? hostMcpl.version : null;
-    // The manifest (§5.1). Cast because the pinned mcpl-core-ts types still
-    // describe 0.4's shape (channels as a boolean, featureSets as an array);
+    // The manifest (§5.1) WITH its §17.2 content-derived revision — the
+    // same object mcpl/manifest answers, from the same snapshot. Cast
+    // because the pinned mcpl-core-ts types still describe 0.4's shape;
     // the WIRE follows the 0.5 spec text, which is what a peer reads.
-    const serverCaps = MCPL_ADVERTISEMENT as unknown as McplCapabilities;
+    const serverCaps = MANIFEST_WITH_REVISION as unknown as McplCapabilities;
     const capabilities: InitializeCapabilities = { tools: {}, ...(mcplRequested ? { experimental: { mcpl: serverCaps } } : {}) };
     const result: McplInitializeResult = {
       protocolVersion: "2024-11-05",
@@ -566,6 +577,14 @@ class Session {
       serverInfo: { name: "eidoverse-worlds", version: "0.1.0" },
     };
     this.conn.sendResponse(msg.request.id, result);
+    // §17 impl note: seed last-announced from THIS handshake, so a fresh
+    // connection never redundantly announces the manifest initialize just
+    // carried. The declared surface is compile-time static today; any
+    // future mutating site calls announcer.announceIfChanged and the
+    // plumbing already works.
+    this.manifestAnnouncer = new ManifestAnnouncer((params) => {
+      try { this.conn.sendNotification("mcpl/manifestChanged", params as unknown as Record<string, unknown>); } catch { /* peer gone */ }
+    });
     const inited = await this.conn.nextMessage();
     if (!(inited.type === "notification" && inited.notification.method === "notifications/initialized")) {
       this.conn.close();

--- a/mcpl/vectors/manifest-digest-vectors.json
+++ b/mcpl/vectors/manifest-digest-vectors.json
@@ -1,0 +1,781 @@
+{
+  "$schema": "https://github.com/anima-research/mcpl conformance/manifest-digest-vectors",
+  "title": "MCPL RFC-003 \u00a73.1 canonical manifest digest \u2014 conformance vectors",
+  "specRevision": "RFC-003 (Accepted, 2026-08-02), against SPEC.md 0.5.0-draft",
+  "generatedBy": "conformance/generate_vectors.py",
+  "readme": "conformance/README.md",
+  "algorithm": {
+    "formula": "revision = \"sha256:\" + base64url_unpadded(SHA-256( JCS( manifest_without_revision ) ) )",
+    "canonicalization": "RFC 8785 JSON Canonicalization Scheme",
+    "hash": "SHA-256 over the UTF-8 encoding of the JCS string",
+    "encoding": "RFC 4648 \u00a75 base64url, '=' padding removed",
+    "strip": "the `revision` member of the manifest root object, and nothing else",
+    "setArraySort": "UTF-8 byte sequence, ascending; duplicates removed",
+    "objectMemberSort": "RFC 8785: UTF-16 code-unit sequence of the member name. Every member name in a conforming manifest is ASCII, so this coincides with UTF-8 byte order throughout.",
+    "identifierCharset": "[A-Za-z0-9._:*-] (non-empty)"
+  },
+  "setValuedArrayPaths": [
+    "featureSets.*.uses",
+    "featureSets.*.tagOntology.coreTags",
+    "featureSets.*.tagOntology.tags.*.implies"
+  ],
+  "listValuedArrayNote": "Every array not listed in setValuedArrayPaths is a list: its order is part of the manifest and is preserved verbatim. This includes `keyed.*.values` (RFC-003 \u00a73.1) and, less obviously, the `tagsAny`/`tagsAll`/`tagsNone` members of `suggestedTreatment` rules, which are semantically sets but are not named as such.",
+  "identifierPositions": [
+    "featureSets.#key",
+    "featureSets.*.uses.[]",
+    "featureSets.*.tagOntology.coreTags.[]",
+    "featureSets.*.tagOntology.tags.#key",
+    "featureSets.*.tagOntology.tags.*.implies.[]",
+    "featureSets.*.tagOntology.keyed.#key",
+    "featureSets.*.tagOntology.keyed.*.values.[]",
+    "featureSets.*.tagOntology.suggestedTreatment.*.tagsAny.[]",
+    "featureSets.*.tagOntology.suggestedTreatment.*.tagsAll.[]",
+    "featureSets.*.tagOntology.suggestedTreatment.*.tagsNone.[]",
+    "featureSets.*.tagOntology.tags.*.facet"
+  ],
+  "identifierPositionsNote": "'#key' means the object's member names at that path; '[]' means the array's elements. RFC-003 does not enumerate these positions; this list is the fail-closed reading and is the one thing in this file most in need of RFC confirmation. Root member names are capability paths and are checked, except `version`, `revision` and `featureSets`, which are not capabilities (RFC-003 \u00a73).",
+  "errorCodes": {
+    "identifier_charset": "A string in an identifier position is empty or contains a character outside [A-Za-z0-9._:*-].",
+    "manifest_not_object": "The manifest is not a JSON object."
+  },
+  "howToRead": "`input` is the manifest as received, before any normalization. `canonicalJson` is the exact JCS string; it is stored as a JSON string, so parse it and encode the result as UTF-8 to obtain the bytes that are hashed \u2014 do not compare raw file bytes. `sha256Hex` is that hash in hex, present so a mismatch localizes to canonicalization or to encoding rather than 'somewhere'. `digest` is the full revision value. A vector carries either `digest` or `expectError`, never both. `sameDigestAs` and `differentDigestFrom` are assertions to test in addition to the digest itself.",
+  "vectors": [
+    {
+      "name": "rfc-003-worked-example",
+      "description": "The single worked vector already present in RFC-003 \u00a73.1. Reproduced and verified here byte for byte; every other vector in this file is only as trustworthy as this one. Object members are supplied out of JCS order and `uses` out of set order, so neither JCS member sorting nor set sorting alone yields this digest.",
+      "input": {
+        "version": "0.5",
+        "pushEvents": true,
+        "contextHooks": {
+          "beforeInference": true
+        },
+        "inferenceLifecycle": true,
+        "channels": {
+          "register": true,
+          "publish": true,
+          "incoming": true
+        },
+        "featureSets": {
+          "demo.messaging": {
+            "description": "Demo",
+            "uses": [
+              "channels.publish",
+              "channels.incoming",
+              "pushEvents",
+              "tools"
+            ]
+          }
+        }
+      },
+      "canonicalJson": "{\"channels\":{\"incoming\":true,\"publish\":true,\"register\":true},\"contextHooks\":{\"beforeInference\":true},\"featureSets\":{\"demo.messaging\":{\"description\":\"Demo\",\"uses\":[\"channels.incoming\",\"channels.publish\",\"pushEvents\",\"tools\"]}},\"inferenceLifecycle\":true,\"pushEvents\":true,\"version\":\"0.5\"}",
+      "sha256Hex": "fd86534b4875b6a4c031923a784942b3349013658dc77c610219a052f348f47e",
+      "digest": "sha256:_YZTS0h1tqTAMZI6eElCszSQE2WNx3xhAhmgUvNI9H4"
+    },
+    {
+      "name": "key-ordering-and-set-ordering-independence",
+      "description": "Same manifest as vector 0 with every object's members supplied in a different order, `uses` reversed, and one duplicate `uses` entry. MUST produce the identical digest to vector 0: JCS fixes member order, set semantics fix `uses` order and remove duplicates. A reader that preserves JSON insertion order sees genuinely shuffled input here; a reader that sorts on parse trivially passes, which is fine \u2014 the invariant is the digest, not the intermediate.",
+      "input": {
+        "featureSets": {
+          "demo.messaging": {
+            "uses": [
+              "tools",
+              "pushEvents",
+              "channels.publish",
+              "channels.incoming",
+              "tools"
+            ],
+            "description": "Demo"
+          }
+        },
+        "channels": {
+          "incoming": true,
+          "register": true,
+          "publish": true
+        },
+        "inferenceLifecycle": true,
+        "contextHooks": {
+          "beforeInference": true
+        },
+        "pushEvents": true,
+        "version": "0.5"
+      },
+      "canonicalJson": "{\"channels\":{\"incoming\":true,\"publish\":true,\"register\":true},\"contextHooks\":{\"beforeInference\":true},\"featureSets\":{\"demo.messaging\":{\"description\":\"Demo\",\"uses\":[\"channels.incoming\",\"channels.publish\",\"pushEvents\",\"tools\"]}},\"inferenceLifecycle\":true,\"pushEvents\":true,\"version\":\"0.5\"}",
+      "sha256Hex": "fd86534b4875b6a4c031923a784942b3349013658dc77c610219a052f348f47e",
+      "digest": "sha256:_YZTS0h1tqTAMZI6eElCszSQE2WNx3xhAhmgUvNI9H4",
+      "sameDigestAs": "rfc-003-worked-example"
+    },
+    {
+      "name": "revision-present-is-stripped",
+      "description": "Vector 0 with a `revision` member carrying a deliberately WRONG value. The digest never covers itself: `revision` is removed before canonicalization, so this MUST yield vector 0's digest and the supplied value MUST NOT influence it. An implementation that hashes the manifest as received fails here. Note `revision` is stripped only at the manifest root \u2014 see vector 'revision-only-stripped-at-root'.",
+      "input": {
+        "revision": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "version": "0.5",
+        "pushEvents": true,
+        "contextHooks": {
+          "beforeInference": true
+        },
+        "inferenceLifecycle": true,
+        "channels": {
+          "register": true,
+          "publish": true,
+          "incoming": true
+        },
+        "featureSets": {
+          "demo.messaging": {
+            "description": "Demo",
+            "uses": [
+              "channels.publish",
+              "channels.incoming",
+              "pushEvents",
+              "tools"
+            ]
+          }
+        }
+      },
+      "canonicalJson": "{\"channels\":{\"incoming\":true,\"publish\":true,\"register\":true},\"contextHooks\":{\"beforeInference\":true},\"featureSets\":{\"demo.messaging\":{\"description\":\"Demo\",\"uses\":[\"channels.incoming\",\"channels.publish\",\"pushEvents\",\"tools\"]}},\"inferenceLifecycle\":true,\"pushEvents\":true,\"version\":\"0.5\"}",
+      "sha256Hex": "fd86534b4875b6a4c031923a784942b3349013658dc77c610219a052f348f47e",
+      "digest": "sha256:_YZTS0h1tqTAMZI6eElCszSQE2WNx3xhAhmgUvNI9H4",
+      "sameDigestAs": "rfc-003-worked-example"
+    },
+    {
+      "name": "revision-only-stripped-at-root",
+      "description": "RFC-003 \u00a73.1 strips `revision` from the manifest object, not from everything named `revision`. A nested member of that name is ordinary content and is hashed. Contrast with 'revision-present-is-stripped'; an implementation that strips recursively produces a different digest here.",
+      "input": {
+        "version": "0.5",
+        "revision": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "demoExtension": {
+          "revision": "not-stripped"
+        }
+      },
+      "canonicalJson": "{\"demoExtension\":{\"revision\":\"not-stripped\"},\"version\":\"0.5\"}",
+      "sha256Hex": "6af42d3f858e782423067830aa96ad8b4c33f4e519ae1c8806b41e7003bc0fff",
+      "digest": "sha256:avQtP4WOeCQjBngwqpati0wz9OUZrhyIBrQecAO8D_8"
+    },
+    {
+      "name": "empty-manifest",
+      "description": "The empty object. Not a valid manifest \u2014 SPEC \u00a75.1 always shows `version` \u2014 but the digest function MUST be total, because a host recomputes the digest of whatever it fetched before deciding anything about it (RFC-003 \u00a76.6: rejection is diagnostics, not authorization). Canonicalizes to two bytes.",
+      "input": {},
+      "canonicalJson": "{}",
+      "sha256Hex": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+      "digest": "sha256:RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o"
+    },
+    {
+      "name": "minimal-manifest",
+      "description": "The smallest manifest a conforming server can present: protocol version only, no capabilities, no feature sets.",
+      "input": {
+        "version": "0.5"
+      },
+      "canonicalJson": "{\"version\":\"0.5\"}",
+      "sha256Hex": "6f31241638571f8ca714ba6d8dbecc150933312117891911b869c0d4657117c8",
+      "digest": "sha256:bzEkFjhXH4ynFLptjb7MFQkzMSEXiRkRuGnA1GVxF8g"
+    },
+    {
+      "name": "unicode-and-json-escapes",
+      "description": "Exercises RFC 8785 \u00a73.2.2.2 string serialization on a `description` (descriptions are free text; only identifiers are charset-restricted). The escaping rule is ECMAScript JSON.stringify: escape ONLY U+0022, U+005C and C0 controls, using \\b \\t \\n \\f \\r where defined and \\u00xx otherwise. Everything else is literal UTF-8 \u2014 including U+007F DELETE, U+2028/U+2029 (which some serializers escape for JavaScript embedding and MUST NOT here), U+00A0, a combining sequence that MUST NOT be NFC-normalized, and an astral emoji that MUST be one 4-byte UTF-8 sequence, not a surrogate pair escape. Non-ASCII also appears in a nested tagOntology `desc`.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.unicode": {
+            "description": "Caf\u00e9 \u65e5\u672c\u8a9e \ud83d\ude42 \"quoted\" and back\\slash, tab[\t] nl[\n] cr[\r] bs[\b] ff[\f] soh[\u0001] us[\u001f] del[\u007f] ls[\u2028] ps[\u2029] nbsp[\u00a0] combining[e\u0301] precomposed[\u00e9] end",
+            "uses": [
+              "pushEvents"
+            ],
+            "tagOntology": {
+              "tags": {
+                "demo:accent": {
+                  "desc": "na\u00efve r\u00e9sum\u00e9 \u2014 em dash, \u00abguillemets\u00bb, \u4e2d\u6587",
+                  "facet": "content"
+                }
+              },
+              "open": true
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"featureSets\":{\"demo.unicode\":{\"description\":\"Caf\u00e9 \u65e5\u672c\u8a9e \ud83d\ude42 \\\"quoted\\\" and back\\\\slash, tab[\\t] nl[\\n] cr[\\r] bs[\\b] ff[\\f] soh[\\u0001] us[\\u001f] del[\u007f] ls[\u2028] ps[\u2029] nbsp[\u00a0] combining[e\u0301] precomposed[\u00e9] end\",\"tagOntology\":{\"open\":true,\"tags\":{\"demo:accent\":{\"desc\":\"na\u00efve r\u00e9sum\u00e9 \u2014 em dash, \u00abguillemets\u00bb, \u4e2d\u6587\",\"facet\":\"content\"}}},\"uses\":[\"pushEvents\"]}},\"version\":\"0.5\"}",
+      "sha256Hex": "584c8cba1a460489b17b6375d34e5060e00b49edbf16d7752b662d0f6cb74163",
+      "digest": "sha256:WEyMuhpGBImxe2N1005QYOALSe2_Ftd1K2YtD2y3QWM"
+    },
+    {
+      "name": "number-canonicalisation",
+      "description": "No spec-defined manifest member is numeric in MCPL 0.5. But RFC-003 \u00a73 digests the COMPLETE experimental.mcpl object \u2014 'every member other than version, revision and featureSets' is the capabilities domain, vendor extensions included \u2014 so an implementation that cannot serialize a number cannot digest a real server's manifest. `demoLimits` is a vendor extension, not spec surface. Values pin RFC 8785 \u00a73.2.2.3 / ECMAScript Number::toString: integer-valued doubles lose the '.0'; negative zero serializes as '0'; 1e20 stays positional while 1e21 goes exponential as '1e+21'; 1e-6 stays positional while 1e-7 becomes '1e-7'; the shortest round-tripping digit string is used, so 0.1 is '0.1' and not '0.1000000000000000055511151231257827'.",
+      "input": {
+        "version": "0.5",
+        "demoLimits": {
+          "zero": 0,
+          "negZero": -0.0,
+          "one": 1.0,
+          "hundred": 100,
+          "negative": -17,
+          "half": 2.5,
+          "tenth": 0.1,
+          "thirds": 0.3333333333333333,
+          "e20": 1e+20,
+          "e21": 1e+21,
+          "e-6": 1e-06,
+          "e-7": 1e-07,
+          "maxSafeInteger": 9007199254740991,
+          "pow2To53": 9007199254740992,
+          "minSubnormal": 5e-324,
+          "large": 1.7976931348623157e+308
+        }
+      },
+      "canonicalJson": "{\"demoLimits\":{\"e-6\":0.000001,\"e-7\":1e-7,\"e20\":100000000000000000000,\"e21\":1e+21,\"half\":2.5,\"hundred\":100,\"large\":1.7976931348623157e+308,\"maxSafeInteger\":9007199254740991,\"minSubnormal\":5e-324,\"negZero\":0,\"negative\":-17,\"one\":1,\"pow2To53\":9007199254740992,\"tenth\":0.1,\"thirds\":0.3333333333333333,\"zero\":0},\"version\":\"0.5\"}",
+      "sha256Hex": "311aa9a702ee06ef2eb61594219658853eae9a0b4cce05cde5653400b9b958e2",
+      "digest": "sha256:MRqppwLuBu8uthWUIZZYhT6umgtMzgXN5WU0ALm5WOI"
+    },
+    {
+      "name": "set-sort-is-utf8-byte-order",
+      "description": "Set-valued arrays sort by UTF-8 byte sequence ascending (RFC-003 \u00a73.1) \u2014 not by locale collation and not case-insensitively. Every value here is a legal identifier, so this is reachable from a conforming manifest. It discriminates byte order from the alternatives: 'demo:Alpha' and 'demo:Zeta' precede ALL lowercase entries because 0x41/0x5A < 0x61; a locale or case-folding sort would interleave them. Within the lowercase run the ASCII punctuation order '-'(0x2D) < '.'(0x2E) < digits(0x30..) < ':'(0x3A) is exercised, which ICU-style collations reorder or ignore entirely. 'demo:alpha' being a proper prefix sorts first. `coreTags` additionally carries a duplicate that MUST be removed.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.sorting": {
+            "description": "Set ordering",
+            "uses": [
+              "tools",
+              "channels.publish",
+              "channels.incoming",
+              "channels.acknowledge",
+              "pushEvents"
+            ],
+            "tagOntology": {
+              "coreTags": [
+                "chat:reply",
+                "chat:dm",
+                "chat:addressed",
+                "chat:mention",
+                "chat:dm",
+                "chat:from-bot",
+                "chat:from-human"
+              ],
+              "tags": {
+                "demo:sorted": {
+                  "desc": "Byte-order probe",
+                  "implies": [
+                    "demo:zeta",
+                    "demo:Zeta",
+                    "demo:alpha-1",
+                    "demo:alpha.1",
+                    "demo:Alpha",
+                    "demo:alpha1",
+                    "demo:alpha:1",
+                    "demo:alpha",
+                    "demo:alpha9",
+                    "demo:alpha-1"
+                  ]
+                }
+              },
+              "open": false
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"featureSets\":{\"demo.sorting\":{\"description\":\"Set ordering\",\"tagOntology\":{\"coreTags\":[\"chat:addressed\",\"chat:dm\",\"chat:from-bot\",\"chat:from-human\",\"chat:mention\",\"chat:reply\"],\"open\":false,\"tags\":{\"demo:sorted\":{\"desc\":\"Byte-order probe\",\"implies\":[\"demo:Alpha\",\"demo:Zeta\",\"demo:alpha\",\"demo:alpha-1\",\"demo:alpha.1\",\"demo:alpha1\",\"demo:alpha9\",\"demo:alpha:1\",\"demo:zeta\"]}}},\"uses\":[\"channels.acknowledge\",\"channels.incoming\",\"channels.publish\",\"pushEvents\",\"tools\"]}},\"version\":\"0.5\"}",
+      "sha256Hex": "e330141afe604023f31f1652b1a3718c36209568f6c45aac8fbd8f739e871f64",
+      "digest": "sha256:4zAUGv5gQCPzHxZSsaNxjDYglWj2xFqsj72Pc56HH2Q"
+    },
+    {
+      "name": "nested-featuresets-and-list-arrays",
+      "description": "Five feature sets with a full tagOntology, pinning the boundary between set-valued and list-valued arrays. SETS (sorted, deduped): `uses`, `tagOntology.coreTags`, `tagOntology.tags.*.implies`. LISTS (order preserved verbatim, RFC-003 \u00a73.1 'any array not listed is a list'): `keyed.*.values`, the `tagOntology.suggestedTreatment` rule list, and \u2014 this is the trap \u2014 the `tagsAny`/`tagsNone` members inside those rules, which are semantically sets but are not named in RFC-003's table. They are supplied out of sorted order and MUST stay that way. Feature-set names also exercise JCS member sorting: 'demo.Messaging' precedes 'demo.messaging' (0x4D < 0x6D), 'demo.messaging.extra' precedes 'demo.messaging2' (0x2E < 0x32), and the all-digits name '10' sorts first \u2014 harmlessly, since JCS re-sorts and JavaScript's integer-like own-key reordering therefore cannot be observed.",
+      "input": {
+        "version": "0.5",
+        "pushEvents": true,
+        "modelInfo": true,
+        "inferenceRequest": {
+          "streaming": true
+        },
+        "contextHooks": {
+          "beforeInference": {
+            "observe": true,
+            "inject": {
+              "system": false,
+              "beforeUser": true,
+              "afterUser": true
+            }
+          }
+        },
+        "channels": {
+          "register": true,
+          "lifecycle": true,
+          "publish": true,
+          "incoming": true,
+          "streaming": false,
+          "acknowledge": true,
+          "typing": false
+        },
+        "featureSets": {
+          "demo.messaging": {
+            "description": "Messaging",
+            "uses": [
+              "channels.publish",
+              "channels.incoming",
+              "channels.register",
+              "pushEvents"
+            ],
+            "tagOntology": {
+              "coreTags": [
+                "chat:mention",
+                "chat:reply",
+                "chat:addressed",
+                "chat:ambient",
+                "chat:from-bot"
+              ],
+              "tags": {
+                "demo:role-mention": {
+                  "desc": "A role the agent holds was pinged",
+                  "facet": "addressing",
+                  "implies": [
+                    "chat:broadcast",
+                    "chat:ambient"
+                  ],
+                  "suggestedTreatment": "throttle"
+                },
+                "demo:voice": {
+                  "desc": "Voice state change",
+                  "facet": "lifecycle",
+                  "stability": "experimental"
+                }
+              },
+              "keyed": {
+                "urgency": {
+                  "desc": "Producer urgency hint",
+                  "values": [
+                    "low",
+                    "normal",
+                    "high",
+                    "critical"
+                  ],
+                  "ordered": true
+                },
+                "locale": {
+                  "desc": "Message locale",
+                  "values": [
+                    "ja-JP",
+                    "en-GB",
+                    "en-US"
+                  ],
+                  "ordered": false
+                }
+              },
+              "suggestedTreatment": [
+                {
+                  "tagsAny": [
+                    "chat:mention",
+                    "chat:addressed"
+                  ],
+                  "behavior": "immediate"
+                },
+                {
+                  "tagsAny": [
+                    "chat:deleted"
+                  ],
+                  "behavior": "mute"
+                },
+                {
+                  "tagsAny": [
+                    "chat:from-bot",
+                    "chat:ambient"
+                  ],
+                  "tagsNone": [
+                    "chat:reply",
+                    "chat:mention"
+                  ],
+                  "behavior": "throttle"
+                }
+              ],
+              "open": true
+            }
+          },
+          "demo.messaging.extra": {
+            "description": "Extra",
+            "uses": [
+              "tools"
+            ],
+            "rollback": true
+          },
+          "demo.messaging2": {
+            "description": "Second",
+            "uses": [
+              "inferenceLifecycle",
+              "modelInfo"
+            ]
+          },
+          "demo.Messaging": {
+            "description": "Capitalised sibling",
+            "uses": [
+              "contextHooks.beforeInference.inject.afterUser",
+              "contextHooks.beforeInference.observe",
+              "contextHooks.beforeInference.inject.beforeUser"
+            ]
+          },
+          "10": {
+            "description": "All-digits feature set name",
+            "uses": [
+              "modelInfo"
+            ]
+          }
+        }
+      },
+      "canonicalJson": "{\"channels\":{\"acknowledge\":true,\"incoming\":true,\"lifecycle\":true,\"publish\":true,\"register\":true,\"streaming\":false,\"typing\":false},\"contextHooks\":{\"beforeInference\":{\"inject\":{\"afterUser\":true,\"beforeUser\":true,\"system\":false},\"observe\":true}},\"featureSets\":{\"10\":{\"description\":\"All-digits feature set name\",\"uses\":[\"modelInfo\"]},\"demo.Messaging\":{\"description\":\"Capitalised sibling\",\"uses\":[\"contextHooks.beforeInference.inject.afterUser\",\"contextHooks.beforeInference.inject.beforeUser\",\"contextHooks.beforeInference.observe\"]},\"demo.messaging\":{\"description\":\"Messaging\",\"tagOntology\":{\"coreTags\":[\"chat:addressed\",\"chat:ambient\",\"chat:from-bot\",\"chat:mention\",\"chat:reply\"],\"keyed\":{\"locale\":{\"desc\":\"Message locale\",\"ordered\":false,\"values\":[\"ja-JP\",\"en-GB\",\"en-US\"]},\"urgency\":{\"desc\":\"Producer urgency hint\",\"ordered\":true,\"values\":[\"low\",\"normal\",\"high\",\"critical\"]}},\"open\":true,\"suggestedTreatment\":[{\"behavior\":\"immediate\",\"tagsAny\":[\"chat:mention\",\"chat:addressed\"]},{\"behavior\":\"mute\",\"tagsAny\":[\"chat:deleted\"]},{\"behavior\":\"throttle\",\"tagsAny\":[\"chat:from-bot\",\"chat:ambient\"],\"tagsNone\":[\"chat:reply\",\"chat:mention\"]}],\"tags\":{\"demo:role-mention\":{\"desc\":\"A role the agent holds was pinged\",\"facet\":\"addressing\",\"implies\":[\"chat:ambient\",\"chat:broadcast\"],\"suggestedTreatment\":\"throttle\"},\"demo:voice\":{\"desc\":\"Voice state change\",\"facet\":\"lifecycle\",\"stability\":\"experimental\"}}},\"uses\":[\"channels.incoming\",\"channels.publish\",\"channels.register\",\"pushEvents\"]},\"demo.messaging.extra\":{\"description\":\"Extra\",\"rollback\":true,\"uses\":[\"tools\"]},\"demo.messaging2\":{\"description\":\"Second\",\"uses\":[\"inferenceLifecycle\",\"modelInfo\"]}},\"inferenceRequest\":{\"streaming\":true},\"modelInfo\":true,\"pushEvents\":true,\"version\":\"0.5\"}",
+      "sha256Hex": "e64bb023608ee82dac13ce24c5b411133a4014ab9d487627e496e95c9b1a41e1",
+      "digest": "sha256:5kuwI2CO6C2sE84kxbQREzpAFKudSHYn5JbpXJsaQeE"
+    },
+    {
+      "name": "boolean-shorthand-is-not-expanded",
+      "description": "SPEC \u00a75.1 says a boolean `true` at any level is shorthand for every leaf beneath it. That shorthand is an input to the host's GRANT computation, not a canonicalization step: RFC-003 \u00a73.1 defines no expansion, and expanding would make the digest depend on a vocabulary that \u00a75.4 says will grow \u2014 two implementations on different vocabulary revisions would then disagree. So the shorthand form and the expanded form are DIFFERENT manifests with DIFFERENT digests. This vector is the shorthand form; 'boolean-shorthand-expanded-differs' is the expansion, and their digests differ by construction. See README 'Unresolved'.",
+      "input": {
+        "version": "0.5",
+        "contextHooks": {
+          "beforeInference": true
+        },
+        "channels": true
+      },
+      "canonicalJson": "{\"channels\":true,\"contextHooks\":{\"beforeInference\":true},\"version\":\"0.5\"}",
+      "sha256Hex": "4cd54f59e40b0eafbf54deb1dafdccb7eabc105af649f112a267f410ad6b63af",
+      "digest": "sha256:TNVPWeQLDq-_VN6x2v3Mt-q8EFr2SfESomf0EK1rY68"
+    },
+    {
+      "name": "boolean-shorthand-expanded-differs",
+      "description": "The expansion of 'boolean-shorthand-is-not-expanded'. Semantically the same advertisement under SPEC \u00a75.1; a different manifest under RFC-003 \u00a73.1, hence a different digest. Asserting the digests differ is the conformance check \u2014 an implementation that normalizes shorthand will collapse these two and fail.",
+      "input": {
+        "version": "0.5",
+        "contextHooks": {
+          "beforeInference": {
+            "observe": true,
+            "inject": {
+              "system": true,
+              "beforeUser": true,
+              "afterUser": true
+            }
+          }
+        },
+        "channels": {
+          "register": true,
+          "lifecycle": true,
+          "publish": true,
+          "incoming": true,
+          "streaming": true,
+          "acknowledge": true,
+          "typing": true
+        }
+      },
+      "canonicalJson": "{\"channels\":{\"acknowledge\":true,\"incoming\":true,\"lifecycle\":true,\"publish\":true,\"register\":true,\"streaming\":true,\"typing\":true},\"contextHooks\":{\"beforeInference\":{\"inject\":{\"afterUser\":true,\"beforeUser\":true,\"system\":true},\"observe\":true}},\"version\":\"0.5\"}",
+      "sha256Hex": "effd2a835358473a39ae28b4adf2fe92f2c49fea21ecde589f6719db200e6ab5",
+      "digest": "sha256:7_0qg1NYRzo5rii0rfL-kvLEn-oh7N5Yn2cZ2yAOarU",
+      "differentDigestFrom": "boolean-shorthand-is-not-expanded"
+    },
+    {
+      "name": "dot-in-capability-member-name",
+      "description": "'.' is inside [A-Za-z0-9._:*-], and capability paths are dot-separated (SPEC \u00a75.4), so a member NAME may legally contain the separator. `{\"a.b\": {\"c\": true}}` and `{\"a\": {\"b.c\": true}}` both flatten to the path 'a.b.c' while being different manifests with different digests. That is not a digest defect \u2014 canonicalization is over the tree, not the flattened paths, so the digest is well defined either way \u2014 but it IS a grant-matching ambiguity, and it is unresolved (see README). This vector pins the digest behaviour so the two libraries agree while the spec question is open: DO NOT flatten before hashing.",
+      "input": {
+        "version": "0.5",
+        "a.b": {
+          "c": true
+        },
+        "a": {
+          "b.c": true
+        }
+      },
+      "canonicalJson": "{\"a\":{\"b.c\":true},\"a.b\":{\"c\":true},\"version\":\"0.5\"}",
+      "sha256Hex": "134be18b3cdc22e5379ef693a0cdea42ddc6d632123b5f0f5242fde5d0a0615d",
+      "digest": "sha256:E0vhizzcIuU3nvaToM3qQt3G1jISO18PUkL95dCgYV0"
+    },
+    {
+      "name": "null-and-false-members-are-content",
+      "description": "RFC-003 \u00a73.1 strips exactly one thing: the root `revision`. 'Nothing else is stripped.' A `false` capability and a `null` member are therefore hashed as written and are NOT equivalent to the member being absent \u2014 see 'null-and-false-members-omitted' for the contrasting digest. An implementation that drops falsy or null members before hashing (a common serializer default) fails here.",
+      "input": {
+        "version": "0.5",
+        "pushEvents": false,
+        "modelInfo": null,
+        "inferenceLifecycle": true
+      },
+      "canonicalJson": "{\"inferenceLifecycle\":true,\"modelInfo\":null,\"pushEvents\":false,\"version\":\"0.5\"}",
+      "sha256Hex": "b5fe1d16ec764ffb10c8cd10263db810530679723d561cb01affb56afadffdf3",
+      "digest": "sha256:tf4dFux2T_sQyM0QJj24EFMGeXI9VhywGv-1avrf_fM"
+    },
+    {
+      "name": "null-and-false-members-omitted",
+      "description": "The same manifest as 'null-and-false-members-are-content' with the false and null members absent. Digests MUST differ.",
+      "input": {
+        "version": "0.5",
+        "inferenceLifecycle": true
+      },
+      "canonicalJson": "{\"inferenceLifecycle\":true,\"version\":\"0.5\"}",
+      "sha256Hex": "c89479fad52a837fdae3aaccff18cf18ec513db7474d913084279090f0c5cf45",
+      "digest": "sha256:yJR5-tUqg3_a46rM_xjPGOxRPbdHTZEwhCeQkPDFz0U",
+      "differentDigestFrom": "null-and-false-members-are-content"
+    },
+    {
+      "name": "negative-non-ascii-tag-identifier",
+      "description": "RFC-003 \u00a73.1: 'capability paths and tag identifiers MUST be ASCII \u2014 [A-Za-z0-9._:*-]'. 'demo:na\u00efve' is a tag identifier containing U+00EF. A conforming digest implementation MUST refuse to produce a revision for this manifest rather than silently hashing it, because the UTF-8-vs-UTF-16 ordering divergence the ASCII rule exists to prevent becomes reachable the moment non-ASCII enters a set-valued array. See README 'Unresolved' \u2014 this is the fail-closed reading; the RFC states the MUST but not who enforces it.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.bad": {
+            "description": "Bad tag identifier",
+            "uses": [
+              "pushEvents"
+            ],
+            "tagOntology": {
+              "tags": {
+                "demo:na\u00efve": {
+                  "desc": "non-ASCII key"
+                }
+              }
+            }
+          }
+        }
+      },
+      "expectError": "identifier_charset",
+      "errorDetail": "featureSets.demo.bad.tagOntology.tags.demo:na\u00efve = 'demo:na\u00efve'"
+    },
+    {
+      "name": "negative-solidus-in-feature-set-name",
+      "description": "Feature-set names are dot-separated identifiers (SPEC \u00a76.3). 'demo/messaging' contains U+002F SOLIDUS, which is outside [A-Za-z0-9._:*-]. MUST be rejected. The value is plausible enough to be typed by hand \u2014 MCPL method names use '/' \u2014 which is exactly why it is here.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo/messaging": {
+            "description": "Slash in name",
+            "uses": [
+              "tools"
+            ]
+          }
+        }
+      },
+      "expectError": "identifier_charset",
+      "errorDetail": "featureSets.demo/messaging = 'demo/messaging'"
+    },
+    {
+      "name": "negative-trailing-space-in-uses",
+      "description": "'channels.publish ' with a trailing U+0020. Invisible in review, invisible in most diffs, and it changes both the digest and the SPEC \u00a76.2 enum match. MUST be rejected on the charset rule. Note this failure is distinct from SPEC \u00a76.4's `invalid_uses` degradation: `invalid_uses` disables one feature set while the manifest still gets a revision, whereas a charset violation means no revision can be computed at all.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.messaging": {
+            "description": "Trailing space",
+            "uses": [
+              "pushEvents",
+              "channels.publish "
+            ]
+          }
+        }
+      },
+      "expectError": "identifier_charset",
+      "errorDetail": "featureSets.demo.messaging.uses[] = 'channels.publish '"
+    },
+    {
+      "name": "negative-space-in-nested-capability-member",
+      "description": "The charset rule applies to capability PATHS, and SPEC \u00a75.1 says advertisement mirrors those paths \u2014 a nested member name is a path segment, so 'contextHooks.beforeInference.inject.before user' is a capability path containing U+0020. \u00a75.4 additionally requires a 'generic recursive walk' and calls a hardcoded set of nestable keys non-conforming, so an implementation that only validates root-level member names is wrong at exactly the depth the vocabulary is growing into. MUST be rejected.",
+      "input": {
+        "version": "0.5",
+        "contextHooks": {
+          "beforeInference": {
+            "observe": true,
+            "inject": {
+              "before user": true
+            }
+          }
+        }
+      },
+      "expectError": "identifier_charset",
+      "errorDetail": "contextHooks.beforeInference.inject.before user = 'before user'"
+    },
+    {
+      "name": "negative-empty-identifier",
+      "description": "The empty string is not a match for [A-Za-z0-9._:*-]+ and is not a capability path. An implementation using a regex without anchors, or one testing 'contains only allowed chars' rather than 'is a non-empty run of allowed chars', accepts this.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.messaging": {
+            "description": "Empty uses entry",
+            "uses": [
+              ""
+            ]
+          }
+        }
+      },
+      "expectError": "identifier_charset",
+      "errorDetail": "featureSets.demo.messaging.uses[] = ''"
+    },
+    {
+      "name": "wrong-typed-set-field-hashed-verbatim",
+      "description": "SPEC \u00a717.2: the digest is TOTAL \u2014 set semantics apply only when the value actually IS an array. `\"uses\": \"tools\"` is a wrong-typed value in a set position: it is hashed verbatim (JCS only), never sorted and never refused. Validation (\u00a76.4 invalid_uses) is where this fails; the digest's job is to give two libraries the same answer for the same bytes. Adjudicated after one implementation refused with an invented error code while the other hashed \u2014 digest-vs-error for identical bytes.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.messaging": {
+            "description": "d",
+            "uses": "tools"
+          }
+        }
+      },
+      "canonicalJson": "{\"featureSets\":{\"demo.messaging\":{\"description\":\"d\",\"uses\":\"tools\"}},\"version\":\"0.5\"}",
+      "sha256Hex": "3ff00fd7174be8a6386bf4ad89ad04a92e991f5fa7e6f15eeeaf113319101fe2",
+      "digest": "sha256:P_AP1xdL6KY4a_Stia0EqS6ZH1-n5vFe7q8RMxkQH-I"
+    },
+    {
+      "name": "array-form-featuresets-hashed-verbatim",
+      "description": "The array-of-{name,...} featureSets shape is NON-CONFORMING (SPEC \u00a76.1 defines an object keyed by name; RFC-001's array example was a documented error, corrected 2026-08-02). A digest implementation MUST NOT set-normalize inside it: \u00a717.2's set paths are written against the object shape, so `uses` here keeps its input order (['tools','pushEvents'] stays unsorted) and no identifier check applies. Adjudicated after one implementation sorted inside the array shape and produced a different revision than the other for identical manifest bytes \u2014 precisely the failure the digest exists to prevent. Hash verbatim; let validation reject the shape.",
+      "input": {
+        "version": "0.5",
+        "featureSets": [
+          {
+            "name": "f",
+            "description": "d",
+            "uses": [
+              "tools",
+              "pushEvents"
+            ]
+          }
+        ]
+      },
+      "canonicalJson": "{\"featureSets\":[{\"description\":\"d\",\"name\":\"f\",\"uses\":[\"tools\",\"pushEvents\"]}],\"version\":\"0.5\"}",
+      "sha256Hex": "388a1f016882cec383a0bb3645f6dc6f24355f0be4deec2d5f9ad47a0f6baff7",
+      "digest": "sha256:OIofAWiCzsODoLs2RfbcbyQ1Xwvk3uwtX5rUeg9rr_c"
+    },
+    {
+      "name": "empty-member-differs-from-absent",
+      "description": "SPEC \u00a717.3: an ABSENT member and an EMPTY one are different manifests \u2014 they canonicalize differently \u2014 so a member appearing or disappearing IS a change to its domain. This vector is {version, featureSets:{}}; its digest MUST differ from minimal-manifest ({version} alone). Adjudicated after one implementation projected absent to {} in its domain diff and under-announced the change.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {}
+      },
+      "canonicalJson": "{\"featureSets\":{},\"version\":\"0.5\"}",
+      "sha256Hex": "6840e5900d7d7c2a6ee52aa5ba97c46051a178330911d53af1c2919faa70e3f4",
+      "digest": "sha256:aEDlkA19fCpu5SqlupfEYFGheDMJEdU68cKRn6pw4_Q",
+      "differentDigestFrom": "minimal-manifest"
+    },
+    {
+      "name": "non-string-set-member-hashed-verbatim",
+      "description": "SPEC \u00a717.2 totality, second corollary (adjudicated 2026-08-03): a set-DECLARED array containing any non-string member is non-conforming input and is hashed VERBATIM \u2014 no set sort, no dedupe, no identifier check. An earlier draft declared a set_member_not_string refusal; both libraries implemented it and review struck it \u2014 the identifier refusal exists solely to keep the UTF-8/UTF-16 sort divergence unreachable, and an unsorted array cannot diverge. Note the order [\"tools\", 1, \"pushEvents\"] is preserved and the duplicate is kept.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "demo.messaging": {
+            "description": "d",
+            "uses": [
+              "tools",
+              1,
+              "pushEvents",
+              "tools"
+            ]
+          }
+        }
+      },
+      "canonicalJson": "{\"featureSets\":{\"demo.messaging\":{\"description\":\"d\",\"uses\":[\"tools\",1,\"pushEvents\",\"tools\"]}},\"version\":\"0.5\"}",
+      "sha256Hex": "5a1b11f09786c34916727031be456d6ff9d7a89c0ed8ba141ea0eea6a10a1715",
+      "digest": "sha256:WhsR8JeGw0kWcnAxvkVtb_nXqJwO2LoUHqDupqEKFxU"
+    },
+    {
+      "name": "non-string-set-member-single",
+      "description": "Minimal companion to non-string-set-member-hashed-verbatim: uses:[1] digests (totality), never refuses.",
+      "input": {
+        "version": "0.5",
+        "featureSets": {
+          "f": {
+            "description": "d",
+            "uses": [
+              1
+            ]
+          }
+        }
+      },
+      "canonicalJson": "{\"featureSets\":{\"f\":{\"description\":\"d\",\"uses\":[1]}},\"version\":\"0.5\"}",
+      "sha256Hex": "0442c55fc2e72aeb6613afa15e3e75f90b42f5bcb80609a8460176791366eea1",
+      "digest": "sha256:BELFX8LnKutmE6-hXj51-QtC9by4BgmoRgF2eRNm7qE"
+    }
+  ],
+  "sortVectors": [
+    {
+      "name": "ascii-punctuation-and-case",
+      "description": "Pure ASCII, reachable from a conforming manifest. Byte order is '*'(0x2A) < '-'(0x2D) < '.'(0x2E) < '0'(0x30) < ':'(0x3A) < 'A'(0x41) < 'a'(0x61). Any case-insensitive or ICU-style collation produces a different order.",
+      "input": [
+        "a:b",
+        "A:b",
+        "a.b",
+        "a-b",
+        "a*b",
+        "a0b",
+        "a:",
+        "a",
+        "ab",
+        "A",
+        "Ab"
+      ],
+      "sorted": [
+        "A",
+        "A:b",
+        "Ab",
+        "a",
+        "a*b",
+        "a-b",
+        "a.b",
+        "a0b",
+        "a:",
+        "a:b",
+        "ab"
+      ]
+    },
+    {
+      "name": "prefix-is-shortest-first",
+      "description": "A proper prefix sorts before any extension of it, in both UTF-8 byte order and every other order \u2014 included because length-then-lexicographic comparators get it wrong.",
+      "input": [
+        "chat:from-self",
+        "chat:from",
+        "chat:from-human",
+        "chat:f",
+        "chat:from-bot"
+      ],
+      "sorted": [
+        "chat:f",
+        "chat:from",
+        "chat:from-bot",
+        "chat:from-human",
+        "chat:from-self"
+      ]
+    },
+    {
+      "name": "utf8-vs-utf16-divergence-above-bmp",
+      "description": "THE reason RFC-003 \u00a73.1 says 'UTF-8 byte sequence' and not 'sort'. U+FFFD encodes as EF BF BD and U+10000 as F0 90 80 80, so UTF-8 puts U+FFFD first. In UTF-16, U+10000 is the surrogate pair D800 DC00 and U+FFFD is FFFD, so JavaScript's default Array.prototype.sort() (UTF-16 code units) puts U+10000 first. Rust's str Ord (UTF-8 bytes, equivalently code points) agrees with the RFC. A JavaScript implementation MUST NOT use the default comparator; compare code points, or encode to UTF-8 and compare bytes. Not reachable from a conforming 0.5 manifest \u2014 see README.",
+      "input": [
+        "\ud800\udc00",
+        "\ufffd",
+        "\ud83d\ude42",
+        "\uffff",
+        "z"
+      ],
+      "sorted": [
+        "z",
+        "\ufffd",
+        "\uffff",
+        "\ud800\udc00",
+        "\ud83d\ude42"
+      ]
+    },
+    {
+      "name": "utf8-equals-codepoint-order",
+      "description": "UTF-8 byte order and Unicode code-point order are the same order \u2014 UTF-8 is order-preserving. This vector exists so an implementation may compare code points instead of encoding, and know that is conforming.",
+      "input": [
+        "\u00ff",
+        "\u0100",
+        "\u07ff",
+        "\u0800",
+        "\u07c0",
+        "\u0080",
+        "\u007f"
+      ],
+      "sorted": [
+        "\u007f",
+        "\u0080",
+        "\u00ff",
+        "\u0100",
+        "\u07c0",
+        "\u07ff",
+        "\u0800"
+      ]
+    }
+  ],
+  "sortVectorsNote": "These test the set-array comparator in isolation: input is a list of strings, `sorted` is the required result after deduplication. They are not manifests. They exist because no set-valued array in the 0.5 manifest shape can legally hold a non-ASCII string \u2014 every one of them holds identifiers \u2014 so RFC-003's 'the UTF-8 rule governs anything else' clause is currently unreachable through a conforming manifest and would otherwise go untested until the first field that needs it."
+}


### PR DESCRIPTION
Closes #2 — the server half of RFC-003 for the eidoverse door, on main's post-#1 state (declaration.ts).

- **§17.2 digest** implemented to the frozen 25-vector corpus (vendored byte-for-byte; all 25 pass plus own-manifest self-consistency and announcer-silence — 28/28 in `mcpl/manifest-test.ts`, run with `bun run manifest-test.ts`). Rules as adjudicated: totality with the all-strings gate, sole refusal `identifier_charset`, verbatim hashing for every non-conforming shape.
- **`initialize` advertises the manifest WITH revision**; **`mcpl/manifest`** answers the identical snapshot (§17.4 — complete, never a delta, ungated).
- **`ManifestAnnouncer` seeded at handshake** (§17 impl note): no redundant announce of what initialize carried; the surface is compile-time static today, so the announcer's silence is itself asserted by test, and any future mutating site gets working plumbing.

Tree discipline per this repo's rules: isolated worktree, explicit-pathspec commit, denoise-test still green, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)