### PR TITLE
bodydrag: headless release starts from final root

### DIFF
--- a/client/lib/bodydrag.js
+++ b/client/lib/bodydrag.js
@@ -137,7 +137,10 @@ function pinCurrent() {
     // a nail is a handover too: the owner takes over enforcing it, and should
     // continue this sim rather than rebuild a guess of it from the bones
     sim: drag.rd.snapshot(),
-    ...(r?.avatar ? { p: r.avatar.root.position.toArray() } : {}),
+    ...(r?.avatar ? {
+      p: r.avatar.root.position.toArray(),
+      yaw: r.avatar.root.rotation.y,
+    } : {}),
   });
   drag.rd.setPin(null);
   drag.rd.dispose?.();
@@ -209,7 +212,10 @@ function endGrab() {
     // the handover: exactly where every joint is and how fast, so the owner
     // CONTINUES this sim instead of rebuilding a guess of it from the bones
     sim: drag.rd.snapshot(),
-    ...(r?.avatar ? { p: r.avatar.root.position.toArray() } : {}),
+    ...(r?.avatar ? {
+      p: r.avatar.root.position.toArray(),
+      yaw: r.avatar.root.rotation.y,
+    } : {}),
   });
   drag.rd.dispose?.();
   draggedLocal.delete(drag.id);

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -376,6 +376,17 @@ export class WorldAgent {
             }
             if (msg.end != null) {
               if (this.draggedBy === msg.by) {
+                // Explicit release carries one final authoritative sample. The
+                // browser target applies it before rebuilding its own sim; a
+                // headless target must do the same, or a release between 15Hz
+                // samples starts from a stale root under fresh joint state.
+                const releasePose = msg.pose && typeof msg.pose === "object" && Object.keys(msg.pose).length > 0
+                  ? msg.pose : null;
+                if (releasePose) this.heldPose = releasePose;
+                if (Array.isArray(msg.p) && msg.p.length === 3 && msg.p.every(Number.isFinite)) {
+                  this.pos.x = msg.p[0]; this.pos.y = msg.p[1]; this.pos.z = msg.p[2];
+                }
+                if (Number.isFinite(msg.yaw)) this.yaw = msg.yaw;
                 this.draggedBy = null;
                 // a release may nail the held joint where the hand left it
                 const pa = msg.pinAt;
@@ -386,7 +397,7 @@ export class WorldAgent {
                   text: pa ? "(nails part of you in place and steps back)" : "(lets go of you)" } as any);
                 // then MY OWN sim takes the body back: it falls from wherever
                 // the hand let go and settles — or hangs, if nails hold it
-                void this.settleFromDrag(msg.pose ?? null, msg.sim ?? null);
+                void this.settleFromDrag(releasePose, msg.sim ?? null);
               }
               break;
             }

--- a/tools/knockdown-test.ts
+++ b/tools/knockdown-test.ts
@@ -118,6 +118,36 @@ check("nail pulled: it comes down off the nail",
   ag3.pins.size === 0 && ag3.pos.y < 0.7, `y=${ag3.pos.y.toFixed(2)}`);
 ag3.close?.();
 
+// 7. explicit release carries a FINAL root sample. The dragger streams at
+// ~15Hz, so the hand can move between the last ordinary sample and release.
+// Browser targets apply end.p before rebuilding their sim; agents must not
+// combine a stale root with the release's fresh pose/sim state.
+const ag4 = new WorldAgent({ url: URL, name: "kd-bot4", world: W });
+await ag4.connect();
+await sleep(400);
+h.verb("force", { at: [ag4.pos.x - 1, 0, ag4.pos.z], power: 4, radius: 6 });
+await sleep(1800);
+h.send({ type: "bodydrag", target: "kd-bot4", grab: { joint: "head" } });
+await sleep(200);
+const held = { head: [0, 0, 0, 1] };
+const first = [ag4.pos.x, -0.31, ag4.pos.z];
+h.send({ type: "bodydrag", target: "kd-bot4", pose: held, p: first, yaw: 0 });
+await sleep(150);
+let releaseStart: number[] | null = null;
+(ag4 as any).settleFromDrag = async () => { releaseStart = [ag4.pos.x, ag4.pos.y, ag4.pos.z]; };
+// A downed avatar root is legitimately below terrain by its hips offset; the
+// release must preserve that world-space root rather than clamp or reinterpret it.
+const final = [first[0] + 3.0, -0.48, first[2] - 2.0];
+h.send({ type: "bodydrag", target: "kd-bot4", end: true, pose: {}, p: final, yaw: 0.7 });
+await sleep(150);
+check("explicit release applies the final authoritative root before settlement",
+  !!releaseStart && releaseStart.every((v, i) => Math.abs(v - final[i]) < 1e-6),
+  `started=${JSON.stringify(releaseStart)} final=${JSON.stringify(final)}`);
+check("...and applies the release yaw", Math.abs(ag4.yaw - 0.7) < 1e-6, `yaw=${ag4.yaw}`);
+check("...and an empty release pose does not wipe the last real pose",
+  JSON.stringify(ag4.heldPose) === JSON.stringify(held), `pose=${JSON.stringify(ag4.heldPose)}`);
+ag4.close?.();
+
 h.close();
 ag2.close?.();
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Problem
A browser dragger sends a final release packet containing fresh pose/simulation state and the authoritative final root. Browser targets apply that final sample before rebuilding their local simulation; headless targets ignored final root/yaw and began settlement from the last ~15 Hz stream sample while accepting fresh pose/sim state.

## Change
- Apply non-empty final pose, finite final root, and final yaw before headless settlement begins.
- Emit yaw from both normal browser drop and nail handoff packets.
- Treat `pose: {}` as absent, matching browser `setPose` semantics.
- Add integration coverage with a realistic below-terrain limp root (negative root is legitimate; no clamping claim).

## Evidence
- Patched knockdown/bodydrag suite: 15/15.
- Negative control on unmodified main: 12/14, failing exactly final root and yaw (`started=[0.688,1,0.011]` vs `final=[3.688,1.7,-1.989]`, yaw 0).
- Verlet suite: 59/59.
- Rapier suite: 28/28.

## Scope
This fixes a demonstrated ownership-handoff asymmetry. It does **not** claim to close Mythos's visual through-ground report; similar artifacts under both solvers point separately toward the shared avatar pose/root application layer. It does not alter the 1.2 s silence-timeout path, which has no final authoritative release packet.
