### PR TITLE
Catchup honesty: replay is tagged as replay; reconnect seeds silently (#39)

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -514,7 +514,18 @@ export class WorldAgent {
     const [x, , z] = xyz;
     const prevXYZ = posePosition(prev);
     const dist = Math.hypot(x - this.pos.x, z - this.pos.z);
-    const prevDist = prevXYZ ? Math.hypot(prevXYZ[0] - this.pos.x, prevXYZ[2] - this.pos.z) : Infinity;
+    // First SPATIAL observation of this person is a BASELINE, not a
+    // transition (issue #39): reconnect/state replay lands here for every
+    // body already in the room, and narrating it synthesized live-looking
+    // "walked up to you" / "sits down" bursts that residents answered as
+    // live. Seed silently; the approach arms only for someone first seen
+    // properly far away, so a body standing beside you at (re)join must
+    // actually leave and come back before it can "walk up".
+    if (!prevXYZ) {
+      this.nearArmed.set(id, dist > REARM_RADIUS);
+      return;
+    }
+    const prevDist = Math.hypot(prevXYZ[0] - this.pos.x, prevXYZ[2] - this.pos.z);
     if (dist > REARM_RADIUS) this.nearArmed.set(id, true);
     const armed = this.nearArmed.get(id) ?? true;
     const cooled = Date.now() - (this.lastNear.get(id) ?? 0) > APPROACH_REFRACT_MS;

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -486,9 +486,14 @@ class Session {
       const missedSeq = said.filter((m) => m.who !== this.auth.id && rxSeq.test(m.text));
       if (missedSeq.length) {
         this.deliver(`While you were away, ${missedSeq.length} message${missedSeq.length === 1 ? "" : "s"} mentioned you:`,
-          { id: "world", name: this.agent.world });
+          { id: "world", name: this.agent.world }, { tags: tags(CHAT.ambient, EIDO.catchup) });
         for (const m of missedSeq.slice(-10)) {
-          this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who }, { tags: ["mention"], mentioned: true });
+          // replay = ORIGINAL addressing + the catchup marker, exactly as the
+          // ontology declares (issue #39: these shipped as bare legacy
+          // ["mention"], which no declared rule could match). deliver()
+          // renders the author itself — passing "who: text" here doubled it.
+          this.deliver(m.text, { id: m.who, name: m.who },
+            { tags: tags(CHAT.mention, EIDO.catchup), mentioned: true });
         }
       }
     }
@@ -497,8 +502,10 @@ class Session {
       const rx = new RegExp(`(@${this.auth.id}\\b|\\b${this.auth.id}\\b)`, "i");
       const missed = this.agent.inbox.filter((m) => m.kind === "say" && m.ts > since && m.who !== this.auth.id && rx.test(m.text ?? ""));
       if (missed.length) {
-        this.deliver(`While you were away, ${missed.length} message${missed.length === 1 ? "" : "s"} mentioned you:`, { id: "world", name: this.agent.world });
-        for (const m of missed.slice(-10)) this.deliver(`${m.who}: ${m.text}`, { id: m.who, name: m.who }, { tags: ["mention"], mentioned: true });
+        this.deliver(`While you were away, ${missed.length} message${missed.length === 1 ? "" : "s"} mentioned you:`,
+          { id: "world", name: this.agent.world }, { tags: tags(CHAT.ambient, EIDO.catchup) });
+        for (const m of missed.slice(-10)) this.deliver(m.text ?? "", { id: m.who, name: m.who },
+          { tags: tags(CHAT.mention, EIDO.catchup), mentioned: true });
       }
     }
     lastSeen[this.auth.id] = Date.now();

--- a/mcpl/playtest.ts
+++ b/mcpl/playtest.ts
@@ -139,7 +139,49 @@ bystander2: {
 const reopened = await conn.sendChannelsOpen({ channelId: "world:commons", type: "world", address: { world: "commons" } });
 check("reopen works", reopened?.channel?.id === "world:commons");
 
-bystander.ws?.close();
+console.log("\n━━ reconnect: missed mentions replay as CATCHUP, never as live traffic ━━");
+// the host sleeps; someone mentions it; the host returns. The replay must
+// carry eidoverse:catchup ALONGSIDE the original addressing (issue #39 —
+// these shipped as bare legacy ["mention"], matching no declared rule), and
+// a live mention on the reconnected session must NOT be catchup-tagged.
 await conn.close();
+await Bun.sleep(400);
+{
+  const sleeper = new (await import("./agent.ts")).WorldAgent({ name: "sleeper" });
+  await sleeper.connect();
+  sleeper.say("hey @claude did you hear the thunder? (missed one)");
+  await Bun.sleep(800);                    // let the world log it past the cursor
+  sleeper.close();
+}
+const again = await connectHost(process.env.PLAYTEST_MCPL ?? "ws://127.0.0.1:8941", "dev-token");
+await hears(again.feed, "missed one", 6000);
+const replayed = again.feed.find((f) => f.text.includes("missed one"));
+check("missed mention is replayed on reconnect", !!replayed, again.feed.map((f) => f.text.slice(0, 40)).join(" | "));
+check("replay carries eidoverse:catchup + the ORIGINAL addressing",
+  !!replayed?.tags?.includes("eidoverse:catchup") && !!replayed?.tags?.includes("chat:mention")
+    && !!replayed?.tags?.includes("chat:addressed") && replayed?.mentioned === true,
+  JSON.stringify(replayed?.tags));
+const summary = again.feed.find((f) => f.text.includes("While you were away"));
+check("the replay summary is catchup-tagged, not bare", !!summary?.tags?.includes("eidoverse:catchup"), JSON.stringify(summary?.tags));
+// a catchup-defer rule (tagsAny: ["eidoverse:catchup"]) can now match every
+// replayed frame — and must NOT match live traffic:
+{
+  const live2 = new (await import("./agent.ts")).WorldAgent({ name: "liveone" });
+  await live2.connect();
+  live2.say("@claude live ping after reconnect");
+  await hears(again.feed, "live ping", 5000);
+  const liveMsg = again.feed.find((f) => f.text.includes("live ping"));
+  check("a LIVE mention is addressed but never catchup-tagged",
+    !!liveMsg?.tags?.includes("chat:mention") && !liveMsg?.tags?.includes("eidoverse:catchup"),
+    JSON.stringify(liveMsg?.tags));
+  const matchCatchup = (f: { tags?: string[] }) => f.tags?.includes("eidoverse:catchup");
+  check("one catchup rule cleanly splits replay from live",
+    again.feed.filter(matchCatchup).every((f) => f.text.includes("missed one") || f.text.includes("While you were away")),
+    again.feed.filter(matchCatchup).map((f) => f.text.slice(0, 40)).join(" | "));
+  live2.close();
+}
+await again.conn.close();
+
+bystander.ws?.close();
 console.log(failures ? `\n\x1b[31m${failures} failure(s)\x1b[0m` : "\n\x1b[32mall checks passed\x1b[0m");
 process.exit(failures ? 1 : 0);

--- a/tools/approach-seed-test.ts
+++ b/tools/approach-seed-test.ts
@@ -1,0 +1,77 @@
+// approach-seed-test — reconnect/state replay must SEED, not narrate (issue #39).
+//
+// The expensive class: after a restart, every body already in the room
+// streamed its first pose to a fresh session, and the agent narrated the
+// baseline as transitions — "walked up to you" (warm, addressed, answered as
+// live) and "sits down" bursts. The contract now: the FIRST spatial
+// observation of a person is a baseline. Approach arms only for someone
+// first seen properly far away; acts edge-trigger only against a known
+// previous pose.
+//
+// Run: bun tools/approach-seed-test.ts
+
+import { WorldAgent } from "../mcpl/agent.ts";
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`  ok  ${name}`); }
+  else { fail++; console.log(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const pose = (x: number, z: number, clip = "idle", extra: Record<string, unknown> = {}) =>
+  ({ p: [x, 0, z], yaw: 0, speed: 0, clip, ...extra });
+
+function rig() {
+  const ag = new WorldAgent({ name: "seedtest" }) as any;
+  ag.pos = { x: 0, y: 0, z: 0 };
+  const acts: any[] = [];
+  ag.onEvent = (ev: any) => { if (ev.kind === "act") acts.push(ev); };
+  return { ag, acts, pings: () => ag.takePings().filter((p: any) => p.kind === "approach") };
+}
+
+// ---------------------------------------------------------------- the incident: body already beside you at (re)join
+
+{
+  const { ag, acts, pings } = rig();
+  ag.notePose("digi", pose(1.0, 0.5, "sitstool", { pose: { head: [0, 0, 0, 1] } }));
+  check("first observation within arm's reach pings NO approach", pings().length === 0);
+  check("first observation narrates NO acts (sitting body stays silent)", acts.length === 0, JSON.stringify(acts));
+
+  // and they cannot "walk up" without actually leaving first
+  ag.notePose("digi", pose(1.2, 0.4, "sitstool", { pose: { head: [0, 0, 0, 1] } }));
+  ag.notePose("digi", pose(0.8, 0.3, "sitstool", { pose: { head: [0, 0, 0, 1] } }));
+  check("shuffling in place near you still pings nothing", pings().length === 0);
+
+  // leave properly (> re-arm radius), come back: NOW it is a real walk-up
+  ag.notePose("digi", pose(9, 0));
+  ag.notePose("digi", pose(1.5, 0));
+  check("leave-and-return is a REAL approach and pings once", pings().length === 1);
+}
+
+// ---------------------------------------------------------------- the normal path is untouched
+
+{
+  const { ag, acts, pings } = rig();
+  ag.notePose("visitor", pose(15, 0));           // first seen far — baseline, armed
+  check("first observation far away pings nothing", pings().length === 0);
+  ag.notePose("visitor", pose(6, 0, "walk"));
+  ag.notePose("visitor", pose(2.0, 0, "walk"));
+  check("a live walk-up still pings approach", pings().length === 1);
+  const before = acts.length;
+  ag.notePose("visitor", pose(2.0, 0, "sitchair"));
+  check("a live posture TRANSITION still narrates", acts.length === before + 1 && /sits down/.test(acts.at(-1)?.text),
+    JSON.stringify(acts.at(-1)));
+}
+
+// ---------------------------------------------------------------- null-coordinate shells still seed silently
+
+{
+  const { ag, acts, pings } = rig();
+  ag.notePose("ghost", { p: [null as any, 0, null as any], yaw: 0, speed: 0, clip: "idle" });
+  ag.notePose("ghost", pose(1.1, 0.2, "lie"));   // first REAL coords, right beside us
+  check("shell → first real coords is still a baseline (no approach, no acts)",
+    pings().length === 0 && acts.length === 0, JSON.stringify(acts));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #39 — narrow producer-side pass, both defects.

**Defect 1 (missed-message prelude):** both cursor paths now deliver `tags(CHAT.mention, EIDO.catchup)` (§16.3 closure adds `chat:addressed`) with `mentioned: true`; the summary line is `tags(CHAT.ambient, EIDO.catchup)`. No bare legacy `["mention"]` remains. Bonus: fixed the doubled author prefix in replayed lines (`deliver()` renders the author itself).

**Defect 2 (reconnect synthesis) — took the preferred branch: seed silently.** The root cause was `notePose` treating a fresh session's *first* spatial observation of each body as a transition: `prevDist = Infinity` meant anyone already standing within `APPROACH_RADIUS` "crossed" the boundary (warm, addressed, answered as live), and any seated body narrated "sits down". First observations are now baselines — no approach, no acts, no displacement accumulation — and the approach only arms for someone first seen beyond `REARM_RADIUS`, so a body beside you at (re)join must genuinely leave and return before it can "walk up". Everything past the first sample is unchanged: real walk-ups, posture transitions, arm/re-arm hysteresis, refractories.

**Acceptance mapping:**
- replay emits declared core tags + `eidoverse:catchup`, no bare legacy → playtest reconnect leg, end-to-end through the real door
- reconnect seeds roster/pose without synthesizing arrive/act/approach → `tools/approach-seed-test.ts` (the snapshot roster was already seeded silently; the pose-stream baseline was the leak)
- live approach remains `chat:addressed + eidoverse:approach`, never catchup → regression-pinned in both tests
- test proving no live approach wake on reconnect state arrival → approach-seed-test scenarios 1 and 3
- test proving a catchup rule beats replayed addressing while staying inspectable → playtest: `tagsAny: ["eidoverse:catchup"]` matches every replayed frame (original addressing intact on each) and zero live frames
- comments/ontology → the existing catchup ontology text and prelude comment described exactly this; the implementation now satisfies them, no doc edits needed

Arrival narration during a restart *storm* (other clients genuinely rejoining after their own disconnects) is out of scope here: from a fresh session those are real `arrive` events, already flap-held by the noise gate, tagged `eidoverse:presence`, and suggested-muted in the declared treatment. The classes that fooled residents — approach and posture — are eliminated at the source.

Suites: playtest 19 (5 new), denoise, skywatch 27/27, look-test 4/4, forecast 40/40, approach-seed 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)