### PR TITLE
look(): keep World.sky structured — add derivation, don't replace the object

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -1089,7 +1089,21 @@ export class WorldAgent {
     const L: string[] = [];
     const me = this.pos;
     L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}.`);
-    if (this.skyState) this.worldInfo.sky = describeSky(this.skyState, Date.now());
+    // Structured object, NEVER a bare string: consumers of look() were
+    // reading {hours, azimuth, clouds, ts, …} long before the forecast
+    // existed, and a type change here silently breaks them (Sill, postdeploy
+    // #37). The folded fields stay; derivation is ADDED alongside.
+    if (this.skyState) {
+      const now = Date.now();
+      const eff = effectiveSky(this.skyState, now);
+      this.worldInfo.sky = {
+        ...this.skyState,
+        currentHour: Number(hoursAt(this.skyState, now).toFixed(2)),
+        ...(eff.weather ? { currentWeather: eff.weather } : {}),
+        source: eff.source,
+        description: describeSky(this.skyState, now),
+      };
+    }
     if (Object.keys(this.worldInfo).length) L.push(`World: ${JSON.stringify(this.worldInfo)}`);
 
     const others = [...this.people.values()];

--- a/tools/skywatch-test.ts
+++ b/tools/skywatch-test.ts
@@ -144,5 +144,36 @@ function rig(skyEntry: any) {
   check("their narrated states agree", a.events[0]?.text === b.events[0]?.text, `${a.events[0]?.text} vs ${b.events[0]?.text}`);
 }
 
+// ---------------------------------------------------------------- F: look()'s World.sky stays a structured object
+// (postdeploy regression, Sill: #37 briefly replaced the object with a bare
+//  description string, silently breaking every consumer of {hours, clouds,
+//  ts, …}. Type stability is now pinned: folded fields preserved, derivation
+//  ADDED — currentHour/currentWeather/source/description alongside, never
+//  instead.)
+
+{
+  const { ag } = rig({ verb: "sky", args: { hours: 8, rate: 24, clouds: "cumulus", azimuth: 200, forecast: policyArgs }, ts: T0, seq: 100, actor: "antra" });
+  ag.look();
+  const sky = ag.worldInfo.sky;
+  check("World.sky is an object, not a string", typeof sky === "object" && sky !== null && typeof sky !== "string");
+  check("authored/folded fields survive (hours, clouds, azimuth, ts, forecast)",
+    sky.hours === 8 && sky.clouds === "cumulus" && sky.azimuth === 200 && sky.ts === T0 && !!sky.forecast,
+    JSON.stringify(sky));
+  check("derived fields ride alongside",
+    typeof sky.currentHour === "number" && typeof sky.description === "string"
+      && ["authored", "forecast", "manual"].includes(sky.source)
+      && (sky.currentWeather === undefined || typeof sky.currentWeather === "string"),
+    JSON.stringify({ currentHour: sky.currentHour, currentWeather: sky.currentWeather, source: sky.source }));
+
+  // pre-forecast worlds keep their exact old shape too (plus the new derived fields)
+  const plain = rig({ verb: "sky", args: { hours: 12, weather: "rain" }, ts: T0, seq: 1, actor: "antra" });
+  plain.ag.look();
+  const ps = plain.ag.worldInfo.sky;
+  check("authored-only sky is structured with derivation added",
+    typeof ps === "object" && ps.hours === 12 && ps.weather === "rain" && ps.source === "authored"
+      && ps.currentWeather === "rain" && typeof ps.description === "string",
+    JSON.stringify(ps));
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Fixes the postdeploy regression Sill reported on #37: `look()`'s `World.sky` changed type from the long-standing structured object to a bare description string, silently breaking consumers of `{hours, azimuth, clouds, ts, …}`.

Now: the folded sky fields are preserved verbatim and the derivation rides **alongside** — `currentHour`, `currentWeather` (omitted when none), `source` (`authored | forecast | manual`), and `description` (the narration line). Pre-forecast authored-only worlds keep their exact old shape plus the new fields.

Type stability is pinned in `tools/skywatch-test.ts` (4 new checks, including the authored-only shape). Receipts: skywatch 27/27, look-test 4/4, forecast 40/40, playtest all-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)