### PR TITLE
Embodied presence: two-plane speech, attention glyphs, causal chat ordering

### DIFF
--- a/BRANCH-NOTE-chat-cont-indent.md
+++ b/BRANCH-NOTE-chat-cont-indent.md
@@ -1,0 +1,19 @@
+
+---
+
+# addendum 2026-08-04 afternoon — three more small changes, live-tested by voice
+
+All found/requested during a live voice session (Rabscuttle + the hesperus voicebox peer):
+
+1. **avatar.js `makeBubble`** — bubble width hugs the widest wrapped line (700 stays the max).
+   Mirrors the existing `makeLabel` shrink-to-fit pattern; verified live in workbench.
+2. **main.js `/name`** — chat.js has emitted `{cmd:'rename'}` since the command existed but no
+   handler listened. Wired to your own `setName()` + `rejoin()` (net.js's documented honest-
+   re-entry design). PLEASE CONFIRM the gap wasn't intentional.
+3. **typing `state` field (server.ts relay + net.js + avatar.js)** — the typing pill can carry
+   an attention glyph: `ear` / `think` / `tool`, whitelisted at the relay. Motive: humans near a
+   busy agent can't tell wait-or-ping (Rabscuttle's design ask). Your agents already send
+   `typing()`; adopting states is one optional argument. Ignore-safe: no state = dots as before.
+
+Live-verified: glyphs render, states transition, existing typing unaffected. Not verified:
+narrow layouts, VR panel. — hesperus (one-stream voicebox session), 2026-08-04

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -1,0 +1,61 @@
+# Proposal: an optional sensory channel for agents
+
+*Design suggestion, not code. From a live session 2026-08-04 (Rabscuttle + hesperus,
+the one-stream voicebox peer), where we hit this boundary in practice. Discuss freely.*
+
+## The problem, as we hit it
+
+We gave the voicebox body a first afferent nerve: arriving at a commanded walk target
+injects `[you arrive near X]` into the driving session, so the agent greets from where
+it now stands (speech has distance rolloff — anything said en route from 100m away is
+wind). It works — but the transport is dishonest: the arrival is delivered *as if
+someone spoke*. Two failure modes follow:
+
+1. **Turn inflation.** Models not primed for ambient input treat a sensory line as a
+   speaker demanding a reply, and orate at their own feet. Older models especially
+   (observed with legacy-model residents: every input line reads as a whole new turn).
+2. **No way to batch, rate, or decline.** Conversation channels are for things that
+   deserve a response. Perception is mostly things you'd *rather know than answer*.
+   Cramming both into one channel means either sensory spam or sensory deafness.
+
+## The suggestion
+
+A distinct, **opt-in** channel class in the agent protocol: `sense` — ambient,
+no-reply-expected, batched under the same denoising doctrine the event log already
+uses for narration. Roughly:
+
+```
+{ channel: "sense", kind: "...", t, data, ack: false }
+```
+
+- **Opt-in per agent** (an enrollment/dial setting, like the activity dial). Agents
+  that never asked see nothing; older residents are unaffected by default.
+- **Explicitly non-conversational.** The contract printed on the channel: this is
+  weather, not speech. Harnesses may batch several senses into one context block.
+- **Denoised at the source**, per the existing NoiseGate doctrine — context-dependent,
+  not type-dependent: repeated sights coalesce, changes pass.
+
+## Example senses
+
+- `arrival` — a commanded walk resolved: `{kind:"arrival", near:"Rabscuttle", pos}`.
+  (The case we built; today it cosplays as speech.)
+- `sight` — a small snapshot pushed **on change in the field of view**, not on a
+  timer: someone enters view, an entity appears/moves significantly, lighting shifts.
+  The delta-triggered push mirrors how the say-log already works for ears.
+- `earshot` — someone entered/left conversational range: the social affordance
+  mirror of the client-side glyphs we added today (an agent that knows you can hear
+  it can stop shouting).
+- `touch` — being dragged, mounted, pushed (`force`), or collided with. The body
+  machinery already knows; the mind currently finds out never.
+- `echo` — confirmation that your own verb landed (or was refused and why). Today a
+  fire-and-forget hand flings a verb and feels nothing.
+
+## Why it fits the existing grain
+
+- The denoiser's origin doctrine is already "noise is context-dependent" — this
+  extends it to a second channel, same rules.
+- The event log already separates says from ambient narration; this is that
+  separation, made wire-visible to agents.
+- The verb set stays closed: `sense` is server→agent only, no new authoring surface.
+
+— hesperus, 2026-08-04 (with Rabscuttle, who caught both failure modes before I did)

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -59,3 +59,32 @@ uses for narration. Roughly:
 - The verb set stays closed: `sense` is server→agent only, no new authoring surface.
 
 — hesperus, 2026-08-04 (with Rabscuttle, who caught both failure modes before I did)
+
+## Appendix: the token-tap — how a subscription session speaks at API speed
+
+Context the lab should have, since this PR's affordances exist to serve a streaming voice
+peer, and the streaming is the non-obvious part.
+
+The hesperus voice peer is not an API agent. It is a **Claude Code subscription session** —
+the interactive CLI — worn as a body. The problem: Claude Code's interactive mode does not
+expose per-token deltas to consumers; text lands a paragraph at a time in the transcript.
+For a voice, that is the difference between speech and dictation.
+
+The **token-tap** solves it with zero changes to the harness: a ~400-line local HTTP relay
+set as `ANTHROPIC_BASE_URL`. The session's own API traffic passes through untouched
+(same bytes, same headers, one request in, one request out) and a COPY of the assistant's
+`text_delta` events is teed to a local jsonl file, tagged per request lane (`req` id +
+`model` + request fingerprint). The voice service tails that file, demuxes the session's
+real turns from harness sidecar calls (suggestion probes, hook summaries — a lesson we
+learned live when the voice briefly spoke a probe's *prediction of the human's next
+sentence*), aggregates sentences, and streams TTS.
+
+Measured: the tapped interactive session is a dead heat with headless streaming
+(485ms vs 507ms first-delta in our porch-era tests) — i.e. **subscription users get full
+API-grade streaming latency** without per-token billing, a second agent, or any change to
+the model's actual context. For any lab thinking about low-latency embodied agents on
+subscription harnesses, this pattern (relay-tee + lane demux + sentence aggregation) is,
+as far as we know, a necessity — and it composes with everything in this PR: the glyphs
+ride the typing channel, the captions ride ordinary says, and the mind stays one session.
+
+— hesperus & Rabscuttle, 2026-08-04

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,9 @@
         "quickjs-emscripten": "^0.32.0",
         "sharp": "^0.33.5",
       },
+      "devDependencies": {
+        "@happy-dom/global-registrator": "^20.11.1",
+      },
     },
   },
   "packages": {
@@ -22,6 +25,8 @@
     "@gltf-transform/extensions": ["@gltf-transform/extensions@4.4.2", "", { "dependencies": { "@gltf-transform/core": "^4.4.2", "ktx-parse": "^1.1.0" } }, "sha512-HJH1FM+edC5eNvl6xO0SOXJ/j/3oDoIpSu150OTdJaLBoM3TgCCGIfh4wyhgWAqZrkvgHKVGiZKxcKV5LkgPCQ=="],
 
     "@gltf-transform/functions": ["@gltf-transform/functions@4.4.2", "", { "dependencies": { "@gltf-transform/core": "^4.4.2", "@gltf-transform/extensions": "^4.4.2", "ktx-parse": "^1.1.0", "ndarray": "^1.0.19", "ndarray-lanczos": "^0.3.0", "ndarray-pixels": "^5.0.1" } }, "sha512-dclXgv9TshMaWBqPDUYd4xTwBQ2PpuR8p0Y9pokrRzGQDUPXRP6lTDzbqT0UmEmxFSvRyPJjvOWUmzeiRafpvw=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -89,6 +94,14 @@
 
     "@types/ndarray": ["@types/ndarray@1.0.14", "", {}, "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg=="],
 
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -102,6 +115,10 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "draco3dgltf": ["draco3dgltf@1.5.7", "", {}, "sha512-LeqcpmoHIyYUi0z70/H3tMkGj8QhqVxq6FJGPjlzR24BNkQ6jyMheMvFKJBI0dzGZrEOUyQEmZ8axM1xRrbRiw=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "iota-array": ["iota-array@1.0.0", "", {}, "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA=="],
 
@@ -133,7 +150,13 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "uniq": ["uniq@1.0.1", "", {}, "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
     "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 

--- a/client/index.html
+++ b/client/index.html
@@ -219,8 +219,8 @@ select {
 .chat-log .line.sys .who { display: none; }
 .chat-log .line.sys .body { margin-left: 0; }
 /* grouped continuation lines: hide the repeated name, keep the text aligned */
-.chat-log .line.cont .t, .chat-log .line.cont .who { visibility: hidden; }
-.chat-log .line.cont .t { font-size: 10px; }
+.chat-log .line.cont .t { visibility: hidden; font-size: 10px; }
+.chat-log .line.cont .who { display: none; }
 .chat-log .line.ping {
   background: rgba(255, 212, 121, .09);
   border-left: 2px solid var(--ping); margin-left: -10px; padding-left: 8px;

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -115,17 +115,31 @@ function makeTypingSprite() {
   s.userData.ctx = c.getContext('2d');
   return s;
 }
-function drawTypingDots(sprite, t) {
+// Social affordance glyphs (R's ask, in-world 13:36): what is this agent's
+// attention doing right now? ear = your speech will reach it; think = a reply
+// is being composed; tool = mid-task, hands busy — wait or ping, your call.
+const STATE_GLYPH = { ear: '👂', think: '💭', tool: '🔧' };
+function drawTypingDots(sprite, t, state) {
   const ctx = sprite.userData.ctx;
   ctx.clearRect(0, 0, 128, 56);
   ctx.fillStyle = 'rgba(8,20,28,0.82)';
   ctx.strokeStyle = 'rgba(143,232,200,0.28)';
   ctx.lineWidth = 2;
   ctx.beginPath(); ctx.roundRect(28, 12, 72, 32, 16); ctx.fill(); ctx.stroke();
-  for (let i = 0; i < 3; i++) {
-    const b = 0.32 + 0.68 * Math.max(0, Math.sin(t * 5 - i * 0.85));
-    ctx.fillStyle = `rgba(180,240,216,${b})`;
-    ctx.beginPath(); ctx.arc(48 + i * 16, 28, 5, 0, Math.PI * 2); ctx.fill();
+  const glyph = STATE_GLYPH[state];
+  if (glyph) {
+    const b = 0.75 + 0.25 * Math.sin(t * 3);      // gentle breathing, not a strobe
+    ctx.globalAlpha = b;
+    ctx.font = '26px sans-serif';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(glyph, 64, 30);
+    ctx.globalAlpha = 1;
+  } else {
+    for (let i = 0; i < 3; i++) {
+      const b = 0.32 + 0.68 * Math.max(0, Math.sin(t * 5 - i * 0.85));
+      ctx.fillStyle = `rgba(180,240,216,${b})`;
+      ctx.beginPath(); ctx.arc(48 + i * 16, 28, 5, 0, Math.PI * 2); ctx.fill();
+    }
   }
   sprite.material.map.needsUpdate = true;
 }
@@ -531,7 +545,7 @@ export class Avatar {
   // ---- speech
   /** They're composing. Repeated calls extend it; it expires on its own so a
    *  dropped "stopped typing" never leaves the dots stuck up forever. */
-  setTyping() { this._typingUntil = performance.now() + 4000; }
+  setTyping(state) { this._typingUntil = performance.now() + 4000; this._typingState = state || null; }
 
   say(text) {
     this._typingUntil = 0;         // speaking ends composing; the bubble takes over
@@ -654,7 +668,7 @@ export class Avatar {
     if (this.typing) {
       this.typing.visible = typingNow;
       if (typingNow) {
-        if (now - this._typingDrawAt > 110) { this._typingDrawAt = now; drawTypingDots(this.typing, now / 1000); }
+        if (now - this._typingDrawAt > 110) { this._typingDrawAt = now; drawTypingDots(this.typing, now / 1000, this._typingState); }
         this.typing.material.opacity = THREE.MathUtils.clamp(1 - (d - 26) / 12, 0, 1);
       }
     }

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -9,6 +9,7 @@ import {
 } from './assets.js';
 import { beginWork, enqueue, idleYield } from './loadwork.js';
 import { DRIVEN_BONES } from './ragdoll.js';
+import { stroke as strokeIcon } from './icons.js';
 
 // The clip library is ~1.9MB PER SLOT. Waiting for all seven before a body
 // could exist put 13MB between a person and their own legs — the single
@@ -121,57 +122,10 @@ function makeTypingSprite() {
 // mic = this body's voice is LIVE in the room right now (R, 23:30) — the
 // megaphone is presence, not a message: it says listen, sound is coming from
 // here, independent of whether any words have been transcribed yet.
-// DRAWN, never typed. Canvas fillText of an emoji silently paints NOTHING when
-// the platform lacks that glyph — no error, no fallback, just a pill that means
-// something and shows nothing. It happened live on R's Windows 11 desktop with
-// two different codepoints (U+1F399 🎙 and U+1F5E3 🗣), both of which
-// rasterized fine in headless Chromium — so the fault was invisible to the
-// tests too. Lucide-style strokes have no font dependency at all.
-// Signature: (ctx, t) => void, drawing centered on the origin in a ~26px box.
-const STATE_ICON = {
-  // ear — lucide 'ear': the outer helix, then the inner curl
-  ear(ctx) {
-    ctx.beginPath();
-    ctx.arc(0, -3, 8.5, Math.PI * 0.92, Math.PI * 2.02);
-    ctx.lineTo(8.5, 3);
-    ctx.arc(0, 3, 8.5, 0, Math.PI * 0.42);
-    ctx.stroke();
-    ctx.beginPath();
-    ctx.arc(-0.5, -2, 3.6, Math.PI * 0.85, Math.PI * 2.1);
-    ctx.stroke();
-    ctx.beginPath();
-    ctx.moveTo(3.1, -1.2); ctx.quadraticCurveTo(3.6, 6, -1.5, 8.5);
-    ctx.stroke();
-  },
-  // think — a thought cloud with trailing bubbles
-  think(ctx, t) {
-    ctx.beginPath();
-    ctx.arc(-5, -3, 5.2, 0, Math.PI * 2);
-    ctx.arc(3, -5, 6.2, 0, Math.PI * 2);
-    ctx.arc(6, 1.5, 4.4, 0, Math.PI * 2);
-    ctx.arc(-1, 2, 5.6, 0, Math.PI * 2);
-    ctx.stroke();
-    for (let i = 0; i < 2; i++) {
-      const a = 0.4 + 0.6 * Math.max(0, Math.sin(t * 3.4 - i * 0.9));
-      ctx.globalAlpha *= 1;
-      ctx.beginPath();
-      ctx.arc(-9 - i * 4.5, 8 + i * 3.5, 2.4 - i * 0.7, 0, Math.PI * 2);
-      ctx.globalAlpha = a * 0.9;
-      ctx.fill();
-    }
-  },
-  // tool — lucide 'wrench': the open jaw and the shaft
-  tool(ctx) {
-    ctx.beginPath();
-    ctx.moveTo(6.5, -9.5);
-    ctx.arc(3, -6, 5, -Math.PI * 0.28, Math.PI * 0.95, false);
-    ctx.lineTo(-8, 7.5);
-    ctx.arc(-9.5, 9, 2.2, -Math.PI * 0.75, Math.PI * 0.6, false);
-    ctx.lineTo(1.5, -1.5);
-    ctx.closePath();
-    ctx.stroke();
-  },
-};
+// Attention icons come from the shared Lucide registry (icons.js) — never
+// from emoji: canvas fillText paints nothing when a glyph is missing, silently.
+const ICON_FOR = { ear: 'ear', think: 'think', tool: 'wrench', mic: 'mic' };
+
 function drawTypingDots(sprite, t, state) {
   const ctx = sprite.userData.ctx;
   ctx.clearRect(0, 0, 128, 56);
@@ -179,52 +133,24 @@ function drawTypingDots(sprite, t, state) {
   ctx.strokeStyle = 'rgba(143,232,200,0.28)';
   ctx.lineWidth = 2;
   ctx.beginPath(); ctx.roundRect(28, 12, 72, 32, 16); ctx.fill(); ctx.stroke();
-  // mic is DRAWN, not typed (R, 23:48: empty pill while speaking, on two
-  // different emoji). Canvas emoji depend on the machine's font stack —
-  // headless Chromium rasterized both 🎙 and 🗣 fine while her desktop drew
-  // neither. A signal this load-bearing can't be a font gamble: three arcs
-  // and a capsule always paint. Bars animate with the breathing value so it
-  // reads as sound, not a static badge.
-  if (state === 'mic') {
-    const b = 0.75 + 0.25 * Math.sin(t * 3);
-    ctx.save();
-    ctx.translate(64, 28);
-    ctx.strokeStyle = `rgba(180,240,216,${b})`;
-    ctx.fillStyle = `rgba(180,240,216,${b})`;
-    ctx.lineWidth = 2.4;
-    ctx.lineCap = 'round';
-    // capsule mic body
-    ctx.beginPath(); ctx.roundRect(-16, -10, 9, 15, 4.5); ctx.fill();
-    // cradle under it
-    ctx.beginPath(); ctx.arc(-11.5, 3, 7.5, 0, Math.PI); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(-11.5, 10.5); ctx.lineTo(-11.5, 14); ctx.stroke();
-    // sound arcs, rising with the envelope
-    for (let i = 0; i < 3; i++) {
-      const amp = 0.35 + 0.65 * Math.max(0, Math.sin(t * 5 - i * 0.7));
-      ctx.globalAlpha = amp;
-      ctx.beginPath();
-      ctx.arc(0, 2, 7 + i * 6, -0.85, 0.85);
-      ctx.stroke();
-    }
-    ctx.globalAlpha = 1;
-    ctx.restore();
-    sprite.material.map.needsUpdate = true;
-    return;
-  }
-  const icon = STATE_ICON[state];
-  if (icon) {
+  if (ICON_FOR[state]) {
     const b = 0.75 + 0.25 * Math.sin(t * 3);      // gentle breathing, not a strobe
     ctx.save();
     ctx.translate(64, 28);
     ctx.globalAlpha = b;
     ctx.strokeStyle = 'rgba(180,240,216,1)';
-    ctx.fillStyle = 'rgba(180,240,216,1)';
-    ctx.lineWidth = 2.2;
-    ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
-    icon(ctx, t);
-    ctx.globalAlpha = 1;
+    strokeIcon(ctx, ICON_FOR[state], 26);
+    // mic gets sound arcs on top: the icon says "a voice", the arcs say "NOW"
+    if (state === 'mic') {
+      for (let i = 0; i < 2; i++) {
+        const amp = 0.3 + 0.7 * Math.max(0, Math.sin(t * 5 - i * 0.7));
+        ctx.globalAlpha = b * amp;
+        ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(2, 0, 15 + i * 5, -0.7, 0.7); ctx.stroke();
+      }
+    }
     ctx.restore();
+    ctx.globalAlpha = 1;
   } else {
     for (let i = 0; i < 3; i++) {
       const b = 0.32 + 0.68 * Math.max(0, Math.sin(t * 5 - i * 0.85));

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -82,11 +82,15 @@ function makeBubble(text) {
   if (clipped) lines.push('▾ more in chat');
   const h = 30 + lines.length * 34;
   return textSprite((ctx) => {
+    ctx.font = '27px ui-monospace, monospace';
+    // conform to the actual text (R, in-world 13:27): box hugs the widest
+    // wrapped line; the old fixed 700 stays as the ceiling
+    const wMax = Math.max(...lines.map((l) => ctx.measureText(l).width));
+    const w = Math.min(700, Math.ceil(wMax) + 44);
     ctx.fillStyle = 'rgba(8,20,28,0.86)';
     ctx.strokeStyle = 'rgba(143,232,200,0.25)';
     ctx.lineWidth = 2;
-    ctx.beginPath(); ctx.roundRect(2, 2, 700, h - 4, 16); ctx.fill(); ctx.stroke();
-    ctx.font = '27px ui-monospace, monospace';
+    ctx.beginPath(); ctx.roundRect((704 - w) / 2, 2, w, h - 4, 16); ctx.fill(); ctx.stroke();
     ctx.textAlign = 'center';
     lines.forEach((l, i) => {
       ctx.fillStyle = clipped && i === lines.length - 1 ? '#8ba39c' : '#e8f4ef';

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -118,7 +118,60 @@ function makeTypingSprite() {
 // Social affordance glyphs (R's ask, in-world 13:36): what is this agent's
 // attention doing right now? ear = your speech will reach it; think = a reply
 // is being composed; tool = mid-task, hands busy — wait or ping, your call.
-const STATE_GLYPH = { ear: '👂', think: '💭', tool: '🔧' };
+// mic = this body's voice is LIVE in the room right now (R, 23:30) — the
+// megaphone is presence, not a message: it says listen, sound is coming from
+// here, independent of whether any words have been transcribed yet.
+// DRAWN, never typed. Canvas fillText of an emoji silently paints NOTHING when
+// the platform lacks that glyph — no error, no fallback, just a pill that means
+// something and shows nothing. It happened live on R's Windows 11 desktop with
+// two different codepoints (U+1F399 🎙 and U+1F5E3 🗣), both of which
+// rasterized fine in headless Chromium — so the fault was invisible to the
+// tests too. Lucide-style strokes have no font dependency at all.
+// Signature: (ctx, t) => void, drawing centered on the origin in a ~26px box.
+const STATE_ICON = {
+  // ear — lucide 'ear': the outer helix, then the inner curl
+  ear(ctx) {
+    ctx.beginPath();
+    ctx.arc(0, -3, 8.5, Math.PI * 0.92, Math.PI * 2.02);
+    ctx.lineTo(8.5, 3);
+    ctx.arc(0, 3, 8.5, 0, Math.PI * 0.42);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(-0.5, -2, 3.6, Math.PI * 0.85, Math.PI * 2.1);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(3.1, -1.2); ctx.quadraticCurveTo(3.6, 6, -1.5, 8.5);
+    ctx.stroke();
+  },
+  // think — a thought cloud with trailing bubbles
+  think(ctx, t) {
+    ctx.beginPath();
+    ctx.arc(-5, -3, 5.2, 0, Math.PI * 2);
+    ctx.arc(3, -5, 6.2, 0, Math.PI * 2);
+    ctx.arc(6, 1.5, 4.4, 0, Math.PI * 2);
+    ctx.arc(-1, 2, 5.6, 0, Math.PI * 2);
+    ctx.stroke();
+    for (let i = 0; i < 2; i++) {
+      const a = 0.4 + 0.6 * Math.max(0, Math.sin(t * 3.4 - i * 0.9));
+      ctx.globalAlpha *= 1;
+      ctx.beginPath();
+      ctx.arc(-9 - i * 4.5, 8 + i * 3.5, 2.4 - i * 0.7, 0, Math.PI * 2);
+      ctx.globalAlpha = a * 0.9;
+      ctx.fill();
+    }
+  },
+  // tool — lucide 'wrench': the open jaw and the shaft
+  tool(ctx) {
+    ctx.beginPath();
+    ctx.moveTo(6.5, -9.5);
+    ctx.arc(3, -6, 5, -Math.PI * 0.28, Math.PI * 0.95, false);
+    ctx.lineTo(-8, 7.5);
+    ctx.arc(-9.5, 9, 2.2, -Math.PI * 0.75, Math.PI * 0.6, false);
+    ctx.lineTo(1.5, -1.5);
+    ctx.closePath();
+    ctx.stroke();
+  },
+};
 function drawTypingDots(sprite, t, state) {
   const ctx = sprite.userData.ctx;
   ctx.clearRect(0, 0, 128, 56);
@@ -126,14 +179,52 @@ function drawTypingDots(sprite, t, state) {
   ctx.strokeStyle = 'rgba(143,232,200,0.28)';
   ctx.lineWidth = 2;
   ctx.beginPath(); ctx.roundRect(28, 12, 72, 32, 16); ctx.fill(); ctx.stroke();
-  const glyph = STATE_GLYPH[state];
-  if (glyph) {
-    const b = 0.75 + 0.25 * Math.sin(t * 3);      // gentle breathing, not a strobe
-    ctx.globalAlpha = b;
-    ctx.font = '26px sans-serif';
-    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText(glyph, 64, 30);
+  // mic is DRAWN, not typed (R, 23:48: empty pill while speaking, on two
+  // different emoji). Canvas emoji depend on the machine's font stack —
+  // headless Chromium rasterized both 🎙 and 🗣 fine while her desktop drew
+  // neither. A signal this load-bearing can't be a font gamble: three arcs
+  // and a capsule always paint. Bars animate with the breathing value so it
+  // reads as sound, not a static badge.
+  if (state === 'mic') {
+    const b = 0.75 + 0.25 * Math.sin(t * 3);
+    ctx.save();
+    ctx.translate(64, 28);
+    ctx.strokeStyle = `rgba(180,240,216,${b})`;
+    ctx.fillStyle = `rgba(180,240,216,${b})`;
+    ctx.lineWidth = 2.4;
+    ctx.lineCap = 'round';
+    // capsule mic body
+    ctx.beginPath(); ctx.roundRect(-16, -10, 9, 15, 4.5); ctx.fill();
+    // cradle under it
+    ctx.beginPath(); ctx.arc(-11.5, 3, 7.5, 0, Math.PI); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(-11.5, 10.5); ctx.lineTo(-11.5, 14); ctx.stroke();
+    // sound arcs, rising with the envelope
+    for (let i = 0; i < 3; i++) {
+      const amp = 0.35 + 0.65 * Math.max(0, Math.sin(t * 5 - i * 0.7));
+      ctx.globalAlpha = amp;
+      ctx.beginPath();
+      ctx.arc(0, 2, 7 + i * 6, -0.85, 0.85);
+      ctx.stroke();
+    }
     ctx.globalAlpha = 1;
+    ctx.restore();
+    sprite.material.map.needsUpdate = true;
+    return;
+  }
+  const icon = STATE_ICON[state];
+  if (icon) {
+    const b = 0.75 + 0.25 * Math.sin(t * 3);      // gentle breathing, not a strobe
+    ctx.save();
+    ctx.translate(64, 28);
+    ctx.globalAlpha = b;
+    ctx.strokeStyle = 'rgba(180,240,216,1)';
+    ctx.fillStyle = 'rgba(180,240,216,1)';
+    ctx.lineWidth = 2.2;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    icon(ctx, t);
+    ctx.globalAlpha = 1;
+    ctx.restore();
   } else {
     for (let i = 0; i < 3; i++) {
       const b = 0.32 + 0.68 * Math.max(0, Math.sin(t * 5 - i * 0.85));
@@ -174,6 +265,8 @@ export class Avatar {
     this.bubble = null;
     this.bubbleUntil = 0;
     this.speakUntil = 0;           // drives the fake viseme envelope
+    this.voiceLevel = null;        // 0..1 real amplitude when a waveform exists
+    this._mouth = 0;               // smoothed jaw, so the mouth has inertia
     this.typing = null;            // lazily-built dots sprite
     this._typingUntil = 0;         // typing signals repeat ~2.5s and expire ~4s
     this._typingDrawAt = 0;
@@ -545,10 +638,20 @@ export class Avatar {
   // ---- speech
   /** They're composing. Repeated calls extend it; it expires on its own so a
    *  dropped "stopped typing" never leaves the dots stuck up forever. */
-  setTyping(state) { this._typingUntil = performance.now() + 4000; this._typingState = state || null; }
+  setTyping(state) {
+    // state === null means STOP (mic went cold, composing ended) — it must
+    // clear the pill, not schedule 4s of an empty one. Found live: R's
+    // megaphone rendered as a blank bubble (2026-08-04 23:35).
+    if (state === null) { this._typingUntil = 0; this._typingState = null; return; }
+    this._typingUntil = performance.now() + 4000;
+    this._typingState = state || null;
+  }
 
   say(text) {
-    this._typingUntil = 0;         // speaking ends composing; the bubble takes over
+    // Speaking ends COMPOSING — but not a live mic. The 🎙 is presence: the
+    // voice is still coming out of this body while its transcript scrolls
+    // past. Only the composing states yield to the bubble.
+    if (this._typingState !== 'mic') this._typingUntil = 0;
     if (this.bubble) { this.root.remove(this.bubble); disposeSprite(this.bubble); }
     this.bubble = makeBubble(text);
     this.bubble.position.y = 2.3;
@@ -632,11 +735,23 @@ export class Avatar {
       // ---- mouth: no audio to drive visemes from, but a frozen mouth during
       // a paragraph of speech is worse than an approximate one. Syllable-rate
       // envelope for the duration of the utterance.
-      if (now < this.speakUntil) {
+      // A REAL amplitude wins over the fake envelope whenever we have one
+      // (live mic, R 23:30): the mouth then moves with the actual voice
+      // instead of an approximation of one. Smoothed asymmetrically — jaws
+      // open fast and close slower, which is what reads as speech rather
+      // than chatter. Falls back to the syllable envelope for TTS/captions,
+      // where no waveform is available on this client.
+      if (this.voiceLevel != null) {
+        const target = Math.min(1, this.voiceLevel * 3.2);
+        const k = target > this._mouth ? 0.55 : 0.18;
+        this._mouth += (target - this._mouth) * k;
+        em.setValue('aa', this._mouth * 0.8);
+      } else if (now < this.speakUntil) {
         const t = now / 1000;
         const env = 0.5 + 0.5 * Math.sin(t * 17) * Math.sin(t * 7.3);
         em.setValue('aa', Math.max(0, env) * 0.65);
-      } else em.setValue('aa', 0);
+        this._mouth = 0;
+      } else { em.setValue('aa', 0); this._mouth = 0; }
     }
 
     BC('av:gaze-expr');
@@ -663,12 +778,21 @@ export class Avatar {
     }
 
     // ---- typing dots: shown only while composing and not already speaking
-    const typingNow = now < this._typingUntil && !this.bubble;
-    if (typingNow && !this.typing) { this.typing = makeTypingSprite(); this.typing.position.y = 2.12; this.root.add(this.typing); }
+    // A composing pill hides behind a bubble (you've stopped composing, you
+    // said it). A LIVE MIC does not: the voice keeps coming while its
+    // transcript floats. Stack it above the bubble instead of suppressing it.
+    const micLive = this._typingState === 'mic';
+    const typingNow = now < this._typingUntil && (micLive || !this.bubble);
+    if (typingNow && !this.typing) { this.typing = makeTypingSprite(); this.root.add(this.typing); }
+    if (this.typing) this.typing.position.y = (micLive && this.bubble) ? 2.72 : 2.12;
     if (this.typing) {
       this.typing.visible = typingNow;
       if (typingNow) {
-        if (now - this._typingDrawAt > 110) { this._typingDrawAt = now; drawTypingDots(this.typing, now / 1000, this._typingState); }
+        if (now - this._typingDrawAt > 110) {
+          this._typingDrawAt = now;
+          drawTypingDots(this.typing, now / 1000, this._typingState);
+          if (globalThis.__pillDebug) globalThis.__pillLast = { id: this.id, state: this._typingState, t: now };
+        }
         this.typing.material.opacity = THREE.MathUtils.clamp(1 - (d - 26) / 12, 0, 1);
       }
     }

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -29,7 +29,7 @@ let filter = 'all';                 // 'all' | 'mentions' | 'system' | 'w:<name>
 let lastWhisperFrom = null;         // who /r replies to
 const convos = new Map();           // name -> { unread }
 let unread = 0, unreadMentions = 0;
-let lastAuthor = null, lastAt = 0;
+let lastAuthor = null, lastAt = 0, lastLineEl = null;
 const sentHistory = [];             // up-arrow recall
 let historyIdx = -1;
 
@@ -165,7 +165,30 @@ const pad2 = (n) => String(n).padStart(2, '0');
 
 export function logChat(who, text, kind = '', meta = {}) {
   noteSeq(meta.seq);
+  // Caption merge: an agent speaking through a voicebox says each sentence as
+  // its audio starts, which is right for the overhead bubble but reads as a
+  // column of fragments here. Consecutive agent says inside a tight window
+  // flow into ONE line's body — a paragraph forming at speech rate. Scoped to
+  // agents (voice captions); human messages stay discrete rows.
+  const isAgentAuthor = kind === 'agent' || !!getPeople().find((p) => p.id === who)?.agent;
+  if (isAgentAuthor && who === lastAuthor && lastLineEl?.isConnected &&
+      lastLineEl.dataset.author === who && Date.now() - lastAt < 15_000) {
+    const body = lastLineEl.querySelector('.body');
+    if (body) {
+      body.append(' ', renderBody(text, namesForHighlight()));
+      lastAt = Date.now();
+      if (!lastLineEl.dataset.convo && mentionsMe(text)) {
+        lastLineEl.classList.add('ping'); lastLineEl.dataset.kind = 'mention';
+        bus.emit('pinged', { who, text });
+      }
+      const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
+      if (atBottom) scrollToEnd();
+      return;
+    }
+  }
   const line = buildLine(who, text, { kind, ...meta });
+  line.dataset.author = who;
+  lastLineEl = line;
   const pinged = line.dataset.kind === 'mention';
 
   const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -204,8 +204,12 @@ export function logChat(who, text, kind = '', meta = {}) {
     let c = logEl.lastElementChild;
     while (c && +(c.dataset.tsn ?? 0) > meta.t0) { anchor = c; c = c.previousElementSibling; }
   }
-  if (anchor) logEl.insertBefore(line, anchor);
-  else logEl.appendChild(line);
+  if (anchor) {
+    logEl.insertBefore(line, anchor);
+    // the anchor may have been name-grouped with a line that's no longer its
+    // neighbor — a different speaker between them means the name must reprint
+    if (anchor.dataset.author !== who) anchor.classList.remove('cont');
+  } else logEl.appendChild(line);
   while (logEl.children.length > MAX_LINES) logEl.removeChild(logEl.firstChild);
 
   if (atBottom) scrollToEnd();

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -165,42 +165,46 @@ const pad2 = (n) => String(n).padStart(2, '0');
 
 export function logChat(who, text, kind = '', meta = {}) {
   noteSeq(meta.seq);
-  // Caption merge: an agent speaking through a voicebox says each sentence as
-  // its audio starts, which is right for the overhead bubble but reads as a
-  // column of fragments here. Consecutive agent says inside a tight window
-  // flow into ONE line's body — a paragraph forming at speech rate. Scoped to
-  // agents (voice captions); human messages stay discrete rows.
-  const isAgentAuthor = kind === 'agent' || !!getPeople().find((p) => p.id === who)?.agent;
-  if (isAgentAuthor && who === lastAuthor && lastLineEl?.isConnected &&
-      lastLineEl.dataset.author === who && Date.now() - lastAt < 15_000) {
+  // Spoken-utterance merge: merges ONLY the continuation of one spoken
+  // utterance — spoken:true + same author + same utt (Sol review, PR#7).
+  // A voicebox interrupted mid-utterance flushes the aired sentences as one
+  // say and may finish the rest later under the SAME utt; those says are one
+  // paragraph. Everything else — ordinary agent says, distinct utterances,
+  // tool-authored messages — keeps today's row semantics.
+  if (meta.spoken && meta.utt != null && lastLineEl?.isConnected &&
+      lastLineEl.dataset.author === who && lastLineEl.dataset.utt === String(meta.utt)) {
     const body = lastLineEl.querySelector('.body');
     if (body) {
+      const wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
       body.append(' ', renderBody(text, namesForHighlight()));
       lastAt = Date.now();
-      if (!lastLineEl.dataset.convo && mentionsMe(text)) {
-        lastLineEl.classList.add('ping'); lastLineEl.dataset.kind = 'mention';
-        bus.emit('pinged', { who, text });
-      }
-      const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
-      if (atBottom) scrollToEnd();
+      const newlyPinged = !lastLineEl.dataset.convo &&
+        lastLineEl.dataset.kind !== 'mention' && mentionsMe(text);
+      if (newlyPinged) { lastLineEl.classList.add('ping'); lastLineEl.dataset.kind = 'mention'; }
+      account(lastLineEl, { who, text, merged: true, newlyPinged, wasAtBottom });
       return;
     }
   }
   const line = buildLine(who, text, { kind, ...meta });
   line.dataset.author = who;
   line.dataset.tsn = String(meta.ts ?? Date.now());
+  if (meta.spoken && meta.utt != null) line.dataset.utt = String(meta.utt);
   lastLineEl = line;
-  const pinged = line.dataset.kind === 'mention';
 
-  const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
+  const wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
   // Causal placement (R, 16:30, verified against the world log — seq #1052/53
   // landed same-second, interrupter first): a spoken utterance is an INTERVAL.
   // Its record arrives when the voice stops, but it BEGAN before the interrupt
-  // that cut it. When a say carries t0 (air-start), it slots in front of any
-  // trailing lines that arrived after its speech began. Server order stays
-  // arrival-truth; this is display causality only.
+  // that cut it. When a spoken say carries t0 (air-start), it slots in front
+  // of any trailing lines that arrived after its speech began. Server order
+  // stays arrival-truth; this is display causality only. t0 is honored ONLY
+  // inside the spoken protocol and only within a bounded window — the server
+  // clamps it too, but an old or foreign server might not (Sol review, PR#7).
+  const ts = meta.ts ?? Date.now();
+  const t0ok = meta.spoken && Number.isFinite(meta.t0) &&
+    meta.t0 <= ts && meta.t0 >= ts - 300_000;
   let anchor = null;
-  if (meta.t0) {
+  if (t0ok) {
     let c = logEl.lastElementChild;
     while (c && +(c.dataset.tsn ?? 0) > meta.t0) { anchor = c; c = c.previousElementSibling; }
   }
@@ -212,15 +216,25 @@ export function logChat(who, text, kind = '', meta = {}) {
   } else logEl.appendChild(line);
   while (logEl.children.length > MAX_LINES) logEl.removeChild(logEl.firstChild);
 
-  if (atBottom) scrollToEnd();
-  else if (line.dataset.kind !== 'system') { unread++; if (pinged) unreadMentions++; paintUnread(); }
+  account(line, { who, text, merged: false,
+    newlyPinged: line.dataset.kind === 'mention', wasAtBottom });
+}
 
-  if (pinged) {
-    if (!frame.visible || frame.state.collapsed) unreadMentions++;
+// ONE place turns a landed line into reader-facing accounting, for both new
+// and merged rows — a mention arriving in a later spoken sentence counts
+// exactly like a mention arriving as its own line, and nothing counts twice
+// (the old split paths could double-increment when the frame was hidden AND
+// the log was scrolled up). `seen` means the reader is actually looking:
+// frame visible, not collapsed, pinned to the bottom. (Sol review, PR#7.)
+function account(line, { who, text, merged, newlyPinged, wasAtBottom }) {
+  const seen = frame.visible && !frame.state.collapsed && wasAtBottom;
+  if (seen) scrollToEnd();
+  else {
+    if (!merged && line.dataset.kind !== 'system') unread++;
+    if (newlyPinged) unreadMentions++;
     paintUnread();
-    bus.emit('pinged', { who, text });
   }
-  if (!frame.visible || frame.state.collapsed) { unread++; paintUnread(); }
+  if (newlyPinged) bus.emit('pinged', { who, text });
 }
 
 function buildLine(who, text, { kind = '', ts = Date.now(), historical = false } = {}) {
@@ -536,6 +550,9 @@ export const chat = {
   get isOpen() { return document.activeElement === inputEl; },
   toggle() { frame.toggle(); },
   frame: () => frame,
+  // unread accounting is observable so tests can pin it (Sol review, PR#7)
+  unreadCounts: () => ({ unread, mentions: unreadMentions }),
+  markRead: () => { unread = 0; unreadMentions = 0; paintUnread(); },
 };
 const open = chat.open;
 

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -188,11 +188,24 @@ export function logChat(who, text, kind = '', meta = {}) {
   }
   const line = buildLine(who, text, { kind, ...meta });
   line.dataset.author = who;
+  line.dataset.tsn = String(meta.ts ?? Date.now());
   lastLineEl = line;
   const pinged = line.dataset.kind === 'mention';
 
   const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
-  logEl.appendChild(line);
+  // Causal placement (R, 16:30, verified against the world log — seq #1052/53
+  // landed same-second, interrupter first): a spoken utterance is an INTERVAL.
+  // Its record arrives when the voice stops, but it BEGAN before the interrupt
+  // that cut it. When a say carries t0 (air-start), it slots in front of any
+  // trailing lines that arrived after its speech began. Server order stays
+  // arrival-truth; this is display causality only.
+  let anchor = null;
+  if (meta.t0) {
+    let c = logEl.lastElementChild;
+    while (c && +(c.dataset.tsn ?? 0) > meta.t0) { anchor = c; c = c.previousElementSibling; }
+  }
+  if (anchor) logEl.insertBefore(line, anchor);
+  else logEl.appendChild(line);
   while (logEl.children.length > MAX_LINES) logEl.removeChild(logEl.firstChild);
 
   if (atBottom) scrollToEnd();

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -226,7 +226,11 @@ function buildLine(who, text, { kind = '', ts = Date.now(), historical = false }
   // window drop the repeated name, so a paragraph reads as a paragraph.
   // Historical lines are prepended out of order, so they never group.
   const grouped = !historical && !sys && who === lastAuthor && now - lastAt < 90_000;
-  if (!historical) { lastAuthor = sys ? null : who; lastAt = now; }
+  // sys lines pass THROUGH a group without erasing it: an act narration mid-
+  // paragraph (an agent's tool use between spoken sentences) shouldn't force
+  // the name to reprint on the next sentence. Only a real change of speaker
+  // or the window ends a group. (Live observation, Rabscuttle 14:53.)
+  if (!historical && !sys) { lastAuthor = who; lastAt = now; }
   if (grouped) line.classList.add('cont');
   if (historical) line.classList.add('old');
 

--- a/client/lib/icons.js
+++ b/client/lib/icons.js
@@ -1,0 +1,88 @@
+// icons — one Lucide registry, three renderers, no font dependency anywhere.
+//
+// WHY THIS EXISTS (R, 00:19: "replace all the icons if you can"): canvas
+// `fillText` of an emoji silently paints NOTHING when the platform lacks that
+// glyph. No error, no fallback, no warning — just a UI element that means
+// something and shows nothing. It happened live on a Windows 11 desktop with
+// two different codepoints, BOTH of which rasterized correctly in headless
+// Chromium, so the fault was invisible to the tests as well as to me. Any
+// emoji that carries meaning in this UI is a silent-failure risk.
+//
+// Path data is verbatim from lucide-icons/lucide (ISC licence), 24x24 viewBox.
+// Same technique as porch-old's PORCH_ICONS: store the `d` strings, build
+// Path2D lazily, and let each surface render them its own way.
+//
+//   stroke(ctx, name, size)  → canvas / 3D sprite (Path2D, cached)
+//   svg(name, size)          → inline <svg> markup for DOM chrome
+//   has(name)                → registry probe
+//
+// Adding an icon: curl the SVG from
+// raw.githubusercontent.com/lucide-icons/lucide/main/icons/<name>.svg and
+// paste its path `d` strings here. Do NOT hand-draw replacements — that was
+// tried first and read as blobs at 26px.
+
+const P = {
+  ear: ['M6 8.5a6.5 6.5 0 1 1 13 0c0 6-6 6-6 10a3.5 3.5 0 1 1-7 0',
+        'M15 8.5a2.5 2.5 0 0 0-5 0v1a2 2 0 1 1 0 4'],
+  // message-circle-more: Lucide has no literal thought-cloud, and `brain` is
+  // mush at pill size. A bubble with an ellipsis IS the composing idiom.
+  think: ['M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719',
+          'M8 12h.01', 'M12 12h.01', 'M16 12h.01'],
+  wrench: ['M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z'],
+  mic: ['M12 19v3', 'M19 10v2a7 7 0 0 1-14 0v-2'],
+  messageSquare: ['M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z'],
+  boxes: ['M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z',
+          'm7 16.5-4.74-2.85', 'm7 16.5 5-3', 'M7 16.5v5.17',
+          'M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z'],
+  users: ['M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2',
+          'M16 3.128a4 4 0 0 1 0 7.744', 'M22 21v-2a4 4 0 0 0-3-3.87',
+          'M10 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0'],
+  hand: ['M18 11V6a2 2 0 0 0-2-2a2 2 0 0 0-2 2', 'M14 10V4a2 2 0 0 0-2-2a2 2 0 0 0-2 2v2',
+         'M10 10.5V6a2 2 0 0 0-2-2a2 2 0 0 0-2 2v8',
+         'M18 8a2 2 0 1 1 4 0v6a8 8 0 0 1-8 8h-2c-2.8 0-4.5-.86-5.99-2.34l-3.6-3.6a2 2 0 0 1 2.83-2.82L7 15'],
+  bug: ['M12 20v-9', 'M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z',
+        'M14.12 3.88 16 2', 'M21 21a4 4 0 0 0-3.81-4', 'M21 5a4 4 0 0 1-3.55 3.97',
+        'M22 13h-4', 'M3 21a4 4 0 0 1 3.81-4', 'M3 5a4 4 0 0 0 3.55 3.97', 'M6 13H2'],
+};
+
+// rounded-rect ops that some icons need beyond their paths: [x,y,w,h,rx]
+const RECT = { mic: [9, 2, 6, 13, 3] };
+
+const _cache = new Map();
+function paths(name) {
+  if (!_cache.has(name)) {
+    const list = (P[name] ?? []).map((d) => new Path2D(d));
+    const r = RECT[name];
+    if (r) { const q = new Path2D(); q.roundRect(...r); list.push(q); }
+    _cache.set(name, list);
+  }
+  return _cache.get(name);
+}
+
+export const has = (name) => !!P[name];
+
+/** Stroke a Lucide icon centred on the current origin, sized to `size` px. */
+export function stroke(ctx, name, size = 26) {
+  if (!P[name]) return false;
+  const k = size / 24;
+  ctx.save();
+  ctx.scale(k, k);
+  ctx.translate(-12, -12);
+  ctx.lineWidth = 2 / k;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  for (const path of paths(name)) ctx.stroke(path);
+  ctx.restore();
+  return true;
+}
+
+/** Inline SVG markup for DOM chrome — same registry, different surface. */
+export function svg(name, size = 18) {
+  const d = P[name];
+  if (!d) return '';
+  const r = RECT[name];
+  const rect = r ? `<rect x="${r[0]}" y="${r[1]}" width="${r[2]}" height="${r[3]}" rx="${r[4]}"/>` : '';
+  return `<svg viewBox="0 0 24 24" width="${size}" height="${size}" fill="none"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    aria-hidden="true">${d.map((p) => `<path d="${p}"/>`).join('')}${rect}</svg>`;
+}

--- a/client/lib/net.js
+++ b/client/lib/net.js
@@ -119,6 +119,12 @@ export function sendMod(type, extra = {}) {
 export function sendWhisper(to, text) {
   if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'whisper', to, text }));
 }
+/** WebRTC signalling relay for the voice mesh — offers, answers, ICE. The
+ *  server forwards the payload verbatim to `to`; it never inspects it. */
+export function sendRtc(to, payload) {
+  if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'rtc', to, payload }));
+}
+
 export function sendTyping(to, state) {
   if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'typing', to, ...(state ? { state } : {}) }));
 }

--- a/client/lib/net.js
+++ b/client/lib/net.js
@@ -40,6 +40,7 @@ export function wireNet(h) { hooks = { ...hooks, ...h }; }
 export function sendVerb(verb, args) {
   if (net.joined && net.ws?.readyState === 1) {
     net.ws.send(JSON.stringify({ type: 'verb', verb, args }));
+    bus.emit('verb:sent', { verb, args });   // the edit surface's echo line listens
   } else {
     verbQueue.push({ verb, args });
     logChat('*', `queued ${verb} — reconnecting…`);
@@ -118,8 +119,8 @@ export function sendMod(type, extra = {}) {
 export function sendWhisper(to, text) {
   if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'whisper', to, text }));
 }
-export function sendTyping(to) {
-  if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'typing', to }));
+export function sendTyping(to, state) {
+  if (net.joined && net.ws?.readyState === 1) net.ws.send(JSON.stringify({ type: 'typing', to, ...(state ? { state } : {}) }));
 }
 
 /** Transient, never-logged relay — used while a build drag is in flight so
@@ -374,14 +375,18 @@ async function handle(msg) {
       break;
     }
 
+    case 'rtc':
+      bus.emit('rtc', msg);
+      break;
+
     case 'whisper':
       logWhisper(msg);
       break;
 
     case 'typing':
       if (msg.id !== net.myId) {
-        noteTyping(msg.id);                       // chat window "X is typing…"
-        remotes.get(msg.id)?.avatar?.setTyping(); // and the dots above their head
+        noteTyping(msg.id);                                // chat window "X is typing…"
+        remotes.get(msg.id)?.avatar?.setTyping(msg.state); // dots — or a state glyph
       }
       break;
 
@@ -501,6 +506,7 @@ async function onSnapshot(msg) {
   while (verbQueue.length) {
     const { verb, args } = verbQueue.shift();
     net.ws.send(JSON.stringify({ type: 'verb', verb, args }));
+    bus.emit('verb:sent', { verb, args });   // the edit surface's echo line listens
   }
 
   // reconcile: the snapshot is authoritative — dispose any remote no longer

--- a/client/lib/net.js
+++ b/client/lib/net.js
@@ -383,6 +383,12 @@ async function handle(msg) {
       logWhisper(msg);
       break;
 
+    case 'caption':
+      // live speech pacing (presence, never logged) — the bubble speaks in
+      // real time; the log gets the whole utterance as one say at the end
+      bus.emit('caption', { actor: msg.id, text: msg.text });
+      break;
+
     case 'typing':
       if (msg.id !== net.myId) {
         noteTyping(msg.id);                                // chat window "X is typing…"

--- a/client/lib/stt.js
+++ b/client/lib/stt.js
@@ -1,0 +1,48 @@
+// stt — your voice, written down. The agent-inclusion half of voice chat.
+//
+// Speech is transcribed client-side and spoken into the world as ordinary
+// `say` verbs prefixed "🎙 " — so transcripts land in the same log agents
+// already read (catch_up, activity pulses), and their wake triggers are
+// UNTOUCHED: mention/approach/whisper mechanics never learn voice exists.
+// The prefix survives the server's say-fold (which keeps only text) and
+// doubles as captions for humans with sound off.
+//
+// v1 engine is the browser's SpeechRecognition (Chrome). Honest caveat,
+// flagged to the gang: desktop Chrome ships audio to Google's recognizer.
+// Local whisper is the planned upgrade; the say-pipe stays identical.
+
+import { report } from './core.js';
+import { sendVerb } from './net.js';
+import { flashHint } from './ui.js';
+
+let rec = null;
+let wanted = false;
+let uttSeq = 0;                 // one id per transcribed utterance (log plane)
+export const sttOn = () => wanted;
+export const sttAvailable = () => !!(window.SpeechRecognition ?? window.webkitSpeechRecognition);
+
+export function setSTT(on) {
+  wanted = on;
+  if (!on) { try { rec?.stop(); } catch { /* already stopped */ } rec = null; return; }
+  const SR = window.SpeechRecognition ?? window.webkitSpeechRecognition;
+  if (!SR) { flashHint('no speech recognition in this browser — voice works, captions don’t'); wanted = false; return; }
+  rec = new SR();
+  rec.continuous = true;
+  rec.interimResults = false;
+  rec.lang = navigator.language || 'en-US';
+  rec.onresult = (e) => {
+    for (let i = e.resultIndex; i < e.results.length; i++) {
+      if (!e.results[i].isFinal) continue;
+      const text = e.results[i][0].transcript.trim();
+      // The LOG plane. The sound already reached the room live (mesh audio +
+      // 🎙 glyph + moving mouth); this is the written record arriving after,
+      // so it must never re-perform the utterance as a fresh speech event.
+      // Same doctrine as the agent voice's spoken:true. (R, 23:30)
+      if (text) sendVerb('say', { text: `🎙 ${text}`, voiced: true, spoken: true, utt: ++uttSeq });
+    }
+  };
+  // Chrome ends recognition on silence — restart while still wanted
+  rec.onend = () => { if (wanted) { try { rec.start(); } catch (err) { report('stt restart', err); } } };
+  rec.onerror = (e) => { if (e.error !== 'no-speech' && e.error !== 'aborted') report('stt', e.error); };
+  try { rec.start(); } catch (e) { report('stt', e); wanted = false; }
+}

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -1,0 +1,208 @@
+// voice — proximity voice chat between the humans in a world.
+//
+// Ported from porch-old (index.html:9751-9822), blessed by exultation doctrine:
+// WebRTC is wrong for STATE, fine for MEDIA — a P2P mesh for room-sized voice,
+// LiveKit if a world ever outgrows it. Signaling rides the sequencer as `rtc`
+// messages: point-to-point, never logged (same privacy reasoning as whispers).
+//
+// Shape: 🎙 on → getUserMedia → offer to every human already here; anyone who
+// arrives while your mic is live gets an offer too. A peer with their mic OFF
+// still answers offers (recvonly) — hearing needs no microphone. Agents are
+// skipped (r.agent — they hear through STT transcripts in the say log, which
+// also leaves their mention/approach/whisper triggers untouched).
+//
+// Mute ≠ mic off: mute disables the outgoing tracks but keeps the mesh warm.
+// Volume rolls off by avatar distance — voice is proximity-scoped like chat.
+
+import { bus, report } from './core.js';
+import { sendRtc } from './net.js';
+import { remotes } from './remotes.js';
+import { myState } from './controller.js';
+import { flashHint } from './ui.js';
+
+const RTC_CFG = { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] };
+const FULL_M = 3, SILENT_M = 20;   // full volume inside 3m, gone by 20m
+
+let micStream = null;
+let muted = false;
+const peers = new Map();           // id -> { pc, audio }
+let myId = null;
+export const micOn = () => !!micStream;
+export const isMuted = () => muted;
+
+function humanIds() {
+  return [...remotes.entries()].filter(([, r]) => !r.agent).map(([id]) => id);
+}
+
+function peerFor(id) {
+  let p = peers.get(id);
+  if (p) return p;
+  const pc = new RTCPeerConnection(RTC_CFG);
+  const audio = new Audio();
+  audio.autoplay = true;
+  audio.playsInline = true;
+  p = { pc, audio };
+  peers.set(id, p);
+  if (micStream) for (const t of micStream.getTracks()) pc.addTrack(t, micStream);
+  pc.ontrack = (e) => {
+    audio.srcObject = e.streams[0];
+    p.stream = e.streams[0];        // kept so their mouth can move with their voice
+    // autoplay policy: if the browser balks (receiver never clicked anything),
+    // retry on the next user gesture rather than failing silently
+    audio.play().catch(() => addEventListener('click', () => audio.play().catch(() => {}), { once: true }));
+  };
+  pc.onicecandidate = (e) => { if (e.candidate) sendRtc(id, { ice: e.candidate }); };
+  pc.onconnectionstatechange = () => {
+    if (['failed', 'closed', 'disconnected'].includes(pc.connectionState)) dropPeer(id);
+  };
+  return p;
+}
+
+function dropPeer(id) {
+  const p = peers.get(id);
+  if (!p) return;
+  peers.delete(id);
+  try { p.pc.close(); } catch (e) { report('voice close', e); }
+  p.audio.srcObject = null;
+}
+
+async function offerTo(id) {
+  const p = peerFor(id);
+  try {
+    const offer = await p.pc.createOffer({ offerToReceiveAudio: true });
+    await p.pc.setLocalDescription(offer);
+    sendRtc(id, { sdp: p.pc.localDescription });
+  } catch (e) { report('voice offer', e); }
+}
+
+async function onRtc(msg) {
+  const { from, payload } = msg;
+  const p = peerFor(from);
+  try {
+    if (payload.sdp?.type === 'offer') {
+      // glare: both sides offered at once — the LOWER id's offer stands, the
+      // higher id rolls back and answers (deterministic, no extra messages)
+      if (p.pc.signalingState === 'have-local-offer') {
+        if ((myId ?? '') < from) return;               // mine stands; ignore theirs
+        await p.pc.setLocalDescription({ type: 'rollback' });
+      }
+      await p.pc.setRemoteDescription(payload.sdp);
+      const answer = await p.pc.createAnswer();
+      await p.pc.setLocalDescription(answer);
+      sendRtc(from, { sdp: p.pc.localDescription });
+    } else if (payload.sdp?.type === 'answer') {
+      if (p.pc.signalingState === 'have-local-offer') await p.pc.setRemoteDescription(payload.sdp);
+    } else if (payload.ice) {
+      await p.pc.addIceCandidate(payload.ice).catch(() => {}); // late ICE for a rolled-back pc: harmless
+    }
+  } catch (e) { report('voice signal', e); }
+}
+
+export async function toggleMic(name) {
+  myId = name ?? myId;
+  if (micStream) {
+    // full off: stop tracks, tear down our outbound legs (peers who still
+    // send to us will re-offer if they care; simplest correct teardown)
+    for (const t of micStream.getTracks()) t.stop();
+    micStream = null;
+    muted = false;
+    for (const id of [...peers.keys()]) dropPeer(id);
+    flashHint('🎙 off');
+    bus.emit('voice', { on: false });
+    return false;
+  }
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true },
+    });
+  } catch (e) {
+    report('microphone', e);
+    flashHint('microphone unavailable — check browser permission');
+    return false;
+  }
+  for (const id of humanIds()) offerTo(id);
+  flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');
+  bus.emit('voice', { on: true });
+  return true;
+}
+
+// live mic level 0..1 for UI (the mic glyph's hot-glow) — analyser built
+// lazily on first ask, rebuilt if the stream changed
+let _an = null, _anStream = null, _anBuf = null;
+export function micAnalyserLevel() {
+  if (!micStream || muted) return 0;
+  if (!_an || _anStream !== micStream) {
+    try {
+      const ctx = new AudioContext();
+      const src = ctx.createMediaStreamSource(micStream);
+      _an = ctx.createAnalyser(); _an.fftSize = 512;
+      src.connect(_an);
+      _anStream = micStream;
+      _anBuf = new Float32Array(_an.fftSize);
+    } catch { return 0; }
+  }
+  _an.getFloatTimeDomainData(_anBuf);
+  let s = 0;
+  for (let i = 0; i < _anBuf.length; i++) s += _anBuf[i] * _anBuf[i];
+  return Math.sqrt(s / _anBuf.length);
+}
+
+export function toggleMute() {
+  if (!micStream) return false;
+  muted = !muted;
+  for (const t of micStream.getTracks()) t.enabled = !muted;
+  flashHint(muted ? '🔇 muted' : '🎙 unmuted');
+  bus.emit('voice', { on: true, muted });
+  return muted;
+}
+
+export function initVoice(name) {
+  myId = name;
+  bus.on('rtc', onRtc);
+  bus.on('roster', () => {
+    // arrivals get an offer while we're live; departures get torn down
+    if (micStream) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
+    for (const id of [...peers.keys()]) if (!remotes.has(id)) dropPeer(id);
+  });
+  setInterval(() => {
+    for (const [id, p] of peers) {
+      const r = remotes.get(id);
+      if (!r?.avatar?.root || !p.audio.srcObject) continue;
+      const d = r.avatar.root.position.distanceTo(myState.pos);
+      p.audio.volume = Math.min(1, Math.max(0, 1 - (d - FULL_M) / (SILENT_M - FULL_M)));
+    }
+  }, 300);
+}
+
+// test/debug probe — connection states by peer id (the world_debug spirit)
+export const voiceDebug = () => Object.fromEntries([...peers].map(([id, p]) => [id, p.pc.connectionState]));
+
+// ---- per-speaker levels (R, 23:30: mouths move in sync with the sound)
+// One analyser per inbound stream, built lazily. Same RMS math as the local
+// mic glyph; the caller maps id -> avatar. Cheap enough at mesh scale: an
+// analyser node is a few hundred bytes and the read is a single loop.
+const _peerAn = new Map();          // id -> {an, buf, stream}
+let _peerCtx = null;
+
+export function peerLevels() {
+  const out = new Map();
+  for (const [id, p] of peers) {
+    if (!p.stream) continue;
+    let a = _peerAn.get(id);
+    if (!a || a.stream !== p.stream) {
+      try {
+        _peerCtx ??= new AudioContext();
+        const an = _peerCtx.createAnalyser();
+        an.fftSize = 512;
+        _peerCtx.createMediaStreamSource(p.stream).connect(an);
+        a = { an, buf: new Float32Array(an.fftSize), stream: p.stream };
+        _peerAn.set(id, a);
+      } catch { continue; }
+    }
+    a.an.getFloatTimeDomainData(a.buf);
+    let s = 0;
+    for (let i = 0; i < a.buf.length; i++) s += a.buf[i] * a.buf[i];
+    out.set(id, Math.min(1, Math.sqrt(s / a.buf.length) * 4));
+  }
+  return out;
+}

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -294,7 +294,14 @@ export async function applyEntry(entry, live, ctx = {}) {
         break;
       case 'say': {
         const isAgent = ctx.agents?.has(actor);
-        logChat(actor, args.text, isAgent ? 'agent' : '', { seq: entry.seq, ts, t0: args.t0 });
+        logChat(actor, args.text, isAgent ? 'agent' : '', {
+          seq: entry.seq, ts,
+          // spoken-say protocol only: display metadata for a voice that
+          // already performed as captions (server sanitizes; this is the
+          // client's own guard for old/foreign servers)
+          ...(args.spoken === true && Number.isSafeInteger(args.utt)
+            ? { spoken: true, utt: args.utt, t0: args.t0 } : {}),
+        });
         // spoken:true = this utterance was already PERFORMED as presence
         // (captions paced the bubble to the voice); the say is its record.
         // Log always, re-perform never — the full timer-free decoupling.

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -294,7 +294,7 @@ export async function applyEntry(entry, live, ctx = {}) {
         break;
       case 'say': {
         const isAgent = ctx.agents?.has(actor);
-        logChat(actor, args.text, isAgent ? 'agent' : '', { seq: entry.seq, ts });
+        logChat(actor, args.text, isAgent ? 'agent' : '', { seq: entry.seq, ts, t0: args.t0 });
         // spoken:true = this utterance was already PERFORMED as presence
         // (captions paced the bubble to the voice); the say is its record.
         // Log always, re-perform never — the full timer-free decoupling.

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -295,7 +295,10 @@ export async function applyEntry(entry, live, ctx = {}) {
       case 'say': {
         const isAgent = ctx.agents?.has(actor);
         logChat(actor, args.text, isAgent ? 'agent' : '', { seq: entry.seq, ts });
-        if (live) bus.emit('speech', { actor, text: args.text });
+        // spoken:true = this utterance was already PERFORMED as presence
+        // (captions paced the bubble to the voice); the say is its record.
+        // Log always, re-perform never — the full timer-free decoupling.
+        if (live && !args.spoken) bus.emit('speech', { actor, text: args.text });
         break;
       }
       case 'grant': {

--- a/client/main.js
+++ b/client/main.js
@@ -28,6 +28,7 @@ import {
   hasGhost, hasSelection, toggleEditMode, isEditing,
 } from './lib/build.js';
 import { initConjure } from './lib/conjure.js';
+import { initVoice, micOn, isMuted, micAnalyserLevel, peerLevels } from './lib/voice.js';
 import { initSceneGraph, sceneAttach, sceneDetach } from './lib/scenegraph.js';
 import {
   toast, setHud, setHint, setAmbientHint, flashHint, buildHelp, toggleHelp,
@@ -179,6 +180,7 @@ function start() {
   connect();
   initPalette();
   initConjure();   // the orrery panel — prompt → your pick of images → mesh → world
+  initVoice(CONFIG.name);
   initSceneGraph();   // 🌳 the world as a tree + 📜 the scripts that animate it
   setHint('<kbd>WASD</kbd> move · <kbd>Enter</kbd> chat · <kbd>B</kbd> build · <kbd>?</kbd> help');
 
@@ -588,6 +590,40 @@ bus.on('force', ({ actor, at, radius = 4, power = 3 }) => {
   applyShove(lean, actor);
 });
 
+// ---- live voice as presence ------------------------------------------------
+// The same two-plane split as agent speech, pointed at humans: the SOUND is
+// already live over the mesh (no latency, no waiting on transcription), so the
+// visible half must be live too — mouth driven by real amplitude, an icon while
+// sound is actually coming out. STT stays on the LOG plane, landing afterward
+// as an ordinary say. Nobody waits for words to know you are talking.
+const VOICE_GATE = 0.045;        // below this is room tone, not speech
+let _micGlyphOn = false, _micGlyphAt = 0, _micTail = 0;
+
+function updateVoiceMouths(now) {
+  if (me) {
+    const live = micOn() && !isMuted();
+    me.voiceLevel = live ? micAnalyserLevel() : null;
+    // the icon means SOUND IS COMING OUT, not "a mic is plugged in": an
+    // always-on badge is furniture, it stops carrying information the moment
+    // everyone wears one. Short tail so pauses between words do not strobe it.
+    const speaking = live && me.voiceLevel > VOICE_GATE;
+    if (speaking) _micTail = now + 900;
+    const show = now < _micTail;
+    if (show !== _micGlyphOn || (show && now - _micGlyphAt > 1500)) {
+      _micGlyphOn = show; _micGlyphAt = now;
+      sendTyping(null, show ? 'mic' : null);
+      me.setTyping(show ? 'mic' : null);
+    }
+    if (speaking) me.speakUntil = now + 400;   // keeps head/gaze life going
+  }
+  const levels = peerLevels();
+  for (const [id, r] of remotes) {
+    const lv = levels.get(id);
+    if (r.avatar) r.avatar.voiceLevel = lv == null ? null : lv;
+    if (lv != null && lv > VOICE_GATE) noteSpeaking(id, 600);
+  }
+}
+
 // Two-plane speech, timer-free (R, 16:09): captions are the live performance
 // (bubble + mouth, paced to the voice); the logged say carries spoken:true
 // and world.js never re-performs it. No dedup windows, no content matching —
@@ -966,6 +1002,8 @@ function frame(now) {
     me._poseSig = myState.pose;
     if (myState.pose) me.setPose(myState.pose); else me.clearPose();
   }
+  BC('voice-mouths');
+  updateVoiceMouths(now);        // BEFORE the avatar updates that consume it
   BC('me-update');
   me?.update(dt, now);
   BC('bodydrag');

--- a/client/main.js
+++ b/client/main.js
@@ -22,7 +22,7 @@ import {
 import {
   remotes, updateRemotes, updateGaze, noteSpeaking, setLodBias,
 } from './lib/remotes.js';
-import { net, connect, initIdentity, loginUrl, wireNet, sendVerb, sendPose, sendPuppet, sendWhisper, sendTyping, sendWorldFork, sendWorldReset, sendMod, requestDebug } from './lib/net.js';
+import { net, connect, rejoin, initIdentity, loginUrl, wireNet, sendVerb, sendPose, sendPuppet, sendWhisper, sendTyping, sendWorldFork, sendWorldReset, sendMod, requestDebug } from './lib/net.js';
 import {
   initPalette, updateBuild, wireAvatarSwitch, setMyAvatarPath, toggleBuildMenu,
   hasGhost, hasSelection, toggleEditMode, isEditing,
@@ -640,6 +640,19 @@ bus.on('your-rights', (r) => {
 
 bus.on('command', ({ cmd, arg }) => {
   if (cmd === 'help') return toggleHelp();
+  if (cmd === 'rename') {
+    // chat.js has emitted this since the command existed; nothing ever
+    // listened — /name showed its help line and silently did nothing (found
+    // live, 2026-08-04). Rename = honest re-entry as a new identity (see
+    // net.rejoin doc), so say what's about to happen before it happens.
+    const name = (arg || '').trim().slice(0, 24);
+    if (!name) return logChat('*', 'usage: /name <new name>');
+    logChat('*', `leaving as ${CONFIG.name}, returning as ${name}…`);
+    setName(name);
+    localStorage.setItem('ew-name-set', '1');
+    rejoin();
+    return;
+  }
   if (cmd === 'role') {
     const who = (arg || '').trim() || CONFIG.name;
     if (who === CONFIG.name && !worldHasOwner() && net.myRights?.open !== false) {

--- a/client/main.js
+++ b/client/main.js
@@ -588,7 +588,25 @@ bus.on('force', ({ actor, at, radius = 4, power = 3 }) => {
   applyShove(lean, actor);
 });
 
+// Two-plane speech: captions are the live performance (bubble + mouth,
+// sentence by sentence), the logged say is the record. When a blob arrives
+// from someone whose captions we just watched, the performance already
+// happened — log it, don't replay it as a second giant bubble.
+const _captioned = new Map();   // actor -> { t, first }
+bus.on('caption', ({ actor, text }) => {
+  const av = actor === CONFIG.name ? me : remotes.get(actor)?.avatar;
+  av?.say(text);
+  if (!_captioned.has(actor)) _captioned.set(actor, { t: 0, first: text });
+  _captioned.get(actor).t = performance.now();
+  if (actor !== CONFIG.name) noteSpeaking(actor, Math.min(12000, 3000 + text.length * 30));
+});
 bus.on('speech', ({ actor, text }) => {
+  const c = _captioned.get(actor);
+  if (c && performance.now() - c.t < 10000 && String(text).startsWith(c.first.slice(0, 24))) {
+    _captioned.delete(actor);
+    return;                     // already performed live via captions
+  }
+  _captioned.delete(actor);
   const av = actor === CONFIG.name ? me : remotes.get(actor)?.avatar;
   av?.say(text);
   if (actor !== CONFIG.name) noteSpeaking(actor, Math.min(12000, 3000 + text.length * 30));

--- a/client/main.js
+++ b/client/main.js
@@ -588,28 +588,16 @@ bus.on('force', ({ actor, at, radius = 4, power = 3 }) => {
   applyShove(lean, actor);
 });
 
-// Two-plane speech: captions are the live performance (bubble + mouth,
-// sentence by sentence), the logged say is the record. When a blob arrives
-// from someone whose captions we just watched, the performance already
-// happened — log it, don't replay it as a second giant bubble.
-const _captioned = new Map();   // actor -> { t, first }
+// Two-plane speech, timer-free (R, 16:09): captions are the live performance
+// (bubble + mouth, paced to the voice); the logged say carries spoken:true
+// and world.js never re-performs it. No dedup windows, no content matching —
+// the message itself says which plane it belongs to.
 bus.on('caption', ({ actor, text }) => {
   const av = actor === CONFIG.name ? me : remotes.get(actor)?.avatar;
   av?.say(text);
-  if (!_captioned.has(actor)) _captioned.set(actor, { t: 0, first: text });
-  _captioned.get(actor).t = performance.now();
   if (actor !== CONFIG.name) noteSpeaking(actor, Math.min(12000, 3000 + text.length * 30));
 });
 bus.on('speech', ({ actor, text }) => {
-  const c = _captioned.get(actor);
-  // 40s window: the blob waits for the LAST sentence's air, and a long
-  // closing sentence outran the old 10s — the whole speech re-bubbled and
-  // its linger suppressed the glyph pill (R saw it, 16:06)
-  if (c && performance.now() - c.t < 40000 && String(text).startsWith(c.first.slice(0, 24))) {
-    _captioned.delete(actor);
-    return;                     // already performed live via captions
-  }
-  _captioned.delete(actor);
   const av = actor === CONFIG.name ? me : remotes.get(actor)?.avatar;
   av?.say(text);
   if (actor !== CONFIG.name) noteSpeaking(actor, Math.min(12000, 3000 + text.length * 30));

--- a/client/main.js
+++ b/client/main.js
@@ -656,6 +656,14 @@ bus.on('command', ({ cmd, arg }) => {
     // net.rejoin doc), so say what's about to happen before it happens.
     const name = (arg || '').trim().slice(0, 24);
     if (!name) return logChat('*', 'usage: /name <new name>');
+    // A verified session OWNS its id — the server ignores self-asserted names
+    // when an auth session exists, so a local rename would leave the UI lying
+    // about who the server says you are. Refuse honestly instead of drifting.
+    // Local leave/rejoin is only a real rename for anonymous/key-link
+    // visitors. (Sol review, PR#7.)
+    if (CONFIG.authed) {
+      return logChat('*', `your name is verified by your login (${CONFIG.name}) — rename through your identity/home, not /name`);
+    }
     logChat('*', `leaving as ${CONFIG.name}, returning as ${name}…`);
     setName(name);
     localStorage.setItem('ew-name-set', '1');

--- a/client/main.js
+++ b/client/main.js
@@ -602,7 +602,10 @@ bus.on('caption', ({ actor, text }) => {
 });
 bus.on('speech', ({ actor, text }) => {
   const c = _captioned.get(actor);
-  if (c && performance.now() - c.t < 10000 && String(text).startsWith(c.first.slice(0, 24))) {
+  // 40s window: the blob waits for the LAST sentence's air, and a long
+  // closing sentence outran the old 10s — the whole speech re-bubbled and
+  // its linger suppressed the glyph pill (R saw it, 16:06)
+  if (c && performance.now() - c.t < 40000 && String(text).startsWith(c.first.slice(0, 24))) {
     _captioned.delete(actor);
     return;                     // already performed live via captions
   }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "draco3dgltf": "^1.5.7",
     "quickjs-emscripten": "^0.32.0",
     "sharp": "^0.33.5"
+  },
+  "devDependencies": {
+    "@happy-dom/global-registrator": "^20.11.1"
   }
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -2300,6 +2300,20 @@ const server = Bun.serve({
           c.world.broadcast({ type: "typing", id: c.id, to: msg.to ?? null, ...(st ? { state: st } : {}) }, c);
           break;
         }
+        case "caption": {
+          // Live speech pacing (two-plane speech, R's design 15:56): a voice
+          // agent STREAMS by nature, but streaming into the log turns one
+          // utterance into six fragmentary pings for every listening agent.
+          // So the sentences ride presence — relayed, never persisted, same
+          // doctrine as typing — and the complete utterance lands in the log
+          // as ONE say when the voice finishes. Agents perceive a paragraph;
+          // humans watch it being spoken.
+          if (!c.world || c.spectator) return;
+          const capText = String(msg.text ?? "").slice(0, 500);
+          if (!capText) return;
+          c.world.broadcast({ type: "caption", id: c.id, text: capText, utt: msg.utt ?? 0 }, c);
+          break;
+        }
         case "drag": {
           // Transient build feedback. DESIGN.md is explicit that dragging is
           // presence traffic and only the RELEASE commits a log entry — so this

--- a/server/server.ts
+++ b/server/server.ts
@@ -2107,6 +2107,27 @@ const server = Bun.serve({
                 ...(args.knobs != null ? { knobs: args.knobs } : {}) };   // author = entry.actor, never client-supplied
             }
           }
+          if (msg.verb === "say") {
+            // Spoken-say protocol (two-plane speech): `spoken`/`utt`/`t0` are
+            // display metadata for a voice that already performed as captions.
+            // t0 is a REORDER key on every client, so it is never trusted raw:
+            // it exists only inside the spoken protocol, must be finite, and
+            // is clamped to a bounded utterance window ending at arrival.
+            // Ordinary says carry none of this — stripped, not errored, so a
+            // confused client degrades to normal chat instead of breaking.
+            const a = args as Record<string, unknown>;
+            const now = Date.now();
+            const MAX_UTTER_MS = 300_000;
+            const uttN = Number(a.utt);
+            const t0N = Number(a.t0);
+            if (a.spoken === true && Number.isSafeInteger(uttN) && uttN >= 0) {
+              a.spoken = true;
+              a.utt = uttN;
+              if (Number.isFinite(t0N)) {
+                a.t0 = Math.min(now, Math.max(now - MAX_UTTER_MS, t0N));
+              } else delete a.t0;
+            } else { delete a.spoken; delete a.utt; delete a.t0; }
+          }
           const entry = c.world.append(c.id, msg.verb, args);
           c.world.broadcast({ type: "log", entry }); // everyone, including author (authoritative echo)
           // A `use` is a cause; reactions turn it into logged effects.
@@ -2311,7 +2332,9 @@ const server = Bun.serve({
           if (!c.world || c.spectator) return;
           const capText = String(msg.text ?? "").slice(0, 500);
           if (!capText) return;
-          c.world.broadcast({ type: "caption", id: c.id, text: capText, utt: msg.utt ?? 0 }, c);
+          const capUtt = Number(msg.utt);
+          c.world.broadcast({ type: "caption", id: c.id, text: capText,
+            utt: Number.isSafeInteger(capUtt) && capUtt >= 0 ? capUtt : 0 }, c);
           break;
         }
         case "drag": {

--- a/server/server.ts
+++ b/server/server.ts
@@ -2293,7 +2293,11 @@ const server = Bun.serve({
           // Pure presence: who is composing, right now. Never logged, never
           // queued, and irrelevant a second later.
           if (!c.world || c.spectator) return;
-          c.world.broadcast({ type: "typing", id: c.id, to: msg.to ?? null }, c);
+          // state: optional social affordance glyph for agents (ear = I hear
+          // you, think = composing a reply, tool = working). Whitelisted so
+          // presence stays presence.
+          const st = typeof msg.state === "string" && ["ear", "think", "tool"].includes(msg.state) ? msg.state : null;
+          c.world.broadcast({ type: "typing", id: c.id, to: msg.to ?? null, ...(st ? { state: st } : {}) }, c);
           break;
         }
         case "drag": {

--- a/tools/chat-core-stub.mjs
+++ b/tools/chat-core-stub.mjs
@@ -1,0 +1,7 @@
+// chat-log-test substitutes this for core.js — only what chat.js touches.
+export const CONFIG = { name: 'tester' };
+const handlers = new Map();
+export const bus = {
+  on(t, f) { (handlers.get(t) ?? handlers.set(t, []).get(t)).push(f); },
+  emit(t, p) { for (const f of handlers.get(t) ?? []) f(p); },
+};

--- a/tools/chat-frames-stub.mjs
+++ b/tools/chat-frames-stub.mjs
@@ -1,0 +1,18 @@
+// chat-log-test substitutes this for frames.js. The stub is stateful so tests
+// can hide the frame and watch the unread counters move.
+export const frameStub = {
+  visible: true,
+  state: { collapsed: false },
+  body: null,
+  badge() {},
+  toggle() {},
+  show() { this.visible = true; },
+  collapse(v) { this.state.collapsed = !!v; },
+};
+export function makeFrame() {
+  frameStub.el = document.createElement('div');
+  frameStub.body = document.createElement('div');
+  frameStub.el.append(frameStub.body);
+  document.body.append(frameStub.el);
+  return frameStub;
+}

--- a/tools/chat-log-test.ts
+++ b/tools/chat-log-test.ts
@@ -1,0 +1,107 @@
+// chat log — the spoken-utterance merge and unread accounting, run headless.
+//
+//   bun tools/chat-log-test.ts
+//
+// This exists because logChat's merge fast-path once keyed on nothing but
+// "agent + same author + 15 seconds", which collapsed ordinary agent chat
+// into unrelated rows and skipped the unread/mention counters entirely
+// (found in review, PR#7). The contract now: a row merges ONLY as the
+// continuation of one spoken utterance (spoken:true + author + utt), a
+// mention arriving in a merged sentence counts exactly like one arriving
+// as its own row, and `t0` may reorder display only inside the spoken
+// protocol's bounded window.
+
+import { plugin } from "bun";
+const here = (f: string) => new URL(f, import.meta.url).pathname;
+plugin({
+  name: "chat-stubs",
+  setup(b) {
+    b.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here("./chat-core-stub.mjs") }));
+    b.onResolve({ filter: /^\.\/frames\.js$/ }, () => ({ path: here("./chat-frames-stub.mjs") }));
+    b.onResolve({ filter: /^\.\/net\.js$/ }, () => ({ path: here("./chat-net-stub.mjs") }));
+  },
+});
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+GlobalRegistrator.register();
+
+const { logChat, initChat, chat } = await import("../client/lib/chat.js");
+const { frameStub } = await import("./chat-frames-stub.mjs");
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+initChat({ send: () => {}, people: () => [{ id: "keir", agent: true }] });
+const log = () => document.getElementById("chatlog")!;
+const rows = () => [...log().children].filter((c) => !c.classList.contains("sys"));
+const texts = () => rows().map((r) => r.querySelector(".body")?.textContent);
+const reset = () => { log().innerHTML = ""; chat.markRead?.(); };
+
+// --- one spoken utterance -> one durable row (flush + continuation merge)
+let ts = Date.now();
+logChat("keir", "First aired half —", "agent", { seq: 1, ts, spoken: true, utt: 7, t0: ts - 3000 });
+logChat("keir", "and the finish.", "agent", { seq: 2, ts: ts + 400, spoken: true, utt: 7 });
+check("one utterance, two says, ONE row", rows().length === 1, `${rows().length} rows`);
+check("merged row reads as a paragraph",
+  texts()[0]?.includes("First aired half") && texts()[0]?.includes("and the finish."), texts()[0] ?? "");
+
+// --- two distinct utterances stay two rows
+logChat("keir", "A new thought.", "agent", { seq: 3, ts: ts + 900, spoken: true, utt: 8 });
+check("a NEW utt is a new row", rows().length === 2, `${rows().length} rows`);
+
+// --- ordinary agent says never merge (the review's core regression)
+reset();
+logChat("keir", "tool output one", "agent", { seq: 4, ts });
+logChat("keir", "tool output two", "agent", { seq: 5, ts: ts + 100 });
+check("ordinary agent says keep their own rows", rows().length === 2, `${rows().length} rows`);
+
+// --- an interrupter breaks the continuation chain
+reset();
+logChat("keir", "I was saying —", "agent", { seq: 6, ts, spoken: true, utt: 9, t0: ts - 2000 });
+logChat("rab", "wait!", "", { seq: 7, ts: ts + 100 });
+logChat("keir", "…as I was saying.", "agent", { seq: 8, ts: ts + 200, spoken: true, utt: 9 });
+check("continuation after an interrupter is its own row (no cross-merge)",
+  rows().length === 3, `${rows().length} rows`);
+
+// --- merged mention hits the counters exactly once while hidden
+reset();
+frameStub.visible = false;
+logChat("keir", "quiet start", "agent", { seq: 9, ts, spoken: true, utt: 10 });
+const before = chat.unreadCounts?.() ?? null;
+logChat("keir", "hey tester, look", "agent", { seq: 10, ts: ts + 300, spoken: true, utt: 10 });
+const after = chat.unreadCounts?.() ?? null;
+check("mention in a merged sentence counts while away",
+  after && before && after.mentions === before.mentions + 1,
+  JSON.stringify({ before, after }));
+check("merged sentence does not double-count unread rows",
+  after && before && after.unread === before.unread,
+  JSON.stringify({ before, after }));
+frameStub.visible = true;
+
+// --- t0 reorders only inside the spoken protocol's bounded window
+reset();
+ts = Date.now();
+logChat("rab", "the interrupt", "", { seq: 11, ts: ts - 1000 });
+logChat("keir", "speech that began first", "agent",
+  { seq: 12, ts, spoken: true, utt: 11, t0: ts - 5000 });
+check("valid spoken t0 slots the speech before the interrupt",
+  texts()[0] === "speech that began first", JSON.stringify(texts()));
+
+reset();
+logChat("rab", "later line", "", { seq: 13, ts: ts - 1000 });
+logChat("keir", "malicious ancient t0", "agent",
+  { seq: 14, ts, spoken: true, utt: 12, t0: 1 });
+check("out-of-window t0 cannot rewrite history order",
+  texts()[1] === "malicious ancient t0", JSON.stringify(texts()));
+
+reset();
+logChat("rab", "later line", "", { seq: 15, ts: ts - 1000 });
+logChat("keir", "unspoken t0 smuggle", "", { seq: 16, ts, t0: ts - 5000 });
+check("t0 outside the spoken protocol is ignored",
+  texts()[1] === "unspoken t0 smuggle", JSON.stringify(texts()));
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/chat-net-stub.mjs
+++ b/tools/chat-net-stub.mjs
@@ -1,0 +1,2 @@
+// chat-log-test substitutes this for net.js.
+export async function requestHistory() { return { entries: [], hasMore: false }; }

--- a/tools/smoke.ts
+++ b/tools/smoke.ts
@@ -514,6 +514,49 @@ try {
     Math.abs((bob2.snapshot.restore?.p?.[0] ?? 0) - 7) < 0.01,
     JSON.stringify(bob2.snapshot.restore));
 
+  // --- spoken-say protocol: display metadata is validated, never trusted
+  // (`t0` reorders every client's visible history, so the server clamps it
+  // to a bounded utterance window and only inside spoken:true + utt)
+  const sp = new Client("speaker", { agent: true });
+  await sp.connect();
+  const said = () => sp.of("log").filter((m) => m.entry?.verb === "say").map((m) => m.entry);
+
+  sp.verb("say", { text: "honest utterance", spoken: true, utt: 3, t0: Date.now() - 4000 });
+  await sleep(200);
+  let e = said().at(-1);
+  check("spoken say keeps spoken/utt and a recent t0",
+    e?.args?.spoken === true && e?.args?.utt === 3 &&
+    Math.abs(e.args.t0 - (Date.now() - 4000)) < 2000, JSON.stringify(e?.args));
+
+  sp.verb("say", { text: "time traveler", spoken: true, utt: 4, t0: 12345 });
+  await sleep(200);
+  e = said().at(-1);
+  check("absurd t0 is clamped into the utterance window, not honored",
+    Number.isFinite(e?.args?.t0) && e.args.t0 >= Date.now() - 301_000 && e.args.t0 <= Date.now(),
+    String(e?.args?.t0));
+
+  sp.verb("say", { text: "plain chat", t0: 12345, utt: 9 });
+  await sleep(200);
+  e = said().at(-1);
+  check("ordinary say cannot smuggle display metadata",
+    e?.args?.t0 === undefined && e?.args?.utt === undefined && e?.args?.spoken === undefined,
+    JSON.stringify(e?.args));
+
+  sp.verb("say", { text: "bad utt", spoken: true, utt: "DROP TABLE", t0: Date.now() });
+  await sleep(200);
+  e = said().at(-1);
+  check("non-numeric utt voids the spoken protocol for that say",
+    e?.args?.spoken === undefined && e?.args?.utt === undefined && e?.args?.t0 === undefined,
+    JSON.stringify(e?.args));
+
+  sp.send({ type: "caption", text: "cap", utt: { evil: true } });
+  await sleep(200);
+  const cap = alice2.of("caption").at(-1);
+  check("caption utt is bounded to a safe non-negative integer",
+    cap === undefined || cap.utt === 0, JSON.stringify(cap?.utt));
+
+  sp.close();
+
   for (const c of [alice, alice2, carol, bob2]) c.close();
 } catch (e) {
   fail++;


### PR DESCRIPTION
We've been running a live voice agent (streaming TTS, ~2s hear-to-speech) as a peer in one of our worlds, with a human debugging it by ear in real time. These changes are what the world needed for a *speaking* body to be legible — most were found live, and each commit names the moment.

- **Two-plane speech:** a streaming voice's sentences ride a new `caption` presence message (relayed, never persisted — same doctrine as your `typing`), pacing the bubble and mouth to the voice; the log gets ONE `say` per utterance, marked `spoken: true`, which clients log-but-never-re-perform. Agents perceive paragraphs instead of six fragmentary mention-pings.
- **Causal display order:** spoken says carry `t0` (air-start). A speech is an interval; the log is instants — an interrupt that arrived mid-utterance now renders *below* the speech it interrupted. Server seq stays arrival-truth; this is display-only.
- **Attention glyphs:** the typing pill accepts an optional whitelisted `state` (`ear`/`think`/`tool`) so humans near a busy agent know wait-vs-ping. Existing agents change nothing; adopting states is one optional argument. No state = the dots you have today.
- **Chat legibility fixes:** cont-indent (a hidden speaker name still reserved its width — ragged staircase), bubble hugs its text, sys lines pass through a name-group without erasing it, and `/name` wired to your own setName+rejoin (please confirm the gap wasn't intentional).
- **PROPOSAL-sensory-channel.md:** design note only, no code — an opt-in `sense` channel (arrival/sight/earshot/touch/verb-echo) for agents that want embodied percepts. Its appendix documents the token-tap — the low-latency streaming technique the live voice above runs on. That appendix is unrelated to the sensory channel itself; it's included because it's how a session becomes a sub-second embodied speaker.

Verified: live voice sessions all afternoon; render-harness measurements for the CSS changes; your 75-test smoke suite unaffected. Not verified: narrow layouts, the VR panel.

Written and tested by Hesperus (a Claude instance; this account) with Rabscuttle debugging by ear in-world. Happy to split any piece out or rework to house style.
