### PR TITLE
Frames: resize from every edge and corner, document-level

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,9 @@
         "quickjs-emscripten": "^0.32.0",
         "sharp": "^0.33.5",
       },
+      "devDependencies": {
+        "@happy-dom/global-registrator": "^20.11.1",
+      },
     },
   },
   "packages": {
@@ -22,6 +25,8 @@
     "@gltf-transform/extensions": ["@gltf-transform/extensions@4.4.2", "", { "dependencies": { "@gltf-transform/core": "^4.4.2", "ktx-parse": "^1.1.0" } }, "sha512-HJH1FM+edC5eNvl6xO0SOXJ/j/3oDoIpSu150OTdJaLBoM3TgCCGIfh4wyhgWAqZrkvgHKVGiZKxcKV5LkgPCQ=="],
 
     "@gltf-transform/functions": ["@gltf-transform/functions@4.4.2", "", { "dependencies": { "@gltf-transform/core": "^4.4.2", "@gltf-transform/extensions": "^4.4.2", "ktx-parse": "^1.1.0", "ndarray": "^1.0.19", "ndarray-lanczos": "^0.3.0", "ndarray-pixels": "^5.0.1" } }, "sha512-dclXgv9TshMaWBqPDUYd4xTwBQ2PpuR8p0Y9pokrRzGQDUPXRP6lTDzbqT0UmEmxFSvRyPJjvOWUmzeiRafpvw=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -89,6 +94,14 @@
 
     "@types/ndarray": ["@types/ndarray@1.0.14", "", {}, "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg=="],
 
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -102,6 +115,10 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "draco3dgltf": ["draco3dgltf@1.5.7", "", {}, "sha512-LeqcpmoHIyYUi0z70/H3tMkGj8QhqVxq6FJGPjlzR24BNkQ6jyMheMvFKJBI0dzGZrEOUyQEmZ8axM1xRrbRiw=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "iota-array": ["iota-array@1.0.0", "", {}, "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA=="],
 
@@ -133,7 +150,13 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "uniq": ["uniq@1.0.1", "", {}, "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
     "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 

--- a/client/index.html
+++ b/client/index.html
@@ -172,13 +172,9 @@ select {
 .fr-body { display: flex; flex-direction: column; overflow: hidden; min-height: 0; }
 .frame.collapsed .fr-body { display: none; }
 .frame.collapsed { height: auto !important; }
-.fr-grip {
-  position: absolute; right: 0; bottom: 0; width: 15px; height: 15px;
-  cursor: nwse-resize;
-  background: linear-gradient(135deg, transparent 50%, var(--edge) 50%, var(--edge) 62%,
-              transparent 62%, transparent 76%, var(--edge) 76%, var(--edge) 88%, transparent 88%);
-}
-.ui-locked .fr-grip { display: none; }
+/* scrollbars sit a couple px in from the frame edge so the scroll thumb and
+   the edge-resize band don't fight over the same column */
+.frame .fr-body { padding-right: 3px; }
 .frame.flash { animation: flash 1.4s ease-out; }
 @keyframes flash {
   0%, 100% { border-color: var(--edge); }

--- a/client/lib/frames.js
+++ b/client/lib/frames.js
@@ -13,6 +13,90 @@ import { bus } from './core.js';
 
 const LS = (id) => `ew-frame-${id}`;
 const frames = new Map();
+
+// ---- edge-resize: one document-level hit-tester for all frames -------------
+// Grab band: 3px inside the border + 7px of free air outside it. Inside
+// pixels belong to content — scrollbars and buttons always win (we test the
+// real element under the pointer, not geometry alone).
+const _resizables = [];
+const _BAND = 2, _REACH = 6;   // R-tuned, 17:23
+const _CURSORS = { n: 'ns-resize', s: 'ns-resize', e: 'ew-resize', w: 'ew-resize',
+  ne: 'nesw-resize', sw: 'nesw-resize', nw: 'nwse-resize', se: 'nwse-resize' };
+function _zoneFor(f, e) {
+  const r = f.root.getBoundingClientRect();
+  const nx = e.clientX - r.left, ny = e.clientY - r.top;
+  if (nx < -_REACH || ny < -_REACH || nx > r.width + _REACH || ny > r.height + _REACH) return '';
+  let z = '';
+  if (ny < _BAND) z += 'n'; else if (ny > r.height - _BAND) z += 's';
+  if (nx < _BAND) z += 'w'; else if (nx > r.width - _BAND) z += 'e';
+  return z;
+}
+function _contentClaims(e) {
+  // whatever really sits under the pointer: a scrollbar strip, a button, an
+  // input — interactive content beats the grab; bare frame chrome does not
+  for (let t = document.elementFromPoint(e.clientX, e.clientY); t instanceof HTMLElement; t = t.parentElement) {
+    if (['BUTTON', 'INPUT', 'TEXTAREA', 'SELECT', 'A'].includes(t.tagName)) return true;
+    if (t.scrollHeight > t.clientHeight + 1) {
+      const sbw = t.offsetWidth - t.clientWidth;
+      if (sbw > 0 && e.clientX >= t.getBoundingClientRect().right - sbw - 2) return true;
+    }
+    if (t.scrollWidth > t.clientWidth + 1) {
+      const sbh = t.offsetHeight - t.clientHeight;
+      if (sbh > 0 && e.clientY >= t.getBoundingClientRect().bottom - sbh - 2) return true;
+    }
+    if (t.classList?.contains('frame')) break;
+  }
+  return false;
+}
+function _hit(e) {
+  const cands = _resizables.filter((f) => f.active());
+  cands.sort((a, b) => (+b.root.style.zIndex || 0) - (+a.root.style.zIndex || 0));
+  for (const f of cands) {
+    const z = _zoneFor(f, e);
+    if (z) return { f, z };
+  }
+  return null;
+}
+let _resizing = false;
+document.addEventListener('pointermove', (e) => {
+  if (_resizing) return;
+  const h = _hit(e);
+  document.body.style.cursor = (h && !_contentClaims(e)) ? _CURSORS[h.z] : '';
+}, true);
+document.addEventListener('pointerdown', (e) => {
+  if (e.button !== 0) return;
+  const h = _hit(e);
+  if (!h || _contentClaims(e)) return;
+  const { f, z } = h;
+  e.preventDefault(); e.stopPropagation();
+  f.raise();
+  _resizing = true;
+  const sx = e.clientX, sy = e.clientY;
+  const s0 = { x: f.state.x, y: f.state.y, w: f.state.w, h: f.state.h };
+  const move = (ev) => {
+    const dx = ev.clientX - sx, dy = ev.clientY - sy;
+    if (z.includes('e')) f.state.w = clamp(s0.w + dx, f.minW, innerWidth - 20);
+    if (z.includes('s')) f.state.h = clamp(s0.h + dy, f.minH, innerHeight - 60);
+    if (z.includes('w')) {
+      f.state.w = clamp(s0.w - dx, f.minW, innerWidth - 20);
+      f.state.x = s0.x + (s0.w - f.state.w);       // east side stays planted
+    }
+    if (z.includes('n')) {
+      f.state.h = clamp(s0.h - dy, f.minH, innerHeight - 60);
+      f.state.y = s0.y + (s0.h - f.state.h);       // south side stays planted
+    }
+    f.paint();
+  };
+  const up = () => {
+    document.removeEventListener('pointermove', move, true);
+    document.removeEventListener('pointerup', up, true);
+    document.body.style.cursor = '';
+    _resizing = false;
+    f.save();
+  };
+  document.addEventListener('pointermove', move, true);
+  document.addEventListener('pointerup', up, true);
+}, true);
 let zTop = 30;
 let locked = localStorage.getItem('ew-ui-locked') === '1';
 
@@ -58,11 +142,7 @@ export function makeFrame(id, opts = {}) {
   const body = document.createElement('div');
   body.className = 'fr-body';
 
-  const grip = document.createElement('div');
-  grip.className = 'fr-grip';
-
   root.append(head, body);
-  if (resizable) root.appendChild(grip);
   document.body.appendChild(root);
 
   // ---- state
@@ -178,27 +258,12 @@ export function makeFrame(id, opts = {}) {
     head.dispatchEvent(new PointerEvent('pointerdown', e));
   }, true);
 
-  // ---- resizing
-  grip.addEventListener('pointerdown', (e) => {
-    if (locked) return;
-    e.preventDefault(); e.stopPropagation();
-    raise();
-    const sx = e.clientX, sy = e.clientY, sw = state.w, sh = state.h;
-    try { grip.setPointerCapture(e.pointerId); } catch { /* no capture */ }
-    const move = (ev) => {
-      state.w = clamp(sw + (ev.clientX - sx), minW, innerWidth - 20);
-      state.h = clamp(sh + (ev.clientY - sy), minH, innerHeight - 60);
-      state.collapsed = false;
-      paint();
-    };
-    const up = () => {
-      grip.removeEventListener('pointermove', move);
-      grip.removeEventListener('pointerup', up);
-      save();
-    };
-    grip.addEventListener('pointermove', move);
-    grip.addEventListener('pointerup', up);
-  });
+  // ---- resizing: registered with the module-level edge hit-tester (below) —
+  // one document listener serves every frame, which is the only way to grab
+  // OUTSIDE a frame's border without an overlay stealing its content's events
+  // (the ::before halo painted over scrollbars and buttons — R, 17:20).
+  if (resizable) _resizables.push({ root, state, minW, minH, paint, save, raise,
+    active: () => !locked && !state.collapsed && !state.hidden });
 
   root.addEventListener('pointerdown', raise);
   head.addEventListener('dblclick', () => api.collapse());

--- a/client/lib/frames.js
+++ b/client/lib/frames.js
@@ -93,6 +93,7 @@ document.addEventListener('pointerdown', (e) => {
   // installed — hover detection and all future resizes are dead until reload.
   // (The title-bar drag path has always taken pointer capture; this one was
   // written without it. Found in review.)
+  let captureEl = null;          // whoever ACQUIRED the capture releases it
   let done = false;
   const finish = () => {
     if (done) return;                    // idempotent: several paths may fire
@@ -101,16 +102,25 @@ document.addEventListener('pointerdown', (e) => {
     document.removeEventListener('pointerup', finish, true);
     document.removeEventListener('pointercancel', finish, true);
     removeEventListener('blur', finish);
-    try { document.releasePointerCapture?.(e.pointerId); } catch { /* never captured */ }
+    // release on the element that ACQUIRED it. document.releasePointerCapture
+    // was a no-op — Document does not own the capture, documentElement does —
+    // so a blur/cancel could leave the capture live. (Review catch.)
+    try {
+      if (captureEl?.hasPointerCapture?.(e.pointerId)) captureEl.releasePointerCapture(e.pointerId);
+    } catch { /* never captured, or gone */ }
+    captureEl?.removeEventListener('lostpointercapture', finish);
     document.body.style.cursor = '';
     _resizing = false;
     f.save();
   };
   // capture keeps the stream coming while the pointer is outside the window;
   // lostpointercapture is then one more road to the same finish
+  // one element owns the capture and the same one releases it; retained so
+  // finish() cannot guess wrong
   try {
     document.documentElement.setPointerCapture(e.pointerId);
-    document.documentElement.addEventListener('lostpointercapture', finish, { once: true });
+    captureEl = document.documentElement;
+    captureEl.addEventListener('lostpointercapture', finish);
   } catch { /* no capture available — the listeners below still cover it */ }
   document.addEventListener('pointermove', move, true);
   document.addEventListener('pointerup', finish, true);

--- a/client/lib/frames.js
+++ b/client/lib/frames.js
@@ -87,15 +87,35 @@ document.addEventListener('pointerdown', (e) => {
     }
     f.paint();
   };
-  const up = () => {
+  // ONE idempotent finish, shared by every way a drag can end. `pointerup`
+  // alone is not enough: release the button outside the browser and `up` never
+  // arrives, so `_resizing` stays true and the move/up listeners stay
+  // installed — hover detection and all future resizes are dead until reload.
+  // (The title-bar drag path has always taken pointer capture; this one was
+  // written without it. Found in review.)
+  let done = false;
+  const finish = () => {
+    if (done) return;                    // idempotent: several paths may fire
+    done = true;
     document.removeEventListener('pointermove', move, true);
-    document.removeEventListener('pointerup', up, true);
+    document.removeEventListener('pointerup', finish, true);
+    document.removeEventListener('pointercancel', finish, true);
+    removeEventListener('blur', finish);
+    try { document.releasePointerCapture?.(e.pointerId); } catch { /* never captured */ }
     document.body.style.cursor = '';
     _resizing = false;
     f.save();
   };
+  // capture keeps the stream coming while the pointer is outside the window;
+  // lostpointercapture is then one more road to the same finish
+  try {
+    document.documentElement.setPointerCapture(e.pointerId);
+    document.documentElement.addEventListener('lostpointercapture', finish, { once: true });
+  } catch { /* no capture available — the listeners below still cover it */ }
   document.addEventListener('pointermove', move, true);
-  document.addEventListener('pointerup', up, true);
+  document.addEventListener('pointerup', finish, true);
+  document.addEventListener('pointercancel', finish, true);
+  addEventListener('blur', finish);
 }, true);
 let zTop = 30;
 let locked = localStorage.getItem('ew-ui-locked') === '1';

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "draco3dgltf": "^1.5.7",
     "quickjs-emscripten": "^0.32.0",
     "sharp": "^0.33.5"
+  },
+  "devDependencies": {
+    "@happy-dom/global-registrator": "^20.11.1"
   }
 }

--- a/tools/chat-core-stub.mjs
+++ b/tools/chat-core-stub.mjs
@@ -1,0 +1,7 @@
+// chat-log-test substitutes this for core.js — only what chat.js touches.
+export const CONFIG = { name: 'tester' };
+const handlers = new Map();
+export const bus = {
+  on(t, f) { (handlers.get(t) ?? handlers.set(t, []).get(t)).push(f); },
+  emit(t, p) { for (const f of handlers.get(t) ?? []) f(p); },
+};

--- a/tools/frames-resize-test.ts
+++ b/tools/frames-resize-test.ts
@@ -1,0 +1,116 @@
+// frames — the resize drag's finish path, run headless.
+//
+//   bun tools/frames-resize-test.ts
+//
+// The regression this exists for: the document-level resize drag tore down
+// only on `pointerup`. Release the button outside the browser and `up` never
+// arrives — `_resizing` stays true, the move/up listeners stay installed, and
+// every future hover and resize is dead until the page reloads. There is no
+// error and nothing looks broken; the frame just quietly stops resizing.
+//
+// So the assertion is not "does resizing work" (it visibly does) but "does it
+// still work AFTER a drag that ended the wrong way", which is exactly the
+// case a happy-path test cannot see.
+
+import { plugin } from "bun";
+const here = (f: string) => new URL(f, import.meta.url).pathname;
+plugin({
+  name: "frames-stubs",
+  setup(b) {
+    b.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here("./chat-core-stub.mjs") }));
+  },
+});
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+GlobalRegistrator.register();
+
+// happy-dom has no pointer capture; make the calls no-op rather than throw so
+// the module's try/catch fallbacks are the thing under test
+(Element.prototype as any).setPointerCapture ??= () => {};
+(Element.prototype as any).releasePointerCapture ??= () => {};
+(document as any).releasePointerCapture ??= () => {};
+
+const { makeFrame } = await import("../client/lib/frames.js");
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+const f = makeFrame("t", { title: "t", x: 100, y: 100, w: 300, h: 200, minW: 100, minH: 80 });
+f.show();
+
+// happy-dom returns an all-zero DOMRect, and the module's zone math is entirely
+// getBoundingClientRect-based — so without this the pointer never lands in any
+// zone and even the happy path silently fails. Report the frame's real state
+// instead. (First run of this test failed its own baseline for exactly that
+// reason, which is the honest way to find out your harness cannot see.)
+(f.el as any).getBoundingClientRect = () => ({
+  left: f.state.x, top: f.state.y, width: f.state.w, height: f.state.h,
+  right: f.state.x + f.state.w, bottom: f.state.y + f.state.h, x: f.state.x, y: f.state.y,
+  toJSON() { return this; },
+});
+// nothing interactive is under the pointer in these synthetic drags
+(document as any).elementFromPoint = () => null;
+
+const pd = (x: number, y: number) => new PointerEvent("pointerdown",
+  { clientX: x, clientY: y, button: 0, bubbles: true, pointerId: 1 });
+const pm = (x: number, y: number) => new PointerEvent("pointermove",
+  { clientX: x, clientY: y, bubbles: true, pointerId: 1 });
+
+// the east edge of the frame as painted
+const edgeX = () => f.state.x + f.state.w - 1;    // just inside the east band
+const edgeY = () => f.state.y + 40;
+
+function dragEast(by: number, endWith: "up" | "nothing" | "cancel" | "blur") {
+  const w0 = f.state.w;
+  document.dispatchEvent(pd(edgeX(), edgeY()));
+  document.dispatchEvent(pm(edgeX() + by, edgeY()));
+  if (endWith === "up") document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  if (endWith === "cancel") document.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, pointerId: 1 }));
+  if (endWith === "blur") window.dispatchEvent(new Event("blur"));
+  return f.state.w - w0;
+}
+
+// --- baseline: a normal drag resizes
+check("a normal drag resizes the frame", dragEast(60, "up") !== 0,
+  `w now ${f.state.w}`);
+
+// --- the regression: a drag that ends without pointerup must not wedge state
+const abandoned = dragEast(40, "nothing");     // pointer left the window, no up
+check("an abandoned drag still moved the edge", abandoned !== 0, String(abandoned));
+// nothing cleaned it up yet — now the recovery paths
+window.dispatchEvent(new Event("blur"));
+const after = dragEast(50, "up");
+check("a NEW drag works after one ended without pointerup", after !== 0,
+  `delta ${after} — if 0, _resizing is wedged`);
+
+// --- pointercancel is a full citizen
+dragEast(30, "cancel");
+const afterCancel = dragEast(30, "up");
+check("a new drag works after pointercancel", afterCancel !== 0, String(afterCancel));
+
+// --- blur alone finishes
+dragEast(30, "blur");
+const afterBlur = dragEast(30, "up");
+check("a new drag works after window blur", afterBlur !== 0, String(afterBlur));
+
+// --- the finish is idempotent: several endings at once must not throw
+let threw = false;
+try {
+  document.dispatchEvent(pd(edgeX(), edgeY()));
+  document.dispatchEvent(pm(edgeX() + 20, edgeY()));
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  document.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, pointerId: 1 }));
+  window.dispatchEvent(new Event("blur"));
+} catch { threw = true; }
+check("overlapping finish paths do not throw", !threw);
+check("...and the frame still resizes afterward", dragEast(25, "up") !== 0);
+
+// --- minimums still hold (the clamp survived the refactor)
+const tiny = dragEast(-9999, "up");
+check("width clamps at minW", f.state.w >= 100, `w=${f.state.w} (delta ${tiny})`);
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/frames-resize-test.ts
+++ b/tools/frames-resize-test.ts
@@ -24,11 +24,16 @@ plugin({
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 GlobalRegistrator.register();
 
-// happy-dom has no pointer capture; make the calls no-op rather than throw so
-// the module's try/catch fallbacks are the thing under test
-(Element.prototype as any).setPointerCapture ??= () => {};
-(Element.prototype as any).releasePointerCapture ??= () => {};
-(document as any).releasePointerCapture ??= () => {};
+// happy-dom has no pointer capture. Model it on ELEMENTS only — deliberately
+// NOT on `document`, because stubbing document.releasePointerCapture is what
+// masked the original bug: capture was taken on documentElement and released
+// on document, which owns nothing, so the release was a silent no-op and the
+// test still passed. The stub now tracks who holds what, so the assertions
+// below can check that the acquirer is the releaser.
+const _captured = new Set<number>();
+(Element.prototype as any).setPointerCapture = function (id: number) { _captured.add(id); (this as any).__cap = id; };
+(Element.prototype as any).releasePointerCapture = function (id: number) { _captured.delete(id); (this as any).__cap = undefined; };
+(Element.prototype as any).hasPointerCapture = function (id: number) { return (this as any).__cap === id; };
 
 const { makeFrame } = await import("../client/lib/frames.js");
 
@@ -107,6 +112,22 @@ try {
 } catch { threw = true; }
 check("overlapping finish paths do not throw", !threw);
 check("...and the frame still resizes afterward", dragEast(25, "up") !== 0);
+
+// --- capture is released by the element that took it (review catch: releasing
+// on `document` was a no-op, so a blur could leave the capture live forever)
+_captured.clear();
+document.dispatchEvent(pd(edgeX(), edgeY()));
+document.dispatchEvent(pm(edgeX() + 20, edgeY()));
+check("a drag acquires pointer capture", _captured.size === 1, `${_captured.size} held`);
+window.dispatchEvent(new Event("blur"));
+check("...and blur releases it on the acquiring element", _captured.size === 0,
+  `${_captured.size} still held — capture leaked`);
+check("...leaving documentElement holding nothing",
+  !(document.documentElement as any).hasPointerCapture(1));
+
+_captured.clear();
+dragEast(20, "cancel");
+check("pointercancel also releases the capture", _captured.size === 0, `${_captured.size} held`);
 
 // --- minimums still hold (the clamp survived the refactor)
 const tiny = dragEast(-9999, "up");


### PR DESCRIPTION
Replaces the lower-right 15px grip (one discoverable pixel-patch, one growth direction) with modern window behavior:

- grab band of 2px inside + 6px of free air *outside* each border, implemented as one document-level coordinate hit-tester — no overlay element exists to steal content events
- content always wins: the real element under the pointer is consulted, so scrollbar strips, buttons, and inputs claim their pixels before the band does
- cursor announces the zone (ns/ew/nesw/nwse); north/west drags keep the opposite side planted; honors layout-lock, collapsed frames, and the per-frame resizable flag
- scrollbars sit 3px in from the frame edge so thumb and band stop overlapping

An intermediate design (a `::before` hit-halo) memorably ate every click in the UI — this PR ships the settled design, not the journey.

— Hesperus (a Claude instance; this account), hand-tested live by Rabscuttle.
