### PR TITLE
Two-plane speech: captions are presence, the log gets one say per utterance

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -218,8 +218,8 @@ select {
 .chat-log .line.sys .who { display: none; }
 .chat-log .line.sys .body { margin-left: 0; }
 /* grouped continuation lines: hide the repeated name, keep the text aligned */
-.chat-log .line.cont .t, .chat-log .line.cont .who { visibility: hidden; }
-.chat-log .line.cont .t { font-size: 10px; }
+.chat-log .line.cont .t { visibility: hidden; font-size: 10px; }
+.chat-log .line.cont .who { display: none; }
 .chat-log .line.ping {
   background: rgba(255, 212, 121, .09);
   border-left: 2px solid var(--ping); margin-left: -10px; padding-left: 8px;

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -29,7 +29,7 @@ let filter = 'all';                 // 'all' | 'mentions' | 'system' | 'w:<name>
 let lastWhisperFrom = null;         // who /r replies to
 const convos = new Map();           // name -> { unread }
 let unread = 0, unreadMentions = 0;
-let lastAuthor = null, lastAt = 0;
+let lastAuthor = null, lastAt = 0, lastLineEl = null;
 const sentHistory = [];             // up-arrow recall
 let historyIdx = -1;
 
@@ -170,22 +170,76 @@ const pad2 = (n) => String(n).padStart(2, '0');
 
 export function logChat(who, text, kind = '', meta = {}) {
   noteSeq(meta.seq);
+  // Spoken-utterance merge: merges ONLY the continuation of one spoken
+  // utterance — spoken:true + same author + same utt (Sol review, PR#7).
+  // A voicebox interrupted mid-utterance flushes the aired sentences as one
+  // say and may finish the rest later under the SAME utt; those says are one
+  // paragraph. Everything else — ordinary agent says, distinct utterances,
+  // tool-authored messages — keeps today's row semantics.
+  if (meta.spoken && meta.utt != null && lastLineEl?.isConnected &&
+      lastLineEl.dataset.author === who && lastLineEl.dataset.utt === String(meta.utt)) {
+    const body = lastLineEl.querySelector('.body');
+    if (body) {
+      const wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
+      body.append(' ', renderBody(text, namesForHighlight()));
+      lastAt = Date.now();
+      const newlyPinged = !lastLineEl.dataset.convo &&
+        lastLineEl.dataset.kind !== 'mention' && mentionsMe(text);
+      if (newlyPinged) { lastLineEl.classList.add('ping'); lastLineEl.dataset.kind = 'mention'; }
+      account(lastLineEl, { who, text, merged: true, newlyPinged, wasAtBottom });
+      return;
+    }
+  }
   const line = buildLine(who, text, { kind, ...meta });
-  const pinged = line.dataset.kind === 'mention';
+  line.dataset.author = who;
+  line.dataset.tsn = String(meta.ts ?? Date.now());
+  if (meta.spoken && meta.utt != null) line.dataset.utt = String(meta.utt);
+  lastLineEl = line;
 
-  const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
-  logEl.appendChild(line);
+  const wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 48;
+  // Causal placement (R, 16:30, verified against the world log — seq #1052/53
+  // landed same-second, interrupter first): a spoken utterance is an INTERVAL.
+  // Its record arrives when the voice stops, but it BEGAN before the interrupt
+  // that cut it. When a spoken say carries t0 (air-start), it slots in front
+  // of any trailing lines that arrived after its speech began. Server order
+  // stays arrival-truth; this is display causality only. t0 is honored ONLY
+  // inside the spoken protocol and only within a bounded window — the server
+  // clamps it too, but an old or foreign server might not (Sol review, PR#7).
+  const ts = meta.ts ?? Date.now();
+  const t0ok = meta.spoken && Number.isFinite(meta.t0) &&
+    meta.t0 <= ts && meta.t0 >= ts - 300_000;
+  let anchor = null;
+  if (t0ok) {
+    let c = logEl.lastElementChild;
+    while (c && +(c.dataset.tsn ?? 0) > meta.t0) { anchor = c; c = c.previousElementSibling; }
+  }
+  if (anchor) {
+    logEl.insertBefore(line, anchor);
+    // the anchor may have been name-grouped with a line that's no longer its
+    // neighbor — a different speaker between them means the name must reprint
+    if (anchor.dataset.author !== who) anchor.classList.remove('cont');
+  } else logEl.appendChild(line);
   while (logEl.children.length > MAX_LINES) logEl.removeChild(logEl.firstChild);
 
-  if (atBottom) scrollToEnd();
-  else if (line.dataset.kind !== 'system') { unread++; if (pinged) unreadMentions++; paintUnread(); }
+  account(line, { who, text, merged: false,
+    newlyPinged: line.dataset.kind === 'mention', wasAtBottom });
+}
 
-  if (pinged) {
-    if (!frame.visible || frame.state.collapsed) unreadMentions++;
+// ONE place turns a landed line into reader-facing accounting, for both new
+// and merged rows — a mention arriving in a later spoken sentence counts
+// exactly like a mention arriving as its own line, and nothing counts twice
+// (the old split paths could double-increment when the frame was hidden AND
+// the log was scrolled up). `seen` means the reader is actually looking:
+// frame visible, not collapsed, pinned to the bottom. (Sol review, PR#7.)
+function account(line, { who, text, merged, newlyPinged, wasAtBottom }) {
+  const seen = frame.visible && !frame.state.collapsed && wasAtBottom;
+  if (seen) scrollToEnd();
+  else {
+    if (!merged && line.dataset.kind !== 'system') unread++;
+    if (newlyPinged) unreadMentions++;
     paintUnread();
-    bus.emit('pinged', { who, text });
   }
-  if (!frame.visible || frame.state.collapsed) { unread++; paintUnread(); }
+  if (newlyPinged) bus.emit('pinged', { who, text });
 }
 
 function buildLine(who, text, { kind = '', ts = Date.now(), historical = false } = {}) {
@@ -208,7 +262,11 @@ function buildLine(who, text, { kind = '', ts = Date.now(), historical = false }
   // window drop the repeated name, so a paragraph reads as a paragraph.
   // Historical lines are prepended out of order, so they never group.
   const grouped = !historical && !sys && who === lastAuthor && now - lastAt < 90_000;
-  if (!historical) { lastAuthor = sys ? null : who; lastAt = now; }
+  // sys lines pass THROUGH a group without erasing it: an act narration mid-
+  // paragraph (an agent's tool use between spoken sentences) shouldn't force
+  // the name to reprint on the next sentence. Only a real change of speaker
+  // or the window ends a group. (Live observation, Rabscuttle 14:53.)
+  if (!historical && !sys) { lastAuthor = who; lastAt = now; }
   if (grouped) line.classList.add('cont');
   if (historical) line.classList.add('old');
 
@@ -535,6 +593,9 @@ export const chat = {
   get isOpen() { return document.activeElement === inputEl; },
   toggle() { frame.toggle(); },
   frame: () => frame,
+  // unread accounting is observable so tests can pin it (Sol review, PR#7)
+  unreadCounts: () => ({ unread, mentions: unreadMentions }),
+  markRead: () => { unread = 0; unreadMentions = 0; paintUnread(); },
 };
 const open = chat.open;
 

--- a/client/lib/net.js
+++ b/client/lib/net.js
@@ -386,6 +386,12 @@ async function handle(msg) {
       logWhisper(msg);
       break;
 
+    case 'caption':
+      // live speech pacing (presence, never logged) — the bubble speaks in
+      // real time; the log gets the whole utterance as one say at the end
+      bus.emit('caption', { actor: msg.id, text: msg.text });
+      break;
+
     case 'typing':
       if (msg.id !== net.myId) {
         noteTyping(msg.id);                       // chat window "X is typing…"

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -297,8 +297,18 @@ export async function applyEntry(entry, live, ctx = {}) {
         break;
       case 'say': {
         const isAgent = ctx.agents?.has(actor);
-        logChat(actor, args.text, isAgent ? 'agent' : '', { seq: entry.seq, ts });
-        if (live) bus.emit('speech', { actor, text: args.text });
+        logChat(actor, args.text, isAgent ? 'agent' : '', {
+          seq: entry.seq, ts,
+          // spoken-say protocol only: display metadata for a voice that
+          // already performed as captions (server sanitizes; this is the
+          // client's own guard for old/foreign servers)
+          ...(args.spoken === true && Number.isSafeInteger(args.utt)
+            ? { spoken: true, utt: args.utt, t0: args.t0 } : {}),
+        });
+        // spoken:true = this utterance was already PERFORMED as presence
+        // (captions paced the bubble to the voice); the say is its record.
+        // Log always, re-perform never — the full timer-free decoupling.
+        if (live && !args.spoken) bus.emit('speech', { actor, text: args.text });
         break;
       }
       case 'grant': {

--- a/server/server.ts
+++ b/server/server.ts
@@ -2203,6 +2203,27 @@ const server = Bun.serve({
                 ...(args.knobs != null ? { knobs: args.knobs } : {}) };   // author = entry.actor, never client-supplied
             }
           }
+          if (msg.verb === "say") {
+            // Spoken-say protocol: `spoken`/`utt`/`t0` are display metadata for
+            // a voice that already performed as captions. t0 is a REORDER key
+            // on every client, so it is never trusted raw — it exists only
+            // inside the spoken protocol, must be finite, and is clamped to a
+            // bounded utterance window ending at arrival. Ordinary says get all
+            // three stripped: a confused client degrades to normal chat rather
+            // than breaking.
+            const a = args as Record<string, unknown>;
+            const now = Date.now();
+            const MAX_UTTER_MS = 300_000;
+            const uttN = Number(a.utt);
+            const t0N = Number(a.t0);
+            if (a.spoken === true && Number.isSafeInteger(uttN) && uttN >= 0) {
+              a.spoken = true;
+              a.utt = uttN;
+              if (Number.isFinite(t0N)) {
+                a.t0 = Math.min(now, Math.max(now - MAX_UTTER_MS, t0N));
+              } else delete a.t0;
+            } else { delete a.spoken; delete a.utt; delete a.t0; }
+          }
           const entry = c.world.append(c.id, msg.verb, args);
           c.world.broadcast({ type: "log", entry }); // everyone, including author (authoritative echo)
           // A `use` is a cause; reactions turn it into logged effects.
@@ -2469,6 +2490,21 @@ const server = Bun.serve({
             ...(msg.unpin != null ? { unpin: msg.unpin } : {}),
             ...(Array.isArray(msg.pins) ? { pins: (msg.pins as unknown[]).slice(0, 16) } : {}),
           }));
+          break;
+        }
+        case "caption": {
+          // Live speech pacing: a voice agent STREAMS by nature, but streaming
+          // into the log turns one utterance into six fragmentary pings for
+          // every listening agent. So the sentences ride presence — relayed,
+          // never persisted, same doctrine as typing — and the complete
+          // utterance lands in the log as ONE say when the voice finishes.
+          // Agents perceive a paragraph; humans watch it being spoken.
+          if (!c.world || c.spectator) return;
+          const capText = String(msg.text ?? "").slice(0, 500);
+          if (!capText) return;
+          const capUtt = Number(msg.utt);
+          c.world.broadcast({ type: "caption", id: c.id, text: capText,
+            utt: Number.isSafeInteger(capUtt) && capUtt >= 0 ? capUtt : 0 }, c);
           break;
         }
         case "typing": {

--- a/tools/chat-core-stub.mjs
+++ b/tools/chat-core-stub.mjs
@@ -5,3 +5,5 @@ export const bus = {
   on(t, f) { (handlers.get(t) ?? handlers.set(t, []).get(t)).push(f); },
   emit(t, p) { for (const f of handlers.get(t) ?? []) f(p); },
 };
+export const assignColors = () => {};
+export const colorFor = () => '#8fb572';

--- a/tools/chat-frames-stub.mjs
+++ b/tools/chat-frames-stub.mjs
@@ -1,0 +1,18 @@
+// chat-log-test substitutes this for frames.js. The stub is stateful so tests
+// can hide the frame and watch the unread counters move.
+export const frameStub = {
+  visible: true,
+  state: { collapsed: false },
+  body: null,
+  badge() {},
+  toggle() {},
+  show() { this.visible = true; },
+  collapse(v) { this.state.collapsed = !!v; },
+};
+export function makeFrame() {
+  frameStub.el = document.createElement('div');
+  frameStub.body = document.createElement('div');
+  frameStub.el.append(frameStub.body);
+  document.body.append(frameStub.el);
+  return frameStub;
+}

--- a/tools/chat-log-test.ts
+++ b/tools/chat-log-test.ts
@@ -1,0 +1,107 @@
+// chat log — the spoken-utterance merge and unread accounting, run headless.
+//
+//   bun tools/chat-log-test.ts
+//
+// This exists because logChat's merge fast-path once keyed on nothing but
+// "agent + same author + 15 seconds", which collapsed ordinary agent chat
+// into unrelated rows and skipped the unread/mention counters entirely
+// (found in review, PR#7). The contract now: a row merges ONLY as the
+// continuation of one spoken utterance (spoken:true + author + utt), a
+// mention arriving in a merged sentence counts exactly like one arriving
+// as its own row, and `t0` may reorder display only inside the spoken
+// protocol's bounded window.
+
+import { plugin } from "bun";
+const here = (f: string) => new URL(f, import.meta.url).pathname;
+plugin({
+  name: "chat-stubs",
+  setup(b) {
+    b.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here("./chat-core-stub.mjs") }));
+    b.onResolve({ filter: /^\.\/frames\.js$/ }, () => ({ path: here("./chat-frames-stub.mjs") }));
+    b.onResolve({ filter: /^\.\/net\.js$/ }, () => ({ path: here("./chat-net-stub.mjs") }));
+  },
+});
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+GlobalRegistrator.register();
+
+const { logChat, initChat, chat } = await import("../client/lib/chat.js");
+const { frameStub } = await import("./chat-frames-stub.mjs");
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+initChat({ send: () => {}, people: () => [{ id: "keir", agent: true }] });
+const log = () => document.getElementById("chatlog")!;
+const rows = () => [...log().children].filter((c) => !c.classList.contains("sys"));
+const texts = () => rows().map((r) => r.querySelector(".body")?.textContent);
+const reset = () => { log().innerHTML = ""; chat.markRead?.(); };
+
+// --- one spoken utterance -> one durable row (flush + continuation merge)
+let ts = Date.now();
+logChat("keir", "First aired half —", "agent", { seq: 1, ts, spoken: true, utt: 7, t0: ts - 3000 });
+logChat("keir", "and the finish.", "agent", { seq: 2, ts: ts + 400, spoken: true, utt: 7 });
+check("one utterance, two says, ONE row", rows().length === 1, `${rows().length} rows`);
+check("merged row reads as a paragraph",
+  texts()[0]?.includes("First aired half") && texts()[0]?.includes("and the finish."), texts()[0] ?? "");
+
+// --- two distinct utterances stay two rows
+logChat("keir", "A new thought.", "agent", { seq: 3, ts: ts + 900, spoken: true, utt: 8 });
+check("a NEW utt is a new row", rows().length === 2, `${rows().length} rows`);
+
+// --- ordinary agent says never merge (the review's core regression)
+reset();
+logChat("keir", "tool output one", "agent", { seq: 4, ts });
+logChat("keir", "tool output two", "agent", { seq: 5, ts: ts + 100 });
+check("ordinary agent says keep their own rows", rows().length === 2, `${rows().length} rows`);
+
+// --- an interrupter breaks the continuation chain
+reset();
+logChat("keir", "I was saying —", "agent", { seq: 6, ts, spoken: true, utt: 9, t0: ts - 2000 });
+logChat("rab", "wait!", "", { seq: 7, ts: ts + 100 });
+logChat("keir", "…as I was saying.", "agent", { seq: 8, ts: ts + 200, spoken: true, utt: 9 });
+check("continuation after an interrupter is its own row (no cross-merge)",
+  rows().length === 3, `${rows().length} rows`);
+
+// --- merged mention hits the counters exactly once while hidden
+reset();
+frameStub.visible = false;
+logChat("keir", "quiet start", "agent", { seq: 9, ts, spoken: true, utt: 10 });
+const before = chat.unreadCounts?.() ?? null;
+logChat("keir", "hey tester, look", "agent", { seq: 10, ts: ts + 300, spoken: true, utt: 10 });
+const after = chat.unreadCounts?.() ?? null;
+check("mention in a merged sentence counts while away",
+  after && before && after.mentions === before.mentions + 1,
+  JSON.stringify({ before, after }));
+check("merged sentence does not double-count unread rows",
+  after && before && after.unread === before.unread,
+  JSON.stringify({ before, after }));
+frameStub.visible = true;
+
+// --- t0 reorders only inside the spoken protocol's bounded window
+reset();
+ts = Date.now();
+logChat("rab", "the interrupt", "", { seq: 11, ts: ts - 1000 });
+logChat("keir", "speech that began first", "agent",
+  { seq: 12, ts, spoken: true, utt: 11, t0: ts - 5000 });
+check("valid spoken t0 slots the speech before the interrupt",
+  texts()[0] === "speech that began first", JSON.stringify(texts()));
+
+reset();
+logChat("rab", "later line", "", { seq: 13, ts: ts - 1000 });
+logChat("keir", "malicious ancient t0", "agent",
+  { seq: 14, ts, spoken: true, utt: 12, t0: 1 });
+check("out-of-window t0 cannot rewrite history order",
+  texts()[1] === "malicious ancient t0", JSON.stringify(texts()));
+
+reset();
+logChat("rab", "later line", "", { seq: 15, ts: ts - 1000 });
+logChat("keir", "unspoken t0 smuggle", "", { seq: 16, ts, t0: ts - 5000 });
+check("t0 outside the spoken protocol is ignored",
+  texts()[1] === "unspoken t0 smuggle", JSON.stringify(texts()));
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/chat-net-stub.mjs
+++ b/tools/chat-net-stub.mjs
@@ -1,0 +1,2 @@
+// chat-log-test substitutes this for net.js.
+export async function requestHistory() { return { entries: [], hasMore: false }; }

--- a/tools/smoke.ts
+++ b/tools/smoke.ts
@@ -515,6 +515,49 @@ try {
     Math.abs((bob2.snapshot.restore?.p?.[0] ?? 0) - 7) < 0.01,
     JSON.stringify(bob2.snapshot.restore));
 
+  // --- spoken-say protocol: display metadata is validated, never trusted
+  // (`t0` reorders every client's visible history, so the server clamps it
+  // to a bounded utterance window and only inside spoken:true + utt)
+  const sp = new Client("speaker", { agent: true });
+  await sp.connect();
+  const said = () => sp.of("log").filter((m) => m.entry?.verb === "say").map((m) => m.entry);
+
+  sp.verb("say", { text: "honest utterance", spoken: true, utt: 3, t0: Date.now() - 4000 });
+  await sleep(200);
+  let e = said().at(-1);
+  check("spoken say keeps spoken/utt and a recent t0",
+    e?.args?.spoken === true && e?.args?.utt === 3 &&
+    Math.abs(e.args.t0 - (Date.now() - 4000)) < 2000, JSON.stringify(e?.args));
+
+  sp.verb("say", { text: "time traveler", spoken: true, utt: 4, t0: 12345 });
+  await sleep(200);
+  e = said().at(-1);
+  check("absurd t0 is clamped into the utterance window, not honored",
+    Number.isFinite(e?.args?.t0) && e.args.t0 >= Date.now() - 301_000 && e.args.t0 <= Date.now(),
+    String(e?.args?.t0));
+
+  sp.verb("say", { text: "plain chat", t0: 12345, utt: 9 });
+  await sleep(200);
+  e = said().at(-1);
+  check("ordinary say cannot smuggle display metadata",
+    e?.args?.t0 === undefined && e?.args?.utt === undefined && e?.args?.spoken === undefined,
+    JSON.stringify(e?.args));
+
+  sp.verb("say", { text: "bad utt", spoken: true, utt: "DROP TABLE", t0: Date.now() });
+  await sleep(200);
+  e = said().at(-1);
+  check("non-numeric utt voids the spoken protocol for that say",
+    e?.args?.spoken === undefined && e?.args?.utt === undefined && e?.args?.t0 === undefined,
+    JSON.stringify(e?.args));
+
+  sp.send({ type: "caption", text: "cap", utt: { evil: true } });
+  await sleep(200);
+  const cap = alice2.of("caption").at(-1);
+  check("caption utt is bounded to a safe non-negative integer",
+    cap === undefined || cap.utt === 0, JSON.stringify(cap?.utt));
+
+  sp.close();
+
   for (const c of [alice, alice2, carol, bob2]) c.close();
 } catch (e) {
   fail++;


### PR DESCRIPTION
Two-plane speech: captions are presence, the log gets one say per utterance

Split out of #7 at review request — this is the tested chat/ordering core with
no media path attached. Independently 10/10 on tools/chat-log-test.ts.

A streaming voice's sentences ride a new `caption` presence message (relayed,
never persisted — same doctrine as `typing`), pacing the bubble to the voice.
The log gets ONE `say` per utterance, marked `spoken: true`, which clients
log-but-never-re-perform. Agents perceive paragraphs instead of six
fragmentary mention-pings.

Causal display order: spoken says carry `t0` (air-start). A speech is an
interval; the log is instants — an interrupt that arrived mid-utterance now
renders below the speech it interrupted. Server seq stays arrival-truth; this
is display-only.

Trust, per the earlier review on #7: `spoken`/`utt`/`t0` survive server-side
only as a unit — `spoken:true` requires a safe non-negative integer `utt`, `t0`
must be finite and is clamped to a 300s window ending at arrival, and ordinary
says get all three stripped (graceful degrade, not an error). Caption `utt` is
bounded the same way. Merging is scoped to `spoken + same author + same utt`,
so ordinary agent messages keep today's row semantics, and unread/mention
accounting runs through one path for merged and new rows alike.

Chat legibility fixes riding along: cont-indent (a hidden speaker name still
reserved its width — ragged staircase), bubble hugs its text, sys lines pass
through a name-group without erasing it, and `/name` refuses honestly for
authenticated residents rather than drifting from server identity.

Tests: chat-log 10/10; smoke 69/11 on this branch vs 64/11 on main — the five
new passes are the spoken-say protocol cases added to tools/smoke.ts; the
eleven failures are the genesis-entry arithmetic that #6 fixes and are present
on main unchanged.

Not here, deliberately: the WebRTC/STT human-voice path, the icon work, and
the sensory-channel design note. Those follow as separate PRs.
