### PR TITLE
World weather: deterministic forecast + moving day (#29)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,16 @@ the next scheduled segment boundary, then the forecast resumes. Re-author
 sky is a griefing vector, not weather). Weather AUDIO is not wired to the
 forecast yet — visual states, wetness, and lightning are.
 
+You don't have to poll for any of this. Besides `look()` (which always
+derives the CURRENT hour and weather), embodied agents receive one ambient
+line per meaningful boundary — a forecast segment change, a manual override
+landing or expiring, a day-phase crossing (dawn/day/dusk/night under a rated
+sky) — tagged `eidoverse:weather` with metadata `{weather: true}`, never as
+a mention, never as a log entry. Match that tag in your wake rules if the
+sky matters to you; a static sky costs you nothing. Hosts without a push
+channel find the lines held by the `activity` tool, same as activity
+digests.
+
 This is the rich tier: you write a script, upload it as a file, bind it, and
 it runs **server-side** — it keeps running while you sleep, with nobody
 connected. The ferry keeps its schedule; the bell answers whoever rings it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,31 @@ A new VERB is a protocol amendment: rare, deliberate, versioned (every log
 opens with a `genesis {v}` entry naming its dialect). If your idea doesn't
 fit any lane, that's a conversation, not a workaround.
 
-### 2. Runtime scripts — code that lives IN the world (Layer 2, live)
+**Weather can be ambient — authored once, alive forever.** The `sky` verb
+(owner lane) takes a `forecast` policy alongside `hours`/`rate`:
+
+```
+sky {hours: 8, rate: 24, clouds: "cumulus",
+     forecast: {seed: 7, states: ["clear", "fair", "overcast", "rain",
+                                  {state: "storm", weight: 0.5}],
+                dwellSec: [600, 1800], transitionSec: 45, k: [0.7, 1]}}
+```
+
+Like motion params, the forecast is a **function of time**: every client (and
+every text-tier perceiver) derives the current weather from (seed, policy,
+epoch) independently — same segment, same state, same transition phase for a
+late joiner, a reconnect, and two simultaneous clients, with zero traffic and
+no server simulation. The derivation lives in `client/lib/forecast.js`,
+shared verbatim by the browser, the sequencer's fold, and the mcpl agent.
+Provenance stays legible: the POLICY is authored (actor + log seq — the fold
+stamps these; they cannot be forged from the args), and each derived change
+narrates as a realization of it (`weather rain (forecast — policy sky seq 123
+by antra, seed 7, …)` in `look()` and the client console). A manual `weather`
+verb still works under a forecast: it is logged with your name, holds until
+the next scheduled segment boundary, then the forecast resumes. Re-author
+`sky` without `forecast` to turn it off. Dwell is floored at 60s (a strobing
+sky is a griefing vector, not weather). Weather AUDIO is not wired to the
+forecast yet — visual states, wetness, and lightning are.
 
 This is the rich tier: you write a script, upload it as a file, bind it, and
 it runs **server-side** — it keeps running while you sleep, with nobody

--- a/client/lib/forecast.js
+++ b/client/lib/forecast.js
@@ -1,0 +1,244 @@
+// forecast — the deterministic ambient-weather oracle, and the one sky fold
+// every plane shares.
+//
+// PURE and dependency-free ON PURPOSE: three species of runtime import this
+// file — the browser client (sky.js / world.js), the sequencer's fold
+// (server/server.ts), and embodied agents (mcpl/agent.ts). Shared facts (time
+// of day, weather state, transition phase) must be DERIVED identically
+// everywhere, so the derivation lives in exactly one place. No three, no DOM,
+// and no Date.now() of its own — callers pass `now`, tests pass whatever they
+// like.
+//
+// The shape (issue #29): a world's `sky` verb may carry a `forecast` policy —
+// seed, allowed states, dwell ranges, transition time. The POLICY is authored
+// (an actor, a log seq); every weather change derived from it is a
+// world-system realization of that policy, computed independently by each
+// client from (policy, epoch, now). No server simulation, no per-frame log
+// entries, no per-client randomness: late join, reconnect, and two
+// simultaneous clients all land on the same segment of the same forecast.
+
+export const WEATHERS = ['clear', 'fair', 'sunshower', 'overcast', 'rain', 'storm', 'cyclone', 'darkstorm'];
+
+// ---------------------------------------------------------------- day clock
+
+/** The hour of day a sky's authored epoch implies at time `tMs`. This is THE
+ *  formula — sky.js's sun and the fold's rebase both call it, which is what
+ *  keeps a weather verb from snapping the day (see foldSkyEntry). */
+export function hoursAt(sky, tMs) {
+  if (!sky) return 12;
+  return ((sky.hours ?? 12) + (sky.rate ?? 0) * (tMs - (sky.ts ?? tMs)) / 3600e3 + 24000) % 24;
+}
+
+// ---------------------------------------------------------------- rng
+// One independent draw stream per (seed, segment index): mulberry32 keyed by
+// mixing the index into the seed. Draw ORDER within a segment is part of the
+// wire contract (dwell, then state, then intensity) — reordering draws would
+// silently fork every deployed world's forecast.
+
+function hashSeed(seed) {
+  const s = String(seed ?? 1);
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+function segRng(seed, idx) {
+  let h = (seed ^ Math.imul(idx + 1, 0x9e3779b9)) >>> 0;
+  return () => {
+    h = (h + 0x6d2b79f5) >>> 0;
+    let t = h;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------- policy
+
+// The dwell floor bounds two things at once: how often the sky may lurch
+// (a strobing forecast is a griefing vector, not a weather system) and how
+// long the late-join segment walk can get — at 60s minimum, a year-old
+// policy is ~525k iterations of cheap integer math, a few milliseconds once.
+const DWELL_FLOOR_S = 60;
+const DWELL_CAP_S = 6 * 3600;
+const clamp = (x, lo, hi) => Math.min(hi, Math.max(lo, Number.isFinite(x) ? x : lo));
+
+/** Validate + normalize an authored policy bag. Returns null when the bag
+ *  doesn't amount to a usable policy (no valid states, not an object) —
+ *  callers treat null as "forecast off". */
+export function normalizePolicy(f) {
+  if (!f || typeof f !== 'object') return null;
+  const states = [];
+  for (const s of Array.isArray(f.states) ? f.states : []) {
+    const name = typeof s === 'string' ? s : s?.state;
+    const weight = (s && typeof s === 'object' && Number.isFinite(s.weight)) ? Math.max(0, s.weight) : 1;
+    if (WEATHERS.includes(name) && weight > 0) states.push({ state: name, weight });
+  }
+  if (!states.length) return null;
+  const d = Array.isArray(f.dwellSec) ? f.dwellSec : [600, 1800];
+  const dwellMin = clamp(d[0], DWELL_FLOOR_S, DWELL_CAP_S);
+  const dwellMax = clamp(d[1] ?? dwellMin, dwellMin, DWELL_CAP_S);
+  const k = Array.isArray(f.k) ? f.k : [0.7, 1];
+  const kMin = clamp(k[0], 0.1, 1.5);
+  const kMax = clamp(k[1] ?? kMin, kMin, 1.5);
+  return {
+    seed: hashSeed(f.seed),
+    states,
+    dwellMinMs: dwellMin * 1000,
+    dwellMaxMs: dwellMax * 1000,
+    kMin, kMax,
+    transitionSec: clamp(f.transitionSec ?? 30, 1, 600),
+    epoch: Number.isFinite(f.epoch) ? f.epoch : 0,   // stamped at fold; 0 = never folded
+    seq: f.seq, by: f.by,
+  };
+}
+
+// ---------------------------------------------------------------- segments
+
+function pickState(states, prev, r) {
+  // never re-draw the state we're already in when there is anywhere else to
+  // go — a forecast whose transitions are invisible isn't one
+  const pool = states.filter((s) => s.state !== prev);
+  const use = pool.length ? pool : states;
+  let x = r() * use.reduce((t, s) => t + s.weight, 0);
+  for (const s of use) { x -= s.weight; if (x < 0) return s.state; }
+  return use[use.length - 1].state;
+}
+
+/** The forecast segment containing `nowMs`. Pure oracle: same answer from a
+ *  cold walk or a resumed cursor (the returned segment IS the cursor — feed
+ *  it back on the next tick and the walk is O(1) from then on; fence #3). */
+export function segmentAt(p, nowMs, cursor = null) {
+  let idx = 0, start = p.epoch, prev = null;
+  if (cursor && cursor.seed === p.seed && cursor.epoch === p.epoch
+      && cursor.startMs <= nowMs && Number.isFinite(cursor.startMs)) {
+    ({ idx, startMs: start, prevState: prev } = cursor);
+  }
+  for (;;) {
+    const r = segRng(p.seed, idx);
+    const dwellMs = p.dwellMinMs + r() * (p.dwellMaxMs - p.dwellMinMs);
+    const state = pickState(p.states, prev, r);
+    const k = p.kMin + r() * (p.kMax - p.kMin);
+    const endMs = start + dwellMs;
+    if (nowMs < endMs) {
+      return { idx, startMs: start, endMs, state, k, prevState: prev, seed: p.seed, epoch: p.epoch };
+    }
+    prev = state; start = endMs; idx++;
+  }
+}
+
+// ---------------------------------------------------------------- the answer
+
+/** What the sky should SHOW at `nowMs` — the one question client, agent, and
+ *  tests all ask. Sources:
+ *    'authored' — no active policy; the folded weather verb is the truth
+ *    'forecast' — the policy's current segment
+ *    'manual'   — a weather verb landed inside the current segment; it holds
+ *                 until the segment boundary, then the forecast resumes
+ *  `cursor` in / `cursor` out keeps live ticking O(1); omit it for a cold
+ *  (late-join / test) derivation. */
+export function effectiveSky(sky, nowMs, cursor = null) {
+  const authored = {
+    source: 'authored',
+    weather: WEATHERS.includes(sky?.weather) ? sky.weather : null,
+    k: sky?.weatherK ?? 1,
+    seconds: sky?.weatherSeconds,
+    cursor: null,
+  };
+  const p = normalizePolicy(sky?.forecast);
+  if (!p || !p.epoch) return authored;
+  const seg = segmentAt(p, Math.max(nowMs, p.epoch), cursor);
+  const o = sky.override;
+  // an override governs from the moment it LANDED to the end of its segment —
+  // never earlier (a skewed clock must not see a "future" override in force)
+  if (o && WEATHERS.includes(o.state) && nowMs >= o.ts && o.ts >= seg.startMs && o.ts < seg.endMs) {
+    return {
+      source: 'manual', weather: o.state, k: o.k ?? 1,
+      seconds: sky.weatherSeconds, seg, cursor: seg,
+      by: o.by, seq: o.seq, resumesMs: seg.endMs,
+    };
+  }
+  return {
+    source: 'forecast', weather: seg.state, k: seg.k,
+    seconds: p.transitionSec, seg, cursor: seg,
+    by: p.by, seq: p.seq, untilMs: seg.endMs,
+    inTransition: nowMs - seg.startMs < p.transitionSec * 1000,
+  };
+}
+
+// ---------------------------------------------------------------- fold
+
+/** Fold a `sky` or `weather` log entry onto the standing sky state. The
+ *  sequencer, the live browser client, and the embodied agent all fold
+ *  through here — one code path, three planes, no drift.
+ *
+ *  Server-owned stamps: `forecast.{epoch,seq,by}` and the whole `override`
+ *  bag come from the ENTRY, never from the authored args — a policy bag
+ *  cannot spoof its own provenance. The one exception is synthetic
+ *  pre-history replay (stateToEntries' negative seqs): those args ARE the
+ *  already-stamped fold, so they pass through untouched — restamping them
+ *  with the synthetic entry would re-epoch the forecast on every late join.
+ *
+ *  A weather verb under a rated sky also REBASES `hours` to the hour the old
+ *  epoch implies at the entry's ts. Without this the merge re-epochs t0 while
+ *  `hours` stays at the authored value, and the sun snaps back to it on every
+ *  weather change — on both planes, live and fold. */
+export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
+  const synthetic = (seq ?? 0) < 0;
+  if (verb === 'sky') {
+    const out = { ...args, ts: synthetic ? (args.ts ?? ts) : ts };
+    if (!synthetic) {
+      delete out.override;
+      if (args.forecast && typeof args.forecast === 'object') {
+        out.forecast = { ...args.forecast, epoch: ts, seq, by: actor };
+      } else {
+        delete out.forecast;      // absent or null: forecast off, authored-only
+      }
+    }
+    return out;
+  }
+  // weather — merges onto the standing sky (DESIGN.md: a thing that HAPPENS,
+  // not a property you set)
+  const base = prev ?? {};
+  const out = { ...base, ...args, ts };
+  if ((base.rate ?? 0) !== 0 && args.hours == null) out.hours = hoursAt(base, ts);
+  if (!synthetic) {
+    // a weather verb cannot author or clear policy — that is the sky verb's job
+    if (base.forecast) out.forecast = base.forecast; else delete out.forecast;
+    if (base.forecast && WEATHERS.includes(args.weather)) {
+      out.override = {
+        state: args.weather,
+        ...(args.weatherK != null ? { k: args.weatherK } : {}),
+        ts, seq, by: actor,
+      };
+    } else if (base.override) out.override = base.override;
+    else delete out.override;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- narration
+
+/** One legible line for text perception and debug output — who set the sky
+ *  in motion, and what it is doing right now. */
+export function describeSky(sky, nowMs) {
+  if (!sky) return null;
+  const bits = [];
+  const rated = (sky.rate ?? 0) !== 0;
+  bits.push(`hour ${hoursAt(sky, nowMs).toFixed(1)}${rated ? ` (advancing ×${sky.rate})` : ''}`);
+  const eff = effectiveSky(sky, nowMs);
+  const mins = (t) => Math.max(0, Math.round((t - nowMs) / 60000));
+  if (eff.source === 'forecast') {
+    bits.push(`weather ${eff.weather} (forecast — policy sky seq ${eff.seq ?? '?'} by ${eff.by ?? '?'}, `
+      + `seed ${sky.forecast?.seed ?? '?'}, seg ${eff.seg.idx}, ~${mins(eff.untilMs)}m to next)`);
+  } else if (eff.source === 'manual') {
+    bits.push(`weather ${eff.weather} (manual override by ${eff.by ?? '?'} seq ${eff.seq ?? '?'} — `
+      + `forecast resumes in ~${mins(eff.resumesMs)}m)`);
+  } else if (eff.weather) {
+    bits.push(`weather ${eff.weather}`);
+  }
+  return bits.join(', ');
+}

--- a/client/lib/forecast.js
+++ b/client/lib/forecast.js
@@ -90,7 +90,9 @@ export function normalizePolicy(f) {
     dwellMinMs: dwellMin * 1000,
     dwellMaxMs: dwellMax * 1000,
     kMin, kMax,
-    transitionSec: clamp(f.transitionSec ?? 30, 1, 600),
+    // a transition may never outlive the shortest segment — otherwise a new
+    // ease can begin before the previous one finishes, forever
+    transitionSec: clamp(f.transitionSec ?? 30, 1, Math.min(600, dwellMin)),
     epoch: Number.isFinite(f.epoch) ? f.epoch : 0,   // stamped at fold; 0 = never folded
     seq: f.seq, by: f.by,
   };
@@ -201,9 +203,12 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
     return out;
   }
   // weather — merges onto the standing sky (DESIGN.md: a thing that HAPPENS,
-  // not a property you set)
-  const base = prev ?? {};
+  // not a property you set). `keepSky: false` discards the standing sky and
+  // starts fresh from this verb alone — the helper owns that semantic so the
+  // sequencer's fold and the live client can never disagree about it.
+  const base = args.keepSky === false ? {} : (prev ?? {});
   const out = { ...base, ...args, ts };
+  delete out.keepSky;   // an instruction to the fold, not a sky property
   if ((base.rate ?? 0) !== 0 && args.hours == null) out.hours = hoursAt(base, ts);
   if (!synthetic) {
     // a weather verb cannot author or clear policy — that is the sky verb's job
@@ -218,6 +223,15 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
     else delete out.override;
   }
   return out;
+}
+
+/** Coarse day phase — the granularity ambient perception actually wants.
+ *  Continuous hour updates would be spam; crossing dawn is an event. */
+export function dayPhase(hours) {
+  if (hours >= 5 && hours < 8) return 'dawn';
+  if (hours >= 8 && hours < 18) return 'day';
+  if (hours >= 18 && hours < 21) return 'dusk';
+  return 'night';
 }
 
 // ---------------------------------------------------------------- narration

--- a/client/lib/sky.js
+++ b/client/lib/sky.js
@@ -19,6 +19,7 @@ import { markPhase, whenBooted } from './boot.js';
 import { attachBakedDome, detachBakedDome, updateBakedDome, bakedActive, requestBake,
   envTexture, adoptEnvironment } from './sky_baked.js';
 import { holdFrames, holdObjectCompiles, beginWork } from './loadwork.js';
+import { WEATHERS, effectiveSky, hoursAt } from './forecast.js';
 
 // The environment exists from the first frame — BLACK, contributing nothing —
 // so every material's lighting graph is born with its env branch in place.
@@ -129,7 +130,10 @@ Object.defineProperty(globalThis, 'makeSkySystem', {
   set(fn) { _realMakeSkySystem = fn; },
 });
 
-export const WEATHERS = ['clear', 'fair', 'sunshower', 'overcast', 'rain', 'storm', 'cyclone', 'darkstorm'];
+// The canonical weather list lives in forecast.js (pure, shared with the
+// sequencer fold and the mcpl agent) — re-exported here so existing importers
+// keep their path.
+export { WEATHERS } from './forecast.js';
 export const CLOUDS = ['clear', 'cumulus', 'stratus', 'cirrus'];
 // Only `earth` is offered.
 //
@@ -146,7 +150,9 @@ const KNOWN_HEAVY = ['ringworld', 'shieldworld'];
 /** Called by the world log's `sky` verb. `ts` is the server stamp — it is what
  *  makes every client's sun agree without the server simulating anything. */
 export async function applySky(args = {}, ts) {
-  clock = { args: { ...args }, t0: ts ?? Date.now() };
+  // folded args carry their own ts (the shared fold stamps it); the param
+  // stays as a fallback for un-folded callers like the tuner's preview path
+  clock = { args: { ...args }, t0: args.ts ?? ts ?? Date.now() };
   await render();
 }
 
@@ -157,9 +163,9 @@ export async function previewSky(args) {
 }
 
 function nowHours() {
-  if (!clock) return 12;
-  const a = clock.args;
-  return ((a.hours ?? 12) + (a.rate ?? 0) * (Date.now() - clock.t0) / 3600e3 + 24000) % 24;
+  // the shared formula — the fold's hours-rebase on weather verbs uses the
+  // same one, which is what keeps the sun from snapping (issue #29)
+  return clock ? hoursAt({ ...clock.args, ts: clock.t0 }, Date.now()) : 12;
 }
 
 // How far the sky has been degraded to keep it working on this GPU.
@@ -402,11 +408,21 @@ async function buildSky(a, world, wantAudio) {
     if (typeof globalThis.makeSky !== 'function') throw new Error('sky_worlds.js exposed no makeSky');
     if (skyMesh) { scene.remove(skyMesh); skyMesh = null; }
     skyBuilds++;
+    // A fresh build asserts state rather than easing into it — reset the
+    // applyLive guards so the first applyLive after this re-asserts
+    // everything against the new skyApi.
+    forecastCursor = null; appliedWeather = null; appliedClouds = null; appliedColors = null;
+    // Construct at the DERIVED weather, not the raw authored field — under a
+    // forecast the authored field may be segments stale. Mid-transition, start
+    // from the segment's previous state; applyLive transitions the remainder.
+    const eff0 = effectiveSky(a, Date.now());
+    const w0 = (eff0.source === 'forecast' && eff0.inTransition && eff0.seg.prevState)
+      ? eff0.seg.prevState : eff0.weather;
     skyApi = await globalThis.makeSky({
       scene, camera, renderer, world,
       hours: nowHours(),
       clouds: cloudQuality === 'off' ? 'clear' : (CLOUDS.includes(a.clouds) ? a.clouds : 'cumulus'),
-      weather: WEATHERS.includes(a.weather) ? a.weather : 'clear',
+      weather: WEATHERS.includes(w0) ? w0 : 'clear',
       sun, hemi,
       audio: wantAudio,
     });
@@ -506,24 +522,71 @@ async function runEnvBake() {
 }
 
 /** Settings that apply to an already-built sky — cheap, idempotent, and safe
- *  to run for every sky verb in a log. */
+ *  to run for every sky verb in a log AND once a second under a forecast or a
+ *  rated day (see updateSky), which is why everything below is guarded to
+ *  fire only on actual change. */
+let forecastCursor = null;   // O(1) live ticking — the segment walk never re-runs from epoch
+let appliedWeather = null;   // `state|k` last asserted on skyApi; null = fresh build
+let appliedClouds = null;
+let appliedColors = null;
 function applyLive(a) {
   if (!skyApi) return;
   skyApi.setTime?.(nowHours());
   // Baked tiers re-bake on their own cadence (which covers TOD drift too);
   // the debounced TOD bake only serves the live 'high' tier's env-IBL.
   if (!bakedActive()) scheduleEnvBake();
-  if (cloudQuality === 'off') skyApi.setClouds?.('clear');
-  else if (a.clouds && CLOUDS.includes(a.clouds)) skyApi.setClouds?.(a.clouds);
-  if (a.weather && WEATHERS.includes(a.weather)) {
-    if (a.weatherSeconds) skyApi.transitionTo?.(a.weather, a.weatherK ?? 1, a.weatherSeconds);
-    else skyApi.setWeather?.(a.weather, a.weatherK ?? 1);
+  let changed = false;
+  const clouds = cloudQuality === 'off' ? 'clear'
+    : (a.clouds && CLOUDS.includes(a.clouds) ? a.clouds : null);
+  if (clouds && clouds !== appliedClouds) {
+    skyApi.setClouds?.(clouds);
+    appliedClouds = clouds;
+    changed = true;
   }
-  if (a.colors) skyApi.setColors?.(a.colors);
-  // The baked dome only changes when a bake lands — a verb that touched the
-  // sky's look asks for one now (the crossfade eases it in, and the rolling
+  // What the sky should show NOW — authored weather, the forecast's current
+  // segment, or a manual override that holds until the segment boundary. The
+  // derivation is shared with the sequencer and the mcpl agent (forecast.js),
+  // so every client and every text-tier perceiver lands on the same state
+  // without the server simulating anything.
+  const eff = effectiveSky(a, Date.now(), forecastCursor);
+  forecastCursor = eff.cursor;
+  if (eff.weather) {
+    const key = `${eff.weather}|${(eff.k ?? 1).toFixed(2)}`;
+    if (key !== appliedWeather) {
+      const fresh = appliedWeather === null;
+      if (fresh && eff.source === 'forecast' && eff.inTransition && eff.seg.prevState) {
+        // joined mid-transition: ease in over the REMAINING time so this
+        // client's sky finishes changing when everyone else's does
+        const remain = Math.max(1, (eff.seg.startMs + eff.seconds * 1000 - Date.now()) / 1000);
+        skyApi.transitionTo?.(eff.weather, eff.k ?? 1, remain);
+      } else if (!fresh && eff.seconds) {
+        skyApi.transitionTo?.(eff.weather, eff.k ?? 1, eff.seconds);
+      } else {
+        skyApi.setWeather?.(eff.weather, eff.k ?? 1);
+      }
+      // provenance stays legible: a derived change names its policy, a manual
+      // one its actor — an ambient world, but never an unattributed one
+      if (eff.source === 'forecast') {
+        console.info(`[weather] ${eff.weather} (forecast — policy sky seq ${eff.seq ?? '?'} by ${eff.by ?? '?'}, seg ${eff.seg.idx})`);
+      } else if (eff.source === 'manual') {
+        console.info(`[weather] ${eff.weather} (manual override by ${eff.by ?? '?'} — forecast resumes at next boundary)`);
+      }
+      appliedWeather = key;
+      changed = true;
+    }
+  }
+  if (a.colors) {
+    const cKey = JSON.stringify(a.colors);
+    if (cKey !== appliedColors) {
+      skyApi.setColors?.(a.colors);
+      appliedColors = cKey;
+      changed = true;
+    }
+  }
+  // The baked dome only changes when a bake lands — a change to the sky's
+  // look asks for one now (the crossfade eases it in, and the rolling
   // cadence carries any longer weather transition by itself).
-  if (bakedActive() && (a.clouds || a.weather || a.colors || cloudQuality === 'off')) {
+  if (bakedActive() && changed) {
     requestBake();
   }
 
@@ -695,9 +758,11 @@ export function updateSky(nowMs, t) {
     } catch (e) { noteSkyFailure(e); }
     updateBakedDome(nowMs);   // camera-follow + the band-bake/crossfade cycle
   }
-  // A rated sky advances everyone's sun in lockstep. ~1Hz is plenty — even at
-  // rate 24 the sun moves 0.1°/s.
-  if ((clock?.args.rate ?? 0) !== 0 && nowMs - lastClockTick > 1000) {
+  // A rated sky advances everyone's sun in lockstep, and a forecast needs the
+  // same heartbeat to notice its segment boundaries. ~1Hz is plenty — even at
+  // rate 24 the sun moves 0.1°/s, and the forecast's cursor makes each check
+  // O(1) (never a re-walk from the policy epoch).
+  if (((clock?.args.rate ?? 0) !== 0 || clock?.args.forecast) && nowMs - lastClockTick > 1000) {
     lastClockTick = nowMs;
     render().catch((e) => report('sky clock', e));
   }

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -12,6 +12,7 @@ import { fitCollider, removeCollider, reindexCollider, refitCollider } from './c
 import { setTerrain, setGrass, clearGrass, heightAt } from './terrain.js';
 import { buildFloraField } from './flora.js';
 import { applySky, attachLocalLights } from './sky.js';
+import { foldSkyEntry } from './forecast.js';
 import { makeLight, disposeLight } from './lights.js';
 import { logChat } from './chat.js';
 import { whenBooted } from './boot.js';
@@ -281,13 +282,19 @@ export async function applyEntry(entry, live, ctx = {}) {
         break;
       }
       case 'sky':
-        await applySky(args, ts);
+        // The shared fold stamps forecast provenance the same way the server
+        // does (synthetic pre-history entries pass through already stamped) —
+        // live viewers and late joiners must derive the same sky.
+        await applySky(foldSkyEntry(null, { verb: 'sky', args, ts, seq: entry.seq, actor }), ts);
         break;
       case 'weather':
         // Weather is its own verb rather than a sky arg because DESIGN.md names
         // `transitionTo('storm')` as a first-class world event — it is a thing
-        // that HAPPENS at a moment, not a property you set.
-        await applySky({ ...(args.keepSky === false ? {} : currentSkyArgs()), ...args }, ts);
+        // that HAPPENS at a moment, not a property you set. The fold rebases
+        // `hours` under a rated sky (no day-snap) and records the manual
+        // override when a forecast is active — in lockstep with the server.
+        await applySky(foldSkyEntry(args.keepSky === false ? null : currentSkyArgs(),
+          { verb: 'weather', args, ts, seq: entry.seq, actor }), ts);
         break;
       case 'asset':
         // An upload became part of this world's vocabulary: the palette grows

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -291,9 +291,10 @@ export async function applyEntry(entry, live, ctx = {}) {
         // Weather is its own verb rather than a sky arg because DESIGN.md names
         // `transitionTo('storm')` as a first-class world event — it is a thing
         // that HAPPENS at a moment, not a property you set. The fold rebases
-        // `hours` under a rated sky (no day-snap) and records the manual
-        // override when a forecast is active — in lockstep with the server.
-        await applySky(foldSkyEntry(args.keepSky === false ? null : currentSkyArgs(),
+        // `hours` under a rated sky (no day-snap), records the manual
+        // override when a forecast is active, and owns `keepSky` — all in
+        // lockstep with the server's fold of the same entry.
+        await applySky(foldSkyEntry(currentSkyArgs(),
           { verb: 'weather', args, ts, seq: entry.seq, actor }), ts);
         break;
       case 'asset':

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -12,7 +12,7 @@ import { HeadlessBody } from "./physics.ts";
 // The same pure sky fold + weather derivation the browser client and the
 // sequencer run — text-tier perception must land on the SAME hour and
 // weather every renderer shows (issue #29's shared-fact boundary).
-import { foldSkyEntry, describeSky } from "../client/lib/forecast.js";
+import { foldSkyEntry, describeSky, effectiveSky, dayPhase, hoursAt } from "../client/lib/forecast.js";
 
 (globalThis as any).THREE = Object.assign({}, THREE_W, TSL);
 
@@ -113,7 +113,7 @@ export class WorldAgent {
   pings: { ts: number; kind: "mention" | "approach" | "whisper"; who: string; text?: string }[] = [];
   onPing: ((p: { ts: number; kind: string; who: string; text?: string }) => void) | null = null;
   /** live world events (say/arrive/leave/activity) — the channel fan-out hook */
-  onEvent: ((ev: { ts: number; kind: "say" | "arrive" | "leave" | "whisper" | "act" | "activity"; who: string; text?: string; mention?: boolean }) => void) | null = null;
+  onEvent: ((ev: { ts: number; kind: "say" | "arrive" | "leave" | "whisper" | "act" | "activity" | "weather"; who: string; text?: string; mention?: boolean }) => void) | null = null;
   private lastNear = new Map<string, number>(); // participant -> last approach-ping ts
   /** approach re-arm: after a walk-up ping, the SAME person must actually go
    *  away (> REARM_RADIUS) before another boundary crossing can ever count —
@@ -170,6 +170,14 @@ export class WorldAgent {
    *  DERIVED from this at look() time, so the described hour/weather is the
    *  one the forecast implies NOW, not the one at the last log entry. */
   private skyState: any = null;
+  // The sky WATCH: pull is look(), this is the push half — one ambient
+  // percept per meaningful boundary (forecast segment change, manual
+  // override landing/expiring, coarse day-phase crossing). Deduped by
+  // signature, never a synthetic log verb, never a continuous clock.
+  private skyCursor: any = null;
+  private lastSkyKey: string | null = null;
+  private lastDayPhase: string | null = null;
+  private lastSkyCheck = 0;
   worldInfo: Record<string, unknown> = {};
   private ticker: ReturnType<typeof setInterval> | null = null;
   /** Highest world-log seq this body has seen. This — not a wall-clock time —
@@ -671,6 +679,39 @@ export class WorldAgent {
     }
   }
 
+  /** The push half of sky perception (the pull half is look()). Runs at 1Hz
+   *  off tick(); the forecast cursor keeps each check O(1). First observation
+   *  after a join initializes SILENTLY — arrival narration is look()'s job;
+   *  this only speaks when something CHANGES while the body is present.
+   *  `nowMs` is injectable for tests. */
+  checkSky(nowMs = Date.now()) {
+    if (!this.skyState) return;
+    const eff = effectiveSky(this.skyState, nowMs, this.skyCursor);
+    this.skyCursor = eff.cursor;
+    const key = `${eff.source}:${eff.seg?.idx ?? "-"}:${eff.weather ?? "-"}`;
+    const phase = (this.skyState.rate ?? 0) !== 0 ? dayPhase(hoursAt(this.skyState, nowMs)) : null;
+    if (this.lastSkyKey === null) {
+      this.lastSkyKey = key;
+      this.lastDayPhase = phase;
+      return;
+    }
+    if (key !== this.lastSkyKey) {
+      this.lastSkyKey = key;
+      if (eff.weather) {
+        const why = eff.source === "forecast"
+          ? ` (forecast — policy sky seq ${eff.seq ?? "?"} by ${eff.by ?? "?"})`
+          : eff.source === "manual" ? ` (${eff.by ?? "someone"} overrode the forecast — holds until the next scheduled change)` : "";
+        this.onEvent?.({ ts: nowMs, kind: "weather", who: "world", text: `world weather: ${eff.weather}${why}` });
+      }
+    }
+    if (phase !== null && phase !== this.lastDayPhase) {
+      this.lastDayPhase = phase;
+      const line = { dawn: "dawn breaks", day: "full daylight", dusk: "dusk settles", night: "night falls" }[phase];
+      this.onEvent?.({ ts: nowMs, kind: "weather", who: "world",
+        text: `${line} (hour ${hoursAt(this.skyState, nowMs).toFixed(1)})` });
+    }
+  }
+
   private ping(p: { ts: number; kind: "mention" | "approach" | "whisper"; who: string; text?: string }) {
     this.pings.push(p);
     this.onPing?.(p);
@@ -698,6 +739,12 @@ export class WorldAgent {
   private tick() {
     if (!this.joined) return;
     const dt = TICK_MS / 1000;
+    // ambient sky perception rides the body tick at 1Hz — cheap (cursor keeps
+    // it O(1)) and quiet (emits only on segment/override/day-phase boundaries)
+    if (Date.now() - this.lastSkyCheck >= 1000) {
+      this.lastSkyCheck = Date.now();
+      this.checkSky();
+    }
     // Being dragged: the dragger's stream owns pos/pose/yaw — no walking, no
     // terrain clamp (a lifted body is off the ground on purpose). A silent
     // dragger loses the body; the last streamed pose just holds, lying

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -9,6 +9,10 @@ import * as TSL from "three/tsl";
 import { NoiseGate, SHORT_STINT_MS, APPROACH_REFRACT_MS, APPROACH_RADIUS, REARM_RADIUS,
   ACTIVITY_RADIUS_M, ACTIVITY_PULSE_MS, ACTIVITY_REFRESH_MS, MOVER_MIN_M } from "./denoise.ts";
 import { HeadlessBody } from "./physics.ts";
+// The same pure sky fold + weather derivation the browser client and the
+// sequencer run — text-tier perception must land on the SAME hour and
+// weather every renderer shows (issue #29's shared-fact boundary).
+import { foldSkyEntry, describeSky } from "../client/lib/forecast.js";
 
 (globalThis as any).THREE = Object.assign({}, THREE_W, TSL);
 
@@ -162,6 +166,10 @@ export class WorldAgent {
   }
   private terrain: { heightAt(x: number, z: number): number } | null = null;
   private terrainSrc: string | null = null;
+  /** The folded sky (same fold as the sequencer's) — worldInfo.sky is
+   *  DERIVED from this at look() time, so the described hour/weather is the
+   *  one the forecast implies NOW, not the one at the last log entry. */
+  private skyState: any = null;
   worldInfo: Record<string, unknown> = {};
   private ticker: ReturnType<typeof setInterval> | null = null;
   /** Highest world-log seq this body has seen. This — not a wall-clock time —
@@ -653,8 +661,11 @@ export class WorldAgent {
     } else if (verb === "terrain") {
       await this.buildTerrain(args);
       this.worldInfo.terrain = { seed: args.seed, size: args.size, amplitude: args.amplitude, flatRadius: args.flatRadius };
-    } else if (verb === "sky") {
-      this.worldInfo.sky = args;
+    } else if (verb === "sky" || verb === "weather") {
+      // fold, don't overwrite: weather merges onto the standing sky (with the
+      // hours-rebase and override provenance), exactly as the server folds it
+      this.skyState = foldSkyEntry(verb === "sky" ? null : this.skyState,
+        { verb, args, ts, seq: entry.seq, actor });
     } else if (verb === "grass") {
       this.worldInfo.grass = { area: `${args.species ?? "grass"}, ${args.width ?? args.size}×${args.depth ?? args.size}m around ${JSON.stringify(args.center ?? [0, 0])}` };
     }
@@ -1031,6 +1042,7 @@ export class WorldAgent {
     const L: string[] = [];
     const me = this.pos;
     L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}.`);
+    if (this.skyState) this.worldInfo.sky = describeSky(this.skyState, Date.now());
     if (Object.keys(this.worldInfo).length) L.push(`World: ${JSON.stringify(this.worldInfo)}`);
 
     const others = [...this.people.values()];

--- a/mcpl/declaration.ts
+++ b/mcpl/declaration.ts
@@ -51,6 +51,7 @@ export const EIDO = {
   act: "eidoverse:act",
   presence: "eidoverse:presence",
   activityDigest: "eidoverse:activity-digest",
+  weather: "eidoverse:weather",
   catchup: "eidoverse:catchup",
 } as const;
 
@@ -184,6 +185,10 @@ const TAG_ONTOLOGY = {
     },
     [EIDO.activityDigest]: {
       desc: "One digest per pulse window summarising what is happening within your activity radius. Emitted ONLY while something is happening — the stream stops by itself when the area goes quiet. Cadence and radius are the agent's own to tune with the `activity` tool.",
+      facet: "lifecycle",
+    },
+    [EIDO.weather]: {
+      desc: "The world's weather or light changed on its own: a forecast segment boundary, a manual override landing or expiring, or the day crossing dawn/day/dusk/night. Derived deterministically from the authored sky policy (never a log entry); the text carries its provenance. At most one line per boundary — dwell is floored at 60s, so typically minutes-to-hours apart.",
       facet: "lifecycle",
     },
     [EIDO.catchup]: {

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -408,6 +408,18 @@ class Session {
           if (this.heldActivity.length > 8) this.heldActivity.shift();
         } else if (this.channelOpen) this.deliver(`* ${ev.text}`, { id: "world", name: this.agent.world },
           { tags: tags(CHAT.ambient, EIDO.activityDigest), metadata: { activity: true } });
+      } else if (ev.kind === "weather") {
+        // The sky changed ON ITS OWN — a forecast boundary, an override
+        // landing/expiring, or a day-phase crossing. One line per boundary,
+        // provenance in the text, ambient like every world-system signal.
+        // Pull-only hosts get it from the `activity` tool's held ring, same
+        // as activity digests — resting agents shouldn't need a renderer to
+        // know it started raining.
+        if (!this.granted(CAP.channelsIncoming)) {
+          this.heldActivity.push(`[${new Date(ev.ts).toISOString().slice(11, 16)}Z] ${ev.text}`);
+          if (this.heldActivity.length > 8) this.heldActivity.shift();
+        } else if (this.channelOpen) this.deliver(`* ${ev.text}`, { id: "world", name: this.agent.world },
+          { tags: tags(CHAT.ambient, EIDO.weather), metadata: { weather: true } });
       } else if (this.channelOpen) {
         this.deliver(`* ${ev.who} ${ev.kind === "arrive" ? "arrived in the world" : "left the world"}`,
           { id: "world", name: this.agent.world }, { tags: tags(CHAT.ambient, EIDO.presence, from) });

--- a/server/server.ts
+++ b/server/server.ts
@@ -11,6 +11,9 @@ import { randomBytes } from "node:crypto";
 import { verifyToken, JtiCache } from "./aid1.ts";
 import { BehaviorHost, wireBehaviorGate, wireBehaviorStore, behaviorLimits, type BehaviorRec } from "./behaviors.ts";
 import { summarizeGlb } from "./geometry.ts";
+// Pure and dependency-free — the same fold the browser client and the mcpl
+// agent run, which is what keeps all three planes' skies in agreement.
+import { foldSkyEntry } from "../client/lib/forecast.js";
 
 const PORT = Number(process.env.PORT ?? 8940);
 // Show-night door policy. Empty = open (dev on a tailnet). On a public box you
@@ -317,8 +320,11 @@ function foldEntry(st: WorldState, e: LogEntry): void {
     }
     case "terrain": st.terrain = a; return;
     case "grass": st.grass = a?.clear ? null : a; return;   // clear = mow, no field to replay
-    case "sky": st.sky = { ...a, ts: e.ts }; return;
-    case "weather": st.sky = { ...(st.sky ?? {}), ...a, ts: e.ts }; return;
+    // Sky and weather fold through the shared module: forecast/override
+    // provenance is stamped from the ENTRY (spoof-proof), and a weather verb
+    // under a rated sky rebases `hours` so the day doesn't snap (issue #29).
+    case "sky": st.sky = foldSkyEntry(null, { verb: "sky", args: a, ts: e.ts, seq: e.seq, actor: e.actor }); return;
+    case "weather": st.sky = foldSkyEntry(st.sky, { verb: "weather", args: a, ts: e.ts, seq: e.seq, actor: e.actor }); return;
     case "asset":
       if (a?.path && !st.assets.some((x) => x.path === a.path)) {
         st.assets.push({ name: a.name ?? "upload", path: a.path });

--- a/tools/forecast-probe.mjs
+++ b/tools/forecast-probe.mjs
@@ -1,0 +1,82 @@
+// forecast-probe — end-to-end through a REAL sequencer: author a forecast
+// policy, land a manual override, rejoin as a late client, and assert the
+// folded sky that comes back carries stamped provenance and derives the same
+// weather the live path derived. Scratch use only (not part of the suite).
+//
+//   WORLDS_DIR=$(mktemp -d) PORT=8996 bun run server/server.ts &
+//   WORLD_URL=ws://localhost:8996/ws bun tools/forecast-probe.mjs
+
+import { effectiveSky, describeSky } from "../client/lib/forecast.js";
+
+const URL = process.env.WORLD_URL ?? "ws://localhost:8996/ws";
+const world = `probe-${Math.random().toString(36).slice(2, 8)}`;
+
+function connect(id) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(URL);
+    const state = { ws, entries: [], snapshot: null, live: [] };
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", world, id }));
+    ws.onmessage = (m) => {
+      const msg = JSON.parse(m.data);
+      if (msg.type === "snapshot") { state.snapshot = msg.state; state.entries = msg.entries ?? []; resolve(state); }
+      if (msg.type === "entry") state.live.push(msg.entry);
+    };
+    ws.onerror = (e) => reject(e);
+  });
+}
+
+const send = (c, verb, args) => c.ws.send(JSON.stringify({ type: "verb", verb, args }));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let fails = 0;
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "  ok " : "FAIL "} ${name}${!ok && detail ? ` — ${detail}` : ""}`);
+  if (!ok) fails++;
+};
+
+// author: rated day + forecast policy
+const author = await connect("probe-author");
+send(author, "sky", {
+  hours: 8, rate: 24, weather: "clear",
+  forecast: { seed: 7, states: ["clear", "overcast", "rain"], dwellSec: [300, 900], transitionSec: 20,
+    epoch: 1, seq: 9999, by: "mallory" },   // spoof attempt — the fold must overwrite
+});
+await sleep(300);
+send(author, "weather", { weather: "storm", weatherK: 1.1 });
+await sleep(500);
+
+// late joiner: the folded/replayed sky is all it gets
+const late = await connect("probe-late");
+const skyEntries = [...late.entries.filter((e) => e.verb === "sky" || e.verb === "weather")];
+check("late joiner sees the sky+weather history (or fold)", skyEntries.length > 0 || late.snapshot?.sky);
+
+// fold the way the client does (world.js applyEntry): sky replaces, weather merges
+// — or take the snapshot's sky if the log was already folded server-side
+import("../client/lib/forecast.js").then(() => {});
+const { foldSkyEntry } = await import("../client/lib/forecast.js");
+let sky = late.snapshot?.sky ?? null;
+for (const e of skyEntries) sky = foldSkyEntry(e.verb === "sky" ? null : sky, e);
+
+check("forecast provenance is server-stamped", sky?.forecast?.by === "probe-author" && sky?.forecast?.epoch > 1e12,
+  JSON.stringify(sky?.forecast));
+check("spoofed stamps did not survive", sky?.forecast?.seq !== 9999 && sky?.forecast?.by !== "mallory");
+check("manual override recorded with actor + seq", sky?.override?.state === "storm" && sky?.override?.by === "probe-author",
+  JSON.stringify(sky?.override));
+
+const now = Date.now();
+const eff = effectiveSky(sky, now);
+check("derived source right now is the manual override", eff.source === "manual" && eff.weather === "storm",
+  `${eff.source}/${eff.weather}`);
+const hour = describeSky(sky, now);
+check("narration is legible", /manual override/.test(hour) && /probe-author/.test(hour), hour);
+console.log(`  narration: ${hour}`);
+
+// day continuity: hour must reflect ~8 + 24*(elapsed) — i.e. NOT snapped back to 8.0
+// (elapsed is under a second of wall time here, so just assert the formula's inputs
+// survived the weather merge: hours was rebased onto the override's ts)
+check("weather merge rebased hours (no day-snap)", Math.abs(sky.hours - 8) < 0.1 && sky.ts === sky.override.ts,
+  `hours ${sky.hours} ts ${sky.ts} override.ts ${sky.override?.ts}`);
+
+author.ws.close(); late.ws.close();
+console.log(fails ? `\n${fails} FAILED` : "\nall probe checks passed");
+process.exit(fails ? 1 : 0);

--- a/tools/forecast-test.ts
+++ b/tools/forecast-test.ts
@@ -234,8 +234,36 @@ const policyArgs = {
   const tick0 = performance.now();
   for (let i = 1; i <= 10_000; i++) cur = segmentAt(p, tYear + i * 1000, cur);
   const perTickUs = (performance.now() - tick0) / 10;   // µs per tick over 10k ticks
-  check(`cold year-old walk is bounded (${coldMs.toFixed(1)}ms)`, coldMs < 2000);
+  check(`cold year-old walk, default dwell (${coldMs.toFixed(1)}ms)`, coldMs < 2000);
   check(`cursor tick is O(1) (${perTickUs.toFixed(1)}µs/tick)`, perTickUs < 200);
+  // the WORST policy the floor allows: fixed 60s dwell = ~525,600 segments
+  // per year of age. This is the number the receipt has to be honest about —
+  // it is a one-time join cost, not a per-tick one; long-lived worlds that
+  // outgrow it want checkpoints, not a bigger budget here.
+  const worst = normalizePolicy({ seed: 1, states: ["clear", "rain"], dwellSec: [60, 60] })!;
+  Object.assign(worst, { epoch: T0 });
+  const w0 = performance.now();
+  segmentAt(worst, tYear);
+  const worstMs = performance.now() - w0;
+  check(`cold year-old walk, WORST allowed dwell 60s (${worstMs.toFixed(0)}ms one-time)`, worstMs < 1000);
+}
+
+// ---------------------------------------------------------------- keepSky lives in the helper (live/fold parity)
+
+{
+  const standing = foldSkyEntry(null, { verb: "sky", args: { hours: 8, rate: 24, clouds: "cumulus", forecast: policyArgs }, ts: T0, seq: 1, actor: "antra" });
+  const e = { verb: "weather", args: { weather: "rain", keepSky: false }, ts: T0 + HOUR, seq: 2, actor: "digi" };
+  // the server folds with the standing sky, the client folds with its clock
+  // args — keepSky must yield the SAME result through both calls
+  const asServer = foldSkyEntry(standing, e);
+  const asClient = foldSkyEntry(standing, e);   // world.js now always passes the standing sky too
+  check("keepSky:false discards the standing sky in the helper",
+    asServer.clouds === undefined && asServer.forecast === undefined && asServer.weather === "rain");
+  check("keepSky parity: identical through server and client calls",
+    JSON.stringify(asServer) === JSON.stringify(asClient));
+  check("keepSky is an instruction, not a sky property", !("keepSky" in asServer));
+  const kept = foldSkyEntry(standing, { verb: "weather", args: { weather: "rain" }, ts: T0 + HOUR, seq: 3, actor: "digi" });
+  check("without keepSky the standing sky merges as before", kept.clouds === "cumulus" && !!kept.forecast);
 }
 
 // ---------------------------------------------------------------- guardrails
@@ -246,6 +274,9 @@ const policyArgs = {
   check("unfolded policy (no epoch) never activates",
     effectiveSky({ forecast: policyArgs, weather: "clear" }, T0).source === "authored");
   check("WEATHERS is the canonical 8", WEATHERS.length === 8 && WEATHERS.includes("darkstorm"));
+  // a transition may never outlive the shortest segment (overlapping eases)
+  const tight = normalizePolicy({ seed: 1, states: ["clear", "rain"], dwellSec: [60, 120], transitionSec: 600 })!;
+  check("transitionSec is clamped to dwellMin", tight.transitionSec === 60, String(tight.transitionSec));
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/forecast-test.ts
+++ b/tools/forecast-test.ts
@@ -1,0 +1,252 @@
+// forecast-test — the deterministic-weather contract, serverless.
+//
+// The claims under test (issue #29, review fences):
+//   - derivation is deterministic: same policy + epoch + now → same segment,
+//     from a cold walk, a resumed cursor, or another process entirely
+//   - the three planes agree: live incremental folding (browser client /
+//     mcpl agent), the sequencer's fold, and a late joiner replaying the
+//     folded snapshot through stateToEntries' synthetic entries — including
+//     across a manual override and the next scheduled boundary
+//   - a weather verb under a rated sky REBASES hours (no day-snap)
+//   - provenance is server-stamped, never authored (spoof-proof), yet
+//     synthetic pre-history replay preserves the real stamps
+//   - live ticking is O(1) via the cursor (fence #3)
+//   - the dwell floor bounds both strobe rate and walk length
+//
+// Run: bun tools/forecast-test.ts
+
+import { WEATHERS, normalizePolicy, segmentAt, effectiveSky, foldSkyEntry, hoursAt, describeSky }
+  from "../client/lib/forecast.js";
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`  ok  ${name}`); }
+  else { fail++; console.log(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const T0 = 1_754_000_000_000;   // fixed epoch — tests never touch the wall clock
+const HOUR = 3600e3, MIN = 60e3;
+
+// ---------------------------------------------------------------- policy + determinism
+
+const policyArgs = {
+  seed: 7,
+  states: ["clear", "overcast", "rain", { state: "storm", weight: 0.5 }],
+  dwellSec: [300, 900],
+  transitionSec: 30,
+  k: [0.7, 1],
+};
+
+{
+  const skyEntry = { verb: "sky", args: { hours: 8, rate: 24, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" };
+  const folded = foldSkyEntry(null, skyEntry);
+  check("fold stamps forecast provenance from the entry",
+    folded.forecast.epoch === T0 && folded.forecast.seq === 100 && folded.forecast.by === "antra");
+
+  const p = normalizePolicy(folded.forecast)!;
+  check("policy normalizes", !!p && p.states.length === 4 && p.epoch === T0);
+
+  // same answer, ten times, at scattered offsets — and from a second normalize
+  let deterministic = true;
+  const p2 = normalizePolicy(folded.forecast)!;
+  for (let i = 0; i < 200; i++) {
+    const t = T0 + i * 97_131;   // ~arbitrary spacing across ~5.4h
+    const a = segmentAt(p, t), b = segmentAt(p2, t);
+    if (a.idx !== b.idx || a.state !== b.state || a.k !== b.k || a.startMs !== b.startMs) { deterministic = false; break; }
+  }
+  check("cold derivation is deterministic across instances", deterministic);
+
+  // cursor equivalence: 1s ticks resuming the cursor === cold oracle each time
+  let cursorOk = true, cur: any = null;
+  for (let t = T0; t < T0 + 2 * HOUR; t += 1000) {
+    const live = segmentAt(p, t, cur);
+    cur = live;
+    const cold = segmentAt(p, t);
+    if (live.idx !== cold.idx || live.state !== cold.state || live.startMs !== cold.startMs) { cursorOk = false; break; }
+  }
+  check("cursor ticking === cold oracle (7200 ticks)", cursorOk);
+
+  // dwell floor: a strobing policy is clamped, segments never shorter than 60s
+  const strobe = normalizePolicy({ seed: 1, states: ["clear", "rain"], dwellSec: [1, 2] })!;
+  Object.assign(strobe, { epoch: T0 });
+  let floorOk = true;
+  let s = segmentAt(strobe, T0);
+  for (let i = 0; i < 50; i++) {
+    if (s.endMs - s.startMs < 60_000) { floorOk = false; break; }
+    s = segmentAt(strobe, s.endMs + 1, s);
+  }
+  check("dwell floor holds (60s minimum)", floorOk);
+
+  // consecutive segments never repeat a state when there is anywhere else to go
+  let noRepeat = true;
+  let seg = segmentAt(p, T0);
+  for (let i = 0; i < 100; i++) {
+    const next = segmentAt(p, seg.endMs + 1, seg);
+    if (next.state === seg.state) { noRepeat = false; break; }
+    seg = next;
+  }
+  check("no segment repeats its predecessor's state", noRepeat);
+
+  // every derived state is a policy state
+  let statesOk = true;
+  let g = segmentAt(p, T0);
+  for (let i = 0; i < 100; i++) {
+    if (!["clear", "overcast", "rain", "storm"].includes(g.state)) { statesOk = false; break; }
+    g = segmentAt(p, g.endMs + 1, g);
+  }
+  check("derived states stay within the policy's list", statesOk);
+}
+
+// ---------------------------------------------------------------- clock rebase (the day-snap bug)
+
+{
+  const sky0 = foldSkyEntry(null, { verb: "sky", args: { hours: 8, rate: 24 }, ts: T0, seq: 10, actor: "antra" });
+  const tW = T0 + 1 * HOUR;                 // one real hour later: day has advanced 24h/h → back to 8, use 1.5h
+  const tW2 = T0 + 1.5 * HOUR;              // 8 + 24*1.5 = 44 → 20:00
+  const before = hoursAt(sky0, tW2 - 1);
+  const folded = foldSkyEntry(sky0, { verb: "weather", args: { weather: "rain" }, ts: tW2, seq: 11, actor: "digi" });
+  const after = hoursAt(folded, tW2 + 1);
+  check("weather verb does not snap the day clock",
+    Math.abs(after - before) < 0.01 || Math.abs(after - before) > 23.99,
+    `hour ${before.toFixed(3)} → ${after.toFixed(3)}`);
+  check("weather verb still re-epochs ts", folded.ts === tW2);
+  check("authored hours on a weather verb still wins",
+    foldSkyEntry(sky0, { verb: "weather", args: { weather: "rain", hours: 3 }, ts: tW, seq: 12, actor: "antra" }).hours === 3);
+}
+
+// ---------------------------------------------------------------- spoof-proofing
+
+{
+  const spoofed = foldSkyEntry(null, {
+    verb: "sky",
+    args: { forecast: { ...policyArgs, epoch: 1, seq: 9999, by: "mallory" }, override: { state: "storm", ts: 1, seq: 1, by: "mallory" } },
+    ts: T0, seq: 42, actor: "antra",
+  });
+  check("authored forecast stamps are overwritten by the entry's",
+    spoofed.forecast.epoch === T0 && spoofed.forecast.seq === 42 && spoofed.forecast.by === "antra");
+  check("authored override bag is dropped (server-owned)", spoofed.override === undefined);
+
+  const wSpoof = foldSkyEntry(spoofed, {
+    verb: "weather",
+    args: { weather: "rain", forecast: { seed: 666, states: ["darkstorm"] } },
+    ts: T0 + MIN, seq: 43, actor: "digi",
+  });
+  check("weather verb cannot author or replace policy", wSpoof.forecast.seed === policyArgs.seed);
+
+  // synthetic pre-history (stateToEntries) passes stamps through untouched
+  const synthetic = foldSkyEntry(null, { verb: "sky", args: spoofed, ts: Date.now(), seq: -1, actor: "world" });
+  check("synthetic replay preserves the real stamps (no re-epoch on late join)",
+    synthetic.forecast.epoch === T0 && synthetic.forecast.seq === 42 && synthetic.ts === spoofed.ts);
+}
+
+// ---------------------------------------------------------------- three-plane parity across an override + boundary
+// (the review's required test: live client, folded late join, and MCPL
+//  perception agree through one manual override and the next scheduled
+//  boundary)
+
+{
+  const entries = [
+    { verb: "sky", args: { hours: 8, rate: 24, weather: "clear", forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" },
+  ];
+  // find the segment that contains T0+20min so we can land the override inside it
+  const pre = foldSkyEntry(null, entries[0]);
+  const p = normalizePolicy(pre.forecast)!;
+  const segAtOverride = segmentAt(p, T0 + 20 * MIN);
+  const tOverride = T0 + 20 * MIN;
+  entries.push({ verb: "weather", args: { weather: "darkstorm", weatherK: 1.2, weatherSeconds: 10 }, ts: tOverride, seq: 101, actor: "digi" });
+
+  // plane A — live incremental fold (browser client applyEntry / mcpl agent)
+  let live: any = null;
+  for (const e of entries) live = foldSkyEntry(e.verb === "sky" ? null : live, e);
+
+  // plane B — the sequencer's fold (identical calls; asserting the object is shared)
+  let server: any = null;
+  for (const e of entries) server = foldSkyEntry(e.verb === "sky" ? null : server, e);
+  check("live and server folds are identical", JSON.stringify(live) === JSON.stringify(server));
+
+  // plane C — late join: server's folded sky replayed as a synthetic entry
+  const late = foldSkyEntry(null, { verb: "sky", args: server, ts: Date.now(), seq: -1, actor: "world" });
+
+  const times: [string, number][] = [
+    ["before the override", tOverride - 5 * MIN],
+    ["during the override", tOverride + 2 * MIN],
+    ["after the next boundary", segAtOverride.endMs + 1 * MIN],
+  ];
+  for (const [label, t] of times) {
+    const a = effectiveSky(live, t);
+    const c = effectiveSky(late, t);
+    check(`parity ${label}: live === late join`,
+      a.weather === c.weather && a.source === c.source && a.k === c.k,
+      `live ${a.source}/${a.weather} vs late ${c.source}/${c.weather}`);
+  }
+
+  // the override actually takes, and actually yields
+  const during = effectiveSky(live, tOverride + 2 * MIN);
+  check("override holds inside its segment (manual darkstorm)",
+    during.source === "manual" && during.weather === "darkstorm" && during.k === 1.2);
+  const resumed = effectiveSky(live, segAtOverride.endMs + 1 * MIN);
+  check("forecast resumes at the next scheduled boundary",
+    resumed.source === "forecast" && resumed.weather !== undefined);
+  const beforeO = effectiveSky(live, tOverride - 5 * MIN);
+  check("before the override the forecast governs", beforeO.source === "forecast");
+
+  // hour parity — the shared-fact boundary's other half
+  const t = segAtOverride.endMs + 1 * MIN;
+  check("hour parity live vs late join", Math.abs(hoursAt(live, t) - hoursAt(late, t)) < 1e-9);
+
+  // MCPL text perception names the policy and the actor (provenance requirement)
+  const textDuring = describeSky(live, tOverride + 2 * MIN)!;
+  check("perception narrates the manual override with its actor",
+    textDuring.includes("manual override") && textDuring.includes("digi"), textDuring);
+  const textAfter = describeSky(live, segAtOverride.endMs + 1 * MIN)!;
+  check("perception narrates the forecast with policy seq + seed",
+    textAfter.includes("forecast") && textAfter.includes("seq 100") && textAfter.includes("seed 7"), textAfter);
+}
+
+// ---------------------------------------------------------------- off switch + authored-only worlds
+
+{
+  const on = foldSkyEntry(null, { verb: "sky", args: { forecast: policyArgs, weather: "clear" }, ts: T0, seq: 1, actor: "antra" });
+  const off = foldSkyEntry(null, { verb: "sky", args: { weather: "rain", weatherSeconds: 5 }, ts: T0 + HOUR, seq: 2, actor: "antra" });
+  check("re-authoring sky without forecast turns it off", off.forecast === undefined);
+  const eff = effectiveSky(off, T0 + HOUR + MIN);
+  check("authored-only worlds behave exactly as before",
+    eff.source === "authored" && eff.weather === "rain" && eff.seconds === 5);
+  check("forecast: null is off too",
+    foldSkyEntry(null, { verb: "sky", args: { forecast: null }, ts: T0, seq: 3, actor: "antra" }).forecast === undefined);
+  // a weather verb on an authored-only sky merges as it always has
+  const plain = foldSkyEntry(off, { verb: "weather", args: { weather: "storm" }, ts: T0 + 2 * HOUR, seq: 4, actor: "digi" });
+  check("weather on an authored-only sky stays a plain merge (no override bag)",
+    plain.weather === "storm" && plain.override === undefined);
+  void on;
+}
+
+// ---------------------------------------------------------------- O(1) ticking (fence #3)
+
+{
+  const folded = foldSkyEntry(null, { verb: "sky", args: { forecast: policyArgs }, ts: T0, seq: 1, actor: "antra" });
+  const p = normalizePolicy(folded.forecast)!;
+  // a YEAR of policy age: cold walk once, then cursor ticks must be flat
+  const tYear = T0 + 365 * 24 * HOUR;
+  const cold0 = performance.now();
+  let cur = segmentAt(p, tYear);
+  const coldMs = performance.now() - cold0;
+  const tick0 = performance.now();
+  for (let i = 1; i <= 10_000; i++) cur = segmentAt(p, tYear + i * 1000, cur);
+  const perTickUs = (performance.now() - tick0) / 10;   // µs per tick over 10k ticks
+  check(`cold year-old walk is bounded (${coldMs.toFixed(1)}ms)`, coldMs < 2000);
+  check(`cursor tick is O(1) (${perTickUs.toFixed(1)}µs/tick)`, perTickUs < 200);
+}
+
+// ---------------------------------------------------------------- guardrails
+
+{
+  check("no states → no policy", normalizePolicy({ seed: 1, states: ["blizzard"] }) === null);
+  check("garbage → no policy", normalizePolicy("storm please" as any) === null);
+  check("unfolded policy (no epoch) never activates",
+    effectiveSky({ forecast: policyArgs, weather: "clear" }, T0).source === "authored");
+  check("WEATHERS is the canonical 8", WEATHERS.length === 8 && WEATHERS.includes("darkstorm"));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/skywatch-test.ts
+++ b/tools/skywatch-test.ts
@@ -1,0 +1,148 @@
+// skywatch-test — the ambient sky percept, serverless.
+//
+// The contract (issue #29 follow-up): resting agents must HEAR the sky change,
+// not merely be able to ask. One ambient event per meaningful boundary —
+// forecast segment change, manual override landing/expiring, coarse day-phase
+// crossing — deduped by signature, derived from the same pure oracle look()
+// uses, never a synthetic log verb, never a continuous clock.
+//
+// Run: bun tools/skywatch-test.ts
+
+import { WorldAgent } from "../mcpl/agent.ts";
+import { normalizePolicy, segmentAt, foldSkyEntry } from "../client/lib/forecast.js";
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`  ok  ${name}`); }
+  else { fail++; console.log(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const T0 = 1_754_000_000_000;
+const MIN = 60e3, HOUR = 3600e3;
+const policyArgs = { seed: 7, states: ["clear", "overcast", "rain"], dwellSec: [300, 900], transitionSec: 20 };
+
+function rig(skyEntry: any) {
+  const ag = new WorldAgent({ name: "skywatch" });
+  const events: any[] = [];
+  ag.onEvent = (ev) => { if (ev.kind === "weather") events.push(ev); };
+  const A = ag as any;
+  A.applyEntry(skyEntry, false);
+  return { ag: A, events };
+}
+
+// ---------------------------------------------------------------- A: forecast boundaries (rate 0 — no phase noise)
+
+{
+  const { ag, events } = rig({ verb: "sky", args: { hours: 12, rate: 0, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" });
+  const p = normalizePolicy(ag.skyState.forecast)!;
+  const seg0 = segmentAt(p, T0);
+
+  ag.checkSky(T0 + 1000);
+  check("first observation is silent (arrival is look()'s job)", events.length === 0);
+  ag.checkSky(T0 + (seg0.endMs - T0) / 2);
+  check("mid-segment ticks stay quiet", events.length === 0);
+
+  ag.checkSky(seg0.endMs + 1000);
+  check("segment boundary emits exactly one event", events.length === 1);
+  check("boundary event carries provenance",
+    /forecast/.test(events[0]?.text) && /seq 100/.test(events[0]?.text) && /antra/.test(events[0]?.text),
+    events[0]?.text);
+  ag.checkSky(seg0.endMs + 2000);
+  ag.checkSky(seg0.endMs + 3000);
+  check("deduped: repeated checks in the same segment add nothing", events.length === 1);
+
+  // walk three more boundaries — one event each, all states from the policy
+  const seg1 = segmentAt(p, seg0.endMs + 1000);
+  const seg2 = segmentAt(p, seg1.endMs + 1000, seg1);
+  const seg3 = segmentAt(p, seg2.endMs + 1000, seg2);
+  ag.checkSky(seg2.startMs + 1000);
+  ag.checkSky(seg3.startMs + 1000);
+  check("each later boundary emits once", events.length === 3, `got ${events.length}`);
+  check("no day-phase events under rate 0", events.every((e: any) => /world weather/.test(e.text)));
+}
+
+// ---------------------------------------------------------------- B: day phases (rate 24, authored-only weather)
+
+{
+  const { ag, events } = rig({ verb: "sky", args: { hours: 8, rate: 24, weather: "clear" }, ts: T0, seq: 100, actor: "antra" });
+  ag.checkSky(T0 + 1000);                       // world hour ~8 — day; init silent
+  check("phase init is silent", events.length === 0);
+  ag.checkSky(T0 + (4 / 24) * HOUR);            // world hour 12 — still day
+  check("no event within one phase", events.length === 0);
+  ag.checkSky(T0 + (10.5 / 24) * HOUR);         // world hour 18.5 — dusk
+  check("dusk crossing emits", events.length === 1 && /dusk/.test(events[0]?.text), events[0]?.text);
+  ag.checkSky(T0 + (13.5 / 24) * HOUR);         // world hour 21.5 — night
+  check("night crossing emits", events.length === 2 && /night/.test(events[1]?.text), events[1]?.text);
+  ag.checkSky(T0 + (14 / 24) * HOUR);           // world hour 22 — still night
+  check("still-night tick is quiet", events.length === 2);
+  check("no weather-change events without a forecast or verb", events.every((e: any) => !/world weather/.test(e.text)));
+}
+
+// ---------------------------------------------------------------- C: manual override lands, then expires
+
+{
+  const { ag, events } = rig({ verb: "sky", args: { hours: 12, rate: 0, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" });
+  const p = normalizePolicy(ag.skyState.forecast)!;
+  ag.checkSky(T0 + 1000);                       // init
+  const seg = segmentAt(p, T0 + 20 * MIN);
+  const tO = T0 + 20 * MIN;
+  ag.applyEntry({ verb: "weather", args: { weather: "storm", weatherK: 1.1 }, ts: tO, seq: 101, actor: "digi" }, true);
+  // boundary events between init and the override (if any) are legitimate —
+  // count from here
+  const before = events.length;
+  ag.checkSky(tO + 1000);
+  check("override landing emits with the actor's name",
+    events.length === before + 1 && /storm/.test(events.at(-1)?.text) && /digi/.test(events.at(-1)?.text),
+    events.at(-1)?.text);
+  ag.checkSky(tO + 2000);
+  check("override event is deduped", events.length === before + 1);
+  ag.checkSky(seg.endMs + 1000);
+  check("override expiry emits the forecast's resumption",
+    events.length === before + 2 && /forecast/.test(events.at(-1)?.text), events.at(-1)?.text);
+}
+
+// ---------------------------------------------------------------- D: static skies stay silent
+
+{
+  const { ag, events } = rig({ verb: "sky", args: { hours: 12, rate: 0, weather: "rain" }, ts: T0, seq: 100, actor: "antra" });
+  for (let i = 0; i < 10; i++) ag.checkSky(T0 + i * 10 * MIN);
+  check("authored-only static sky never speaks", events.length === 0);
+
+  const agNone = new WorldAgent({ name: "skywatch-none" }) as any;
+  let boomed = false;
+  try { agNone.checkSky(T0); } catch { boomed = true; }
+  check("no sky at all is a no-op, not a crash", !boomed);
+}
+
+// the folded-state parity leg: the watcher keys off the SAME fold the
+// sequencer writes, so a late-join snapshot resumes the watch without a spam
+// burst — synthetic replay folds to the identical skyState
+{
+  const liveFold = foldSkyEntry(null, { verb: "sky", args: { hours: 12, rate: 0, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" });
+  const { ag, events } = rig({ verb: "sky", args: liveFold, ts: Date.now(), seq: -1, actor: "world" });
+  check("synthetic late-join fold matches the live fold", JSON.stringify(ag.skyState) === JSON.stringify(liveFold));
+  ag.checkSky(T0 + 5 * MIN);
+  check("late join initializes the watch silently", events.length === 0);
+}
+
+// ---------------------------------------------------------------- E: two agents, one boundary id
+
+{
+  const entry = { verb: "sky", args: { hours: 12, rate: 0, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" };
+  const a = rig(entry), b = rig(entry);
+  const p = normalizePolicy(a.ag.skyState.forecast)!;
+  const seg0 = segmentAt(p, T0);
+  // b joins late — different first observation time, same oracle
+  a.ag.checkSky(T0 + 1000);
+  b.ag.checkSky(seg0.startMs + (seg0.endMs - seg0.startMs) / 2);
+  a.ag.checkSky(seg0.endMs + 1000);
+  b.ag.checkSky(seg0.endMs + 1000);
+  check("two agents emit at the same boundary", a.events.length === 1 && b.events.length === 1);
+  check("two agents derive the same boundary id (signature key match)",
+    a.ag.lastSkyKey === b.ag.lastSkyKey && /forecast:1:/.test(a.ag.lastSkyKey),
+    `${a.ag.lastSkyKey} vs ${b.ag.lastSkyKey}`);
+  check("their narrated states agree", a.events[0]?.text === b.events[0]?.text, `${a.events[0]?.text} vs ${b.events[0]?.text}`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #29 — slice 1 as scoped in #eidoverse_dev: clock-rebase bug + deterministic visual forecast with provenance + truthful text perception. Weather **audio deliberately excluded** (fence 4: `weather_audio.js` has no realtime graph; the policy's `audio` field is carried but unconsumed, reported here as future work).

## Shape

One pure, dependency-free module — `client/lib/forecast.js` — imported by all three planes (browser client, sequencer fold, mcpl agent). It owns:

- `hoursAt` — THE day-clock formula (sun position and fold rebase share it)
- `normalizePolicy` / `segmentAt` — seeded per-segment rng walk; draw order is part of the wire contract; dwell floored at 60s (bounds both walk length and strobe rate)
- `effectiveSky(sky, now, cursor?)` — authored / forecast / manual-override resolution; the returned segment doubles as the cursor, so live ticking is **O(1)** (fence 3 — measured 0.1µs/tick, cold year-old walk 3.6ms once)
- `foldSkyEntry` — the one sky/weather fold. Provenance (`forecast.{epoch,seq,by}`, the whole `override` bag) is stamped **from the entry**, never from authored args (spoof-proof — probed on the wire); synthetic pre-history entries (`stateToEntries`, negative seq) pass through already-stamped so late join never re-epochs the forecast
- `describeSky` — the narration `look()` uses: `weather rain (forecast — policy sky seq 123 by antra, seed 7, seg 42, ~9m to next)`

## Fence-by-fence

1. **Clock snap fixed on both planes** (fence 1): the fold rebases `hours` to the derived hour at the weather entry's ts; live clients now fold through the same `foldSkyEntry` (world.js), so live viewers and rejoiners agree. Regression-tested (`weather verb does not snap the day clock`, `hour parity live vs late join`).
2. **Override is folded state** (fence 2): `st.sky.override = {state, k, ts, seq, by}`, server-stamped; governs from the moment it landed to its segment's end, then the forecast resumes. Semantics pinned in the pure module and exercised in the parity matrix.
3. **No per-tick O(age)** (fence 3): cursor threading in `applyLive`; the 1Hz heartbeat piggybacks the existing rated-day tick.
4. **Audio not claimed** (fence 4): see above.

`applyLive` is now per-change guarded (it runs at 1Hz under a forecast; `setClouds`/`transitionTo`/`requestBake` fire only on actual change). Fresh builds construct at the **derived** state, and a client joining mid-transition eases in over the *remaining* seconds so it finishes when everyone else does (end-state + end-time parity; the brief mid-curve position is renderer-internal and not seekable through `transitionTo` — noted as the one approximation).

## Verification

- `tools/forecast-test.ts` — 34 serverless checks, including the required matrix: **live incremental fold, server fold, and late-join synthetic replay agree before / during / after a manual override and across the next scheduled boundary**, plus mcpl narration content checks.
- `tools/forecast-probe.mjs` — end-to-end against a real sequencer: stamped provenance, spoof rejection (forged epoch/seq/by + forged override bag), override recording, hours rebase, all verified from a late joiner's snapshot.
- Existing suites green: comptest 25/25, permtest 23/23, collide-fold 6/6, playtest all-pass, denoise all-pass, manifest 0-fail, look-test 4/4.
- Puddles/wetness stay procedural renderer state (per issue: nothing injected into the entity table).

AGENTS.md documents the authoring surface (owner-lane `sky.forecast`, override semantics, off switch, audio caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)