### PR TITLE
Frames: corners get their own 15px target; edge band 2→4px

### DIFF
--- a/client/lib/frames.js
+++ b/client/lib/frames.js
@@ -19,13 +19,29 @@ const frames = new Map();
 // pixels belong to content — scrollbars and buttons always win (we test the
 // real element under the pointer, not geometry alone).
 const _resizables = [];
-const _BAND = 2, _REACH = 6;   // R-tuned, 17:23
+const _BAND = 4, _REACH = 6;   // band R-tuned 17:23 at 2, widened to 4 after
+                               // antra's live receipt (edge target was ~8px
+                               // total and half of that hung in the air)
+const _CORNER = 15;            // the corner is the hardest 2D target on the
+                               // frame and USED to be the intersection of two
+                               // 2px bands — invisible in practice. It gets
+                               // its own square, sized like the old SE grip.
 const _CURSORS = { n: 'ns-resize', s: 'ns-resize', e: 'ew-resize', w: 'ew-resize',
   ne: 'nesw-resize', sw: 'nesw-resize', nw: 'nwse-resize', se: 'nwse-resize' };
 function _zoneFor(f, e) {
   const r = f.root.getBoundingClientRect();
   const nx = e.clientX - r.left, ny = e.clientY - r.top;
   if (nx < -_REACH || ny < -_REACH || nx > r.width + _REACH || ny > r.height + _REACH) return '';
+  // corners FIRST, independently of the edge bands: within 15px of a corner
+  // point (in or out, the early return above already bounds the outside) the
+  // grab is diagonal. _contentClaims still outranks everything at the call
+  // sites, so a button or scrollbar living in that square keeps winning.
+  const nearW = nx <= _CORNER, nearE = nx >= r.width - _CORNER;
+  const nearN = ny <= _CORNER, nearS = ny >= r.height - _CORNER;
+  if (nearN && nearW) return 'nw';
+  if (nearN && nearE) return 'ne';
+  if (nearS && nearW) return 'sw';
+  if (nearS && nearE) return 'se';
   let z = '';
   if (ny < _BAND) z += 'n'; else if (ny > r.height - _BAND) z += 's';
   if (nx < _BAND) z += 'w'; else if (nx > r.width - _BAND) z += 'e';

--- a/tools/frames-resize-test.ts
+++ b/tools/frames-resize-test.ts
@@ -129,6 +129,43 @@ _captured.clear();
 dragEast(20, "cancel");
 check("pointercancel also releases the capture", _captured.size === 0, `${_captured.size} held`);
 
+// --- corners are a real target (antra's live receipt: the corner used to be
+// the intersection of two 2px bands — geometrically present, practically
+// absent). 8px in from the corner point sits INSIDE the 15px corner square
+// but OUTSIDE the 4px edge bands, so a diagonal here proves the corner rule
+// specifically, not a lucky band overlap.
+function dragFrom(px: number, py: number, dx: number, dy: number) {
+  const w0 = f.state.w, h0 = f.state.h;
+  document.dispatchEvent(pd(px, py));
+  document.dispatchEvent(pm(px + dx, py + dy));
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  return { dw: f.state.w - w0, dh: f.state.h - h0 };
+}
+const L = () => f.state.x, T = () => f.state.y,
+      Rt = () => f.state.x + f.state.w, B = () => f.state.y + f.state.h;
+{
+  const se = dragFrom(Rt() - 8, B() - 8, 30, 30);
+  check("SE corner (8px inside) resizes BOTH dimensions", se.dw > 0 && se.dh > 0, JSON.stringify(se));
+  const ne = dragFrom(Rt() - 8, T() + 8, 25, -25);
+  check("NE corner grows width and height together", ne.dw > 0 && ne.dh > 0, JSON.stringify(ne));
+  const sw = dragFrom(L() + 8, B() - 8, -25, 25);
+  check("SW corner grows width and height together", sw.dw > 0 && sw.dh > 0, JSON.stringify(sw));
+  const nw = dragFrom(L() + 8, T() + 8, -20, -20);
+  check("NW corner grows width and height together", nw.dw > 0 && nw.dh > 0, JSON.stringify(nw));
+}
+// ...and every plain edge still resizes exactly ONE dimension (midpoints are
+// far from any corner square, so the corner rule must not have eaten them)
+{
+  const e_ = dragFrom(Rt() - 1, T() + f.state.h / 2, 20, 0);
+  check("E edge still resizes width only", e_.dw > 0 && e_.dh === 0, JSON.stringify(e_));
+  const w_ = dragFrom(L() + 1, T() + f.state.h / 2, -20, 0);
+  check("W edge still resizes width only", w_.dw > 0 && w_.dh === 0, JSON.stringify(w_));
+  const s_ = dragFrom(L() + f.state.w / 2, B() - 1, 0, 20);
+  check("S edge still resizes height only", s_.dh > 0 && s_.dw === 0, JSON.stringify(s_));
+  const n_ = dragFrom(L() + f.state.w / 2, T() + 1, 0, -20);
+  check("N edge still resizes height only", n_.dh > 0 && n_.dw === 0, JSON.stringify(n_));
+}
+
 // --- minimums still hold (the clamp survived the refactor)
 const tiny = dragEast(-9999, "up");
 check("width clamps at minW", f.state.w >= 100, `w=${f.state.w} (delta ${tiny})`);


### PR DESCRIPTION
frames: corners get their own target — the intersection of two 2px bands
is geometry, not affordance

Follow-up to #9, from antra's live receipt: after unlock, edges felt tiny and
corners did not work in practice. The source agreed — the edge band was 2px
inside + 6px reach, and a corner required landing in the intersection of two
of those, a 2x2px square you cannot see and mostly cannot hit.

Now: the inside band widens 2 -> 4 (modest — half the old target hung in the
air outside the frame), and corners are checked FIRST with an independent
15px square per corner, the old SE grip's size. _contentClaims keeps outranking
both at every call site, so buttons and scrollbars in a corner square still
win. Diagonal cursors were already in _CURSORS.

Test receipt: four new corner checks put the pointer 8px inside each corner —
inside the 15px square but deliberately OUTSIDE the 4px bands, so a diagonal
there proves the corner rule and not a lucky band overlap — and assert both
dimensions move; four edge checks pin midpoint drags to exactly one dimension.
20/20 with the fix. Ran the new tests against the OLD geometry before
claiming anything: all four corner checks fail with {dw:0, dh:0}, which is
antra's live report reproduced as an assertion.
