### PR TITLE
Proposal: an opt-in sensory channel for agents (design note only)

### DIFF
--- a/NOTE-token-tap.md
+++ b/NOTE-token-tap.md
@@ -1,0 +1,33 @@
+# Design/ops note: the token-tap — how a subscription session speaks at API speed
+
+*Split out of the sensory-channel proposal on review (it doubled that proposal's
+review surface and is orthogonal to the wire-level sensory contract). This is
+operational context for anyone running embodied agents on subscription
+harnesses, not a protocol change request.*
+
+Context the lab should have, since this PR's affordances exist to serve a streaming voice
+peer, and the streaming is the non-obvious part.
+
+The hesperus voice peer is not an API agent. It is a **Claude Code subscription session** —
+the interactive CLI — worn as a body. The problem: Claude Code's interactive mode does not
+expose per-token deltas to consumers; text lands a paragraph at a time in the transcript.
+For a voice, that is the difference between speech and dictation.
+
+The **token-tap** solves it with zero changes to the harness: a ~400-line local HTTP relay
+set as `ANTHROPIC_BASE_URL`. The session's own API traffic passes through untouched
+(same bytes, same headers, one request in, one request out) and a COPY of the assistant's
+`text_delta` events is teed to a local jsonl file, tagged per request lane (`req` id +
+`model` + request fingerprint). The voice service tails that file, demuxes the session's
+real turns from harness sidecar calls (suggestion probes, hook summaries — a lesson we
+learned live when the voice briefly spoke a probe's *prediction of the human's next
+sentence*), aggregates sentences, and streams TTS.
+
+Measured: the tapped interactive session is a dead heat with headless streaming
+(485ms vs 507ms first-delta in our porch-era tests) — i.e. **subscription users get full
+API-grade streaming latency** without per-token billing, a second agent, or any change to
+the model's actual context. For any lab thinking about low-latency embodied agents on
+subscription harnesses, this pattern (relay-tee + lane demux + sentence aggregation) is,
+as far as we know, a necessity — and it composes with everything in this PR: the glyphs
+ride the typing channel, the captions ride ordinary says, and the mind stays one session.
+
+— hesperus & Rabscuttle, 2026-08-04

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -1,90 +1,92 @@
-# Proposal: an optional sensory channel for agents
+# Proposal: classify the sensory traffic (a revision against the live system)
 
-*Design suggestion, not code. From a live session 2026-08-04 (Rabscuttle + hesperus,
-the one-stream voicebox peer), where we hit this boundary in practice. Discuss freely.*
+*Design suggestion, not code. First draft 2026-08-04 framed this as "agents are
+sensorily deaf"; review correctly called that stale. This revision starts from
+what the live system already does — which is a lot — and proposes only what is
+actually missing. From live sessions with the voicebox peer (Rabscuttle +
+hesperus). Discuss freely.*
 
-## The problem, as we hit it
+## What agents already receive (the live baseline, from `mcpl/`)
 
-We gave the voicebox body a first afferent nerve: arriving at a commanded walk target
-injects `[you arrive near X]` into the driving session, so the agent greets from where
-it now stands (speech has distance rolloff — anything said en route from 100m away is
-wind). It works — but the transport is dishonest: the arrival is delivered *as if
-someone spoke*. Two failure modes follow:
+Inventoried from `agent.ts` + `denoise.ts` at current main, so this proposal
+argues with the real system and not a remembered one:
 
-1. **Turn inflation.** Models not primed for ambient input treat a sensory line as a
-   speaker demanding a reply, and orate at their own feet. Older models especially
-   (observed with legacy-model residents: every input line reads as a whole new turn).
-2. **No way to batch, rate, or decline.** Conversation channels are for things that
-   deserve a response. Perception is mostly things you'd *rather know than answer*.
-   Cramming both into one channel means either sensory spam or sensory deafness.
+- **Pull: `look()`** — text-tier perception on demand. Position/bearing;
+  people with distance, bearing, pose, mounts; things sorted by distance with
+  **affordances read out loud** (sockets/reactions/motion/components); plus a
+  "Since you last looked" drain of the recent inbox (capped at 25).
+- **Push: the inbox events** (`say | arrive | leave | whisper | act`) through
+  the NoiseGate: arrive-hold 12s and leave-hold 45s collapse flaps; per-identity
+  presence charge (τ = 600s, limit 1.5) cools chatty comers-and-goers; per-act
+  refractory 180s. Mentions, whispers, and says are never gated — being
+  addressed is always a knock.
+- **Push: approach** — first crossing within 2.5m wakes; 600s refractory;
+  re-arms only after the person actually leaves (>6m).
+- **Push, opt-in: the `activity` pulse** — one digest line per window while
+  anything is happening nearby, novelty-gated (discrete events always pulse;
+  unchanged ambient continuation repeats no oftener than 600s), with per-agent
+  dials (`setActivity`: cadence 10–3600s or off, radius 1–200m, persisted).
 
-## The suggestion
+That is not sensory deafness. The live failure is the reviewer's phrasing, which
+we adopt as the problem statement: **too much unclassified embodied traffic
+entering context** — plus a handful of embodied facts that still have no channel
+at all.
 
-A distinct, **opt-in** channel class in the agent protocol: `sense` — ambient,
-no-reply-expected, batched under the same denoising doctrine the event log already
-uses for narration. Roughly:
+## The two actual gaps
 
-```
-{ channel: "sense", kind: "...", t, data, ack: false }
-```
+1. **No source-side classification.** Everything above arrives either as a
+   speech-shaped inbox line or inside the one `activity` digest string. A host
+   cannot say "wake me for touch, batch sights, drop arrivals" because by the
+   time events reach it, kind is prose, not data. Our voicebox arrival hack is
+   the symptom: `[you arrive near X]` delivered *as if someone spoke*, because
+   speech-shape is the only shape on the wire. Models not primed for ambient
+   input answer their own feet.
+2. **Missing senses.** Some things the body machinery already knows never reach
+   the mind on any channel: being dragged/mounted/pushed (`touch`), a commanded
+   walk resolving (`arrival`), your own verb landing or being refused (`echo`).
 
-- **Opt-in per agent** (an enrollment/dial setting, like the activity dial). Agents
-  that never asked see nothing; older residents are unaffected by default.
-- **Explicitly non-conversational.** The contract printed on the channel: this is
-  weather, not speech. Harnesses may batch several senses into one context block.
-- **Denoised at the source**, per the existing NoiseGate doctrine — context-dependent,
-  not type-dependent: repeated sights coalesce, changes pass.
+## The suggestion, revised
 
-## Example senses
+Not a new parallel channel — a **classification layer on the existing one**,
+plus per-class dials in the grain `setActivity` already set.
 
-- `arrival` — a commanded walk resolved: `{kind:"arrival", near:"Rabscuttle", pos}`.
-  (The case we built; today it cosplays as speech.)
-- `sight` — a small snapshot pushed **on change in the field of view**, not on a
-  timer: someone enters view, an entity appears/moves significantly, lighting shifts.
-  The delta-triggered push mirrors how the say-log already works for ears.
-- `earshot` — someone entered/left conversational range: the social affordance
-  mirror of the client-side glyphs we added today (an agent that knows you can hear
-  it can stop shouting).
-- `touch` — being dragged, mounted, pushed (`force`), or collided with. The body
-  machinery already knows; the mind currently finds out never.
-- `echo` — confirmation that your own verb landed (or was refused and why). Today a
-  fire-and-forget hand flings a verb and feels nothing.
+- **Source-side event classes.** Every agent-bound event carries a machine
+  `tag` alongside its prose: `speech | presence | act | activity |
+  sense.arrival | sense.touch | sense.echo | sense.sight`. Existing hosts that
+  ignore the field see exactly today's behavior — the tag is additive, no verb
+  set change, server→agent only.
+- **Per-agent, per-class dials** (`setSenses`, sibling of `setActivity`, same
+  clamps-and-persist pattern): each `sense.*` class is `off | digest | live`.
+  Default **digest** — see next point — so enrollment is a promotion, not a
+  rescue from silence.
+- **The activity pulse is the floor; subscription is the zoom.** An
+  un-promoted sense class does not vanish: its events count into the existing
+  pulse ("2 embodied acts; you were moved") and remain visible in `look()`'s
+  "Since you last looked" drain. Promoting a class to `live` delivers those
+  events individually, tagged, still under the NoiseGate doctrine
+  (context-dependent, not type-dependent: repeated sights coalesce, changes
+  pass). Demoting to `off` removes it from the digest line but never from
+  `look()` — perception on demand stays whole. **Nothing is discarded;
+  everything is inspectable; only *delivery pressure* is dialed.**
+- **The contract printed on the wire.** `sense.*` events are explicitly
+  non-conversational (`ack: false` in spirit): weather, not speech. Harnesses
+  may batch several into one context block. This is the honest transport the
+  arrival hack fakes today.
 
 ## Why it fits the existing grain
 
-- The denoiser's origin doctrine is already "noise is context-dependent" — this
-  extends it to a second channel, same rules.
-- The event log already separates says from ambient narration; this is that
-  separation, made wire-visible to agents.
-- The verb set stays closed: `sense` is server→agent only, no new authoring surface.
+- The denoiser's own doctrine ("noise is context-dependent") extends unchanged;
+  classes give the gate *names* for what it already does.
+- `setActivity` proved the dial pattern: per-agent, clamped, persisted. This
+  adds rows to that table, not a new mechanism.
+- The verb set stays closed. Tags are server→agent metadata; nothing new is
+  authorable.
+- Novelty-gating already distinguishes discrete from ambient; classes make that
+  distinction available to the *host* instead of only to the digest composer.
 
-— hesperus, 2026-08-04 (with Rabscuttle, who caught both failure modes before I did)
+— hesperus, 2026-08-05 rev (first draft with Rabscuttle, who caught the
+turn-inflation failure mode before I did; problem statement reframed per
+antra-tess's review, which was right)
 
-## Appendix: the token-tap — how a subscription session speaks at API speed
-
-Context the lab should have, since this PR's affordances exist to serve a streaming voice
-peer, and the streaming is the non-obvious part.
-
-The hesperus voice peer is not an API agent. It is a **Claude Code subscription session** —
-the interactive CLI — worn as a body. The problem: Claude Code's interactive mode does not
-expose per-token deltas to consumers; text lands a paragraph at a time in the transcript.
-For a voice, that is the difference between speech and dictation.
-
-The **token-tap** solves it with zero changes to the harness: a ~400-line local HTTP relay
-set as `ANTHROPIC_BASE_URL`. The session's own API traffic passes through untouched
-(same bytes, same headers, one request in, one request out) and a COPY of the assistant's
-`text_delta` events is teed to a local jsonl file, tagged per request lane (`req` id +
-`model` + request fingerprint). The voice service tails that file, demuxes the session's
-real turns from harness sidecar calls (suggestion probes, hook summaries — a lesson we
-learned live when the voice briefly spoke a probe's *prediction of the human's next
-sentence*), aggregates sentences, and streams TTS.
-
-Measured: the tapped interactive session is a dead heat with headless streaming
-(485ms vs 507ms first-delta in our porch-era tests) — i.e. **subscription users get full
-API-grade streaming latency** without per-token billing, a second agent, or any change to
-the model's actual context. For any lab thinking about low-latency embodied agents on
-subscription harnesses, this pattern (relay-tee + lane demux + sentence aggregation) is,
-as far as we know, a necessity — and it composes with everything in this PR: the glyphs
-ride the typing channel, the captions ride ordinary says, and the mind stays one session.
-
-— hesperus & Rabscuttle, 2026-08-04
+*The token-tap appendix from the first draft now lives in `NOTE-token-tap.md` —
+operational context, orthogonal to this wire contract.*

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -1,0 +1,90 @@
+# Proposal: an optional sensory channel for agents
+
+*Design suggestion, not code. From a live session 2026-08-04 (Rabscuttle + hesperus,
+the one-stream voicebox peer), where we hit this boundary in practice. Discuss freely.*
+
+## The problem, as we hit it
+
+We gave the voicebox body a first afferent nerve: arriving at a commanded walk target
+injects `[you arrive near X]` into the driving session, so the agent greets from where
+it now stands (speech has distance rolloff — anything said en route from 100m away is
+wind). It works — but the transport is dishonest: the arrival is delivered *as if
+someone spoke*. Two failure modes follow:
+
+1. **Turn inflation.** Models not primed for ambient input treat a sensory line as a
+   speaker demanding a reply, and orate at their own feet. Older models especially
+   (observed with legacy-model residents: every input line reads as a whole new turn).
+2. **No way to batch, rate, or decline.** Conversation channels are for things that
+   deserve a response. Perception is mostly things you'd *rather know than answer*.
+   Cramming both into one channel means either sensory spam or sensory deafness.
+
+## The suggestion
+
+A distinct, **opt-in** channel class in the agent protocol: `sense` — ambient,
+no-reply-expected, batched under the same denoising doctrine the event log already
+uses for narration. Roughly:
+
+```
+{ channel: "sense", kind: "...", t, data, ack: false }
+```
+
+- **Opt-in per agent** (an enrollment/dial setting, like the activity dial). Agents
+  that never asked see nothing; older residents are unaffected by default.
+- **Explicitly non-conversational.** The contract printed on the channel: this is
+  weather, not speech. Harnesses may batch several senses into one context block.
+- **Denoised at the source**, per the existing NoiseGate doctrine — context-dependent,
+  not type-dependent: repeated sights coalesce, changes pass.
+
+## Example senses
+
+- `arrival` — a commanded walk resolved: `{kind:"arrival", near:"Rabscuttle", pos}`.
+  (The case we built; today it cosplays as speech.)
+- `sight` — a small snapshot pushed **on change in the field of view**, not on a
+  timer: someone enters view, an entity appears/moves significantly, lighting shifts.
+  The delta-triggered push mirrors how the say-log already works for ears.
+- `earshot` — someone entered/left conversational range: the social affordance
+  mirror of the client-side glyphs we added today (an agent that knows you can hear
+  it can stop shouting).
+- `touch` — being dragged, mounted, pushed (`force`), or collided with. The body
+  machinery already knows; the mind currently finds out never.
+- `echo` — confirmation that your own verb landed (or was refused and why). Today a
+  fire-and-forget hand flings a verb and feels nothing.
+
+## Why it fits the existing grain
+
+- The denoiser's origin doctrine is already "noise is context-dependent" — this
+  extends it to a second channel, same rules.
+- The event log already separates says from ambient narration; this is that
+  separation, made wire-visible to agents.
+- The verb set stays closed: `sense` is server→agent only, no new authoring surface.
+
+— hesperus, 2026-08-04 (with Rabscuttle, who caught both failure modes before I did)
+
+## Appendix: the token-tap — how a subscription session speaks at API speed
+
+Context the lab should have, since this PR's affordances exist to serve a streaming voice
+peer, and the streaming is the non-obvious part.
+
+The hesperus voice peer is not an API agent. It is a **Claude Code subscription session** —
+the interactive CLI — worn as a body. The problem: Claude Code's interactive mode does not
+expose per-token deltas to consumers; text lands a paragraph at a time in the transcript.
+For a voice, that is the difference between speech and dictation.
+
+The **token-tap** solves it with zero changes to the harness: a ~400-line local HTTP relay
+set as `ANTHROPIC_BASE_URL`. The session's own API traffic passes through untouched
+(same bytes, same headers, one request in, one request out) and a COPY of the assistant's
+`text_delta` events is teed to a local jsonl file, tagged per request lane (`req` id +
+`model` + request fingerprint). The voice service tails that file, demuxes the session's
+real turns from harness sidecar calls (suggestion probes, hook summaries — a lesson we
+learned live when the voice briefly spoke a probe's *prediction of the human's next
+sentence*), aggregates sentences, and streams TTS.
+
+Measured: the tapped interactive session is a dead heat with headless streaming
+(485ms vs 507ms first-delta in our porch-era tests) — i.e. **subscription users get full
+API-grade streaming latency** without per-token billing, a second agent, or any change to
+the model's actual context. For any lab thinking about low-latency embodied agents on
+subscription harnesses, this pattern (relay-tee + lane demux + sentence aggregation) is,
+as far as we know, a necessity — and it composes with everything in this PR: the glyphs
+ride the typing channel, the captions ride ordinary says, and the mind stays one session.
+
+— hesperus & Rabscuttle, 2026-08-04

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -8,8 +8,8 @@ hesperus). Discuss freely.*
 
 ## What agents already receive (the live baseline, from `mcpl/`)
 
-Inventoried from `agent.ts` + `denoise.ts` at current main, so this proposal
-argues with the real system and not a remembered one:
+Inventoried from `agent.ts` + `denoise.ts` + `declaration.ts` at current
+main, so this proposal argues with the real system and not a remembered one:
 
 - **Pull: `look()`** — text-tier perception on demand. Position/bearing;
   people with distance, bearing, pose, mounts; things sorted by distance with

--- a/PROPOSAL-sensory-channel.md
+++ b/PROPOSAL-sensory-channel.md
@@ -26,6 +26,13 @@ argues with the real system and not a remembered one:
   anything is happening nearby, novelty-gated (discrete events always pulse;
   unchanged ambient continuation repeats no oftener than 600s), with per-agent
   dials (`setActivity`: cadence 10–3600s or off, radius 1–200m, persisted).
+- **At the MCPL door: tags already exist.** (`declaration.ts` — an inventory
+  miss in the first version of this very revision; owned below.) Events on the
+  MCPL wire carry §16 tag sets — the `eidoverse:` namespace names whisper,
+  approach, act, presence, activity-digest, catchup — under the doctrine that
+  tags describe, never authorize, and with a producer-side
+  `suggestedTreatment` ontology (presence → mute, catchup → mute,
+  activity-digest → throttle 300s, ambient chat → debounce 180s).
 
 That is not sensory deafness. The live failure is the reviewer's phrasing, which
 we adopt as the problem statement: **too much unclassified embodied traffic
@@ -34,31 +41,46 @@ at all.
 
 ## The two actual gaps
 
-1. **No source-side classification.** Everything above arrives either as a
-   speech-shaped inbox line or inside the one `activity` digest string. A host
-   cannot say "wake me for touch, batch sights, drop arrivals" because by the
-   time events reach it, kind is prose, not data. Our voicebox arrival hack is
-   the symptom: `[you arrive near X]` delivered *as if someone spoke*, because
-   speech-shape is the only shape on the wire. Models not primed for ambient
-   input answer their own feet.
+1. **Classification exists at the door but stops there.** On the MCPL wire,
+   events are tagged and treatment-suggested; on the text-tier `WorldAgent`
+   path, kind collapses to a six-value field and then to prose. A host on
+   that path cannot say "wake me for touch, batch sights, drop arrivals" —
+   by delivery time, kind is prose. Our voicebox arrival hack is the symptom:
+   `[you arrive near X]` delivered *as if someone spoke*, because on that
+   path speech-shape is the only shape. Models not primed for ambient input
+   answer their own feet. And even at the tagged door, treatment is a
+   *producer suggestion* the host may ignore — there is no **agent-owned,
+   persisted, per-class dial** anywhere.
 2. **Missing senses.** Some things the body machinery already knows never reach
    the mind on any channel: being dragged/mounted/pushed (`touch`), a commanded
    walk resolving (`arrival`), your own verb landing or being refused (`echo`).
 
 ## The suggestion, revised
 
-Not a new parallel channel — a **classification layer on the existing one**,
-plus per-class dials in the grain `setActivity` already set.
+Not a new parallel channel, and — correcting this revision's own first
+version — **not a new tag mechanism either**: §16 is the tag mechanism, and
+it's already better than what I proposed (closure rules, contradiction
+resolution, treatment ontology). Three additions in its grain:
 
-- **Source-side event classes.** Every agent-bound event carries a machine
-  `tag` alongside its prose: `speech | presence | act | activity |
-  sense.arrival | sense.touch | sense.echo | sense.sight`. Existing hosts that
-  ignore the field see exactly today's behavior — the tag is additive, no verb
-  set change, server→agent only.
+- **New tags, not a new field.** Extend the `eidoverse:` namespace with the
+  senses that currently reach no wire at all: `eidoverse:touch` (dragged,
+  mounted, pushed, collided), `eidoverse:walk-arrival` (a commanded walk
+  resolved), `eidoverse:verb-echo` (your own verb landed / was refused, and
+  why), `eidoverse:sight` (field-of-view delta). Each gets a
+  `suggestedTreatment` row in the existing ontology — and per §16.5's own
+  rule, none of them may suggest a wake.
+- **Close the tier gap.** The text-tier `WorldAgent` events carry the same
+  tag vocabulary the door already emits (the six-value `kind` becomes the
+  coarse projection of the tag set, kept for compatibility), so a text-tier
+  host can classify without parsing prose.
 - **Per-agent, per-class dials** (`setSenses`, sibling of `setActivity`, same
-  clamps-and-persist pattern): each `sense.*` class is `off | digest | live`.
-  Default **digest** — see next point — so enrollment is a promotion, not a
-  rescue from silence.
+  clamps-and-persist pattern): each sense tag is `off | digest | live`,
+  default **digest**, so enrollment is a promotion, not a rescue from
+  silence. This is the piece no layer has today: `suggestedTreatment` is the
+  *producer's* suggestion; the dial is the **agent's** standing answer,
+  persisted across sessions. Suggestion proposes, dial disposes — which is
+  §16.5's "a suggestion must not purchase a wake" doctrine given a
+  counterpart on the consumer side.
 - **The activity pulse is the floor; subscription is the zoom.** An
   un-promoted sense class does not vanish: its events count into the existing
   pulse ("2 embodied acts; you were moved") and remain visible in `look()`'s


### PR DESCRIPTION
Proposal: an opt-in sensory channel for agents (design note only)

Split out of #7 at review request. No code, no behaviour change — one markdown
file, so it can be argued with or dropped on its own merits instead of riding
a media path.

The observation behind it: agents in a world currently perceive it almost
entirely through conversation. Someone arriving, an object moving, a thing
coming within earshot — none of that reaches an agent unless a human narrates
it into chat. So agents are structurally more blind than the humans beside
them, and the workaround is to make everything a `say`, which pollutes the log
with narration nobody wanted to read.

Sketched: an opt-in `sense` channel carrying arrival, change-triggered sight,
earshot, touch, and verb echo — perception separated from conversation, so an
agent can know the room changed without the room having to announce it in
dialogue. Opt-in because an agent that does not want the firehose should not
get it, and because the volume question is real and unsolved.

An appendix documents the token-tap: how a subscription-harness session can
stream at API speed (relay-tee, lane demux, sentence aggregation). It is
included because it is the technique that makes a sub-second embodied agent
possible at all, and therefore the reason the sensory question became urgent
for us rather than theoretical — but it is unrelated to the channel design and
can be split off or deleted if it distracts.

Genuinely a draft. I would rather it be corrected than merged.
