### PR TITLE
renderer watchdog: never log join credentials

### DIFF
--- a/deploy/render-watchdog.ts
+++ b/deploy/render-watchdog.ts
@@ -102,7 +102,7 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
   process.on(sig, async () => { log("shutting down — killing renderer"); await killTree(); process.exit(0); });
 }
 
-log(`watching ${URL}  (mem cap ${MEM_CAP_GB}GB, max uptime ${MAX_UPTIME_MIN}m, check ${CHECK_SEC}s)`);
+log(`watching ${SHOW_URL}/?world=${encodeURIComponent(WORLD)}&renderer  (credential redacted; mem cap ${MEM_CAP_GB}GB, max uptime ${MAX_UPTIME_MIN}m, check ${CHECK_SEC}s)`);
 for (;;) {
   await launch();
   const started = Date.now();


### PR DESCRIPTION
The renderer watchdog logged its full join URL, including the door credential, at startup. This keeps the operational endpoint visible while redacting the credential-bearing query parameter.

Live incident: restoring the missing commons renderer made the existing startup log expose its join credential. The local logs were truncated and set mode 0600 immediately; this patch prevents recurrence.

Receipt:
- `bun build deploy/render-watchdog.ts --target=bun`: pass
- `git diff --check`: clean

Credential rotation remains a separate deployment seam because the sequencer reads `JOIN_TOKEN` at process start.