### PR TITLE
chat: re-derive an inserted line's grouping from its visual neighbor

### DIFF
--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -218,6 +218,18 @@ export function logChat(who, text, kind = '', meta = {}) {
     // the anchor may have been name-grouped with a line that's no longer its
     // neighbor — a different speaker between them means the name must reprint
     if (anchor.dataset.author !== who) anchor.classList.remove('cont');
+    // ...and the inserted line's OWN grouping must be re-derived from its
+    // visual predecessor. buildLine computed it against chronological arrival
+    // (lastAuthor), and the two disagree exactly when this branch runs — a
+    // 'cont' line landing under another speaker renders their nameplate over
+    // these words. (2026-08-05, "your line was credited to me"; repro:
+    // exultation/tools/repro-stale-t0.mjs. Sys lines pass through a group,
+    // same as the chronological rule.)
+    let prev = line.previousElementSibling;
+    while (prev && prev.dataset.kind === 'system') prev = prev.previousElementSibling;
+    const near = !!prev && prev.dataset.author === who &&
+      +(line.dataset.tsn ?? 0) - +(prev.dataset.tsn ?? 0) < 90_000;
+    line.classList.toggle('cont', near);
   } else logEl.appendChild(line);
   while (logEl.children.length > MAX_LINES) logEl.removeChild(logEl.firstChild);
 

--- a/tools/chat-log-test.ts
+++ b/tools/chat-log-test.ts
@@ -103,5 +103,37 @@ logChat("keir", "unspoken t0 smuggle", "", { seq: 16, ts, t0: ts - 5000 });
 check("t0 outside the spoken protocol is ignored",
   texts()[1] === "unspoken t0 smuggle", JSON.stringify(texts()));
 
+// --- REGRESSION (#27 review): an inserted line derives its grouping from its
+// VISUAL neighbor, not chronological arrival — and the displaced anchor
+// reprints its name. All three fail on main (buildLine keys cont off
+// lastAuthor; nothing re-derives after a t0 insert).
+reset();
+ts = Date.now();
+logChat("rab", "alpha", "", { seq: 20, ts: ts - 4000 });
+logChat("keir", "beta later", "agent", { seq: 21, ts: ts - 1000 });
+logChat("keir", "aired earlier", "agent", { seq: 22, ts, spoken: true, utt: 20, t0: ts - 3000 });
+check("stale-attribution setup: t0 insert lands between the speakers",
+  texts()[1] === "aired earlier", JSON.stringify(texts()));
+check("inserted line under ANOTHER speaker is NOT cont (nameplate reprints)",
+  !rows()[1].classList.contains("cont"),
+  `cont=${rows()[1].classList.contains("cont")} — keir's words would render under rab's nameplate`);
+
+reset();
+logChat("keir", "one", "agent", { seq: 25, ts: ts - 4000 });
+logChat("rab", "later", "", { seq: 26, ts: ts - 1000 });
+logChat("keir", "aired mid-thought", "agent", { seq: 27, ts, spoken: true, utt: 21, t0: ts - 3000 });
+check("inserted line under the SAME speaker stays cont (no duplicate nameplate)",
+  rows()[1].classList.contains("cont"),
+  `cont=${rows()[1].classList.contains("cont")} though visual predecessor is keir`);
+
+reset();
+logChat("keir", "first", "agent", { seq: 30, ts: ts - 4000 });
+logChat("keir", "second", "agent", { seq: 31, ts: ts - 1000 });
+check("pre-insert: second groups under first", rows()[1].classList.contains("cont"));
+logChat("rab", "spoken wedge", "", { seq: 32, ts, spoken: true, utt: 22, t0: ts - 3000 });
+check("displaced anchor reprints its name when a different speaker wedges in",
+  texts()[1] === "spoken wedge" && !rows()[2].classList.contains("cont"),
+  JSON.stringify({ order: texts(), anchorCont: rows()[2].classList.contains("cont") }));
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
One-hunk bugfix to PR #7's causal placement.

`buildLine` computes `cont` (drop-the-repeated-nameplate) against the *chronological* last author — but a spoken say carrying `t0` inserts at a non-tail position, where the visual predecessor can be a different speaker. A nameless `cont` line landing under someone else's line renders **their nameplate over these words**. Found live today: a human's typed line displayed under the agent's name (and vice versa) whenever an agent say hoisted past it.

Fix: after `insertBefore`, re-derive `cont` from the actual `previousElementSibling` — sys lines pass through a group and the 90s window is preserved, exactly matching the chronological rule's semantics at the tail. The existing anchor-side guard already handled the line *below* the insertion; this adds the line's own side.

Deterministic repro (drives `logChat` directly, no network): before the fix the inserted line renders `cont` under the other speaker; after, every line wears its own name. Grouping regressions checked: tail merge, sys pass-through, group-break, and a legit insert-under-own-line all unchanged. chat-log-test 10/10 · smoke 85/85.

(The *producer* bug that made stale `t0`s common — our voicebox re-using the previous utterance's air-start — is fixed on our side; this hardens the consumer against any client that lies inside the clamp window.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)