### PR TITLE
particles: entities can emit, and text-tier residents perceive it (#25 slice 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,10 +214,13 @@ fire. Bounded overrides: `count` (≤600), `size`, `opacity`, `speed`,
 `lifetime`, `area`. Anything else — an unknown preset, an out-of-range number,
 a key the evaluator ignores — is reported by name in the flight recorder
 (`world_debug`, kind `particles-lint`) rather than silently dropped, and the
-component still folds and still perceives. **Visual quality may reduce the
-sprite count on a slow machine; preset, state, seed and provenance may not
-differ.** Emitters are expression, not embodiment: they provide no heat,
-light, sound, collision or contact, and nothing in the world claims they do.
+component still folds and still perceives. `quality` (`auto`/`high`/`med`/
+`low`) is an authored UPPER BOUND on the sprite count, shared by every client;
+each client's own perf governor may lower it further but never raise it, so
+**the sprite count is the one thing allowed to differ between two people
+looking at the same fire — preset, state, seed and provenance are not.**
+Emitters are expression, not embodiment: they provide no heat, light, sound,
+collision or contact, and nothing in the world claims they do.
 
 Text-tier perception treats an emitter as the semantic thing it is, on the
 entity that owns it — `[hearth] … — emitting fire (particles; local origin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,42 @@ the next scheduled segment boundary, then the forecast resumes. Re-author
 sky is a griefing vector, not weather). Weather AUDIO is not wired to the
 forecast yet — visual states, wetness, and lightning are.
 
+**Things can EMIT — fire, embers, smoke, motes.** `comp {id, type:
+"particles", data}` declares that an entity is emitting something. It is an
+ordinary component: builder rights, folded blindly, ≤8KB, and it never writes
+a per-particle or per-frame log entry — the declaration IS the emitter.
+
+```
+comp {id: "hearth", type: "particles",
+      data: {preset: "fire", seed: 1234, origin: [0, 0.25, 0], count: 150,
+             texture: "eidoverse/assets/particle_textures/flame_05.png",
+             quality: "auto"}}
+comp {id: "hearth", type: "particles", data: null}      # put it out
+```
+
+`preset` is one of `fire · sparks · embers · smoke · dust · snow · magic ·
+stars · muzzle`. `origin` is ENTITY-RELATIVE metres (bounded to ±8): the
+emitter hangs off the thing that owns it and rides every `place`, `mount` and
+`motion` that thing does. `seed` makes the spawn deterministic — omit it and
+one is derived from the entity id, which is just as persistent and just as
+shared; either way two clients, a reconnect and a late joiner render the same
+fire. Bounded overrides: `count` (≤600), `size`, `opacity`, `speed`,
+`lifetime`, `area`. Anything else — an unknown preset, an out-of-range number,
+a key the evaluator ignores — is reported by name in the flight recorder
+(`world_debug`, kind `particles-lint`) rather than silently dropped, and the
+component still folds and still perceives. **Visual quality may reduce the
+sprite count on a slow machine; preset, state, seed and provenance may not
+differ.** Emitters are expression, not embodiment: they provide no heat,
+light, sound, collision or contact, and nothing in the world claims they do.
+
+Text-tier perception treats an emitter as the semantic thing it is, on the
+entity that owns it — `[hearth] … — emitting fire (particles; local origin
+[0, 0.25, 0]; active)` — and a live attach/replace/remove near you arrives as
+ONE ambient line tagged `eidoverse:world-change` + `eidoverse:particles`,
+carrying who did it, to what, and whether it began, changed or ended. Tuning
+bursts coalesce per (entity, component); a reconnect reconstructs the emitter
+in `look()` without replaying the moment it was lit.
+
 You don't have to poll for any of this. Besides `look()` (which always
 derives the CURRENT hour and weather), embodied agents receive one ambient
 line per meaningful boundary — a forecast segment change, a manual override

--- a/client/lib/autohooks.js
+++ b/client/lib/autohooks.js
@@ -1,0 +1,69 @@
+// autohooks — who owns what in the engine's per-frame hook array.
+//
+// `globalThis._autoParticleSystems` is a GLOBAL the toolkit drains every frame
+// (sky.js's updateAutoSystems). Three different owners push into it: the sky
+// system (cloud drift, weather), the meadow (wind, avatar pushers), and now
+// every entity emitter. Nobody announces which entries are theirs.
+//
+// The sky owns its entries by DIFFING the array around its own async build,
+// which is sound only while nothing else registers during that build. It is a
+// real window: a `comp {type:"particles"}` folding while the sky is still
+// awaiting its modules registers a hook the sky then claims and, at its next
+// teardown, silently removes — leaving the emitter in the scene, frozen,
+// facing wherever the camera was. The scene-children half of that diff already
+// refuses to claim what the world owns (`userData.entityId`); this is the same
+// refusal for the hook half, and it is deliberately general rather than a
+// particles-shaped special case: any host subsystem that keeps a per-frame
+// hook should mark it, and any subsystem that claims by diff should skip
+// marked hooks.
+//
+// DOM-free and THREE-free; unit-tested in tools/particles-test.ts.
+
+/** The engine's hook array, created on demand. Never captured in a module
+ *  const — the toolkit makes it lazily and this file may load first. */
+export const autoHooks = () => (globalThis._autoParticleSystems ||= []);
+
+/** Hooks a host subsystem owns and will retire itself. Identity, not index. */
+const hostOwned = new Set();
+
+/** Mark an already-registered hook as host-owned. Used when the hook was
+ *  pushed by upstream code we called (makeParticles registers its own
+ *  billboard update) rather than by us. */
+export function ownHook(fn) {
+  if (typeof fn === 'function') hostOwned.add(fn);
+  return fn;
+}
+
+/** Register a host-owned per-frame hook. */
+export function pushHostHook(fn) {
+  autoHooks().push(ownHook(fn));
+  return fn;
+}
+
+/** Unregister a hook by IDENTITY and drop its ownership mark. Returns whether
+ *  it was actually in the array. Safe to call twice. */
+export function releaseHook(fn, autos = autoHooks()) {
+  if (typeof fn !== 'function') return false;
+  hostOwned.delete(fn);
+  if (!Array.isArray(autos)) return false;
+  const i = autos.indexOf(fn);
+  if (i >= 0) autos.splice(i, 1);
+  return i >= 0;
+}
+
+export const isHostOwned = (fn) => hostOwned.has(fn);
+
+/**
+ * What a subsystem that claims by DIFF may legitimately call its own: hooks
+ * that appeared since `before` (a Set snapshotted at build start) and that no
+ * host subsystem has claimed. The second condition is what makes the claim
+ * safe across an await — a hook registered DURING the build is new, but it is
+ * not therefore the builder's.
+ */
+export function claimUnowned(before, autos = autoHooks()) {
+  const seen = before instanceof Set ? before : new Set(before ?? []);
+  return (autos ?? []).filter((h) => !seen.has(h) && !hostOwned.has(h));
+}
+
+/** Test seam: how many hooks are currently marked host-owned. */
+export const hostOwnedCount = () => hostOwned.size;

--- a/client/lib/emitter_field.js
+++ b/client/lib/emitter_field.js
@@ -1,0 +1,117 @@
+// emitter_field — the `particles` component's LIFECYCLE, DOM-free and
+// THREE-free so it can be unit-tested without a browser (tools/emitters-test.ts).
+//
+// The upstream builder (`eidoverse/particles.js`) is a one-way door: it makes a
+// mesh, adds it to a scene, pushes its billboard `update` into the global
+// `_autoParticleSystems` array, and hands back no way to undo any of that.
+// Flora taught the same lesson and got `dispose()` upstream; until particles
+// does, THIS is where the undo lives — one registry that owns every emitter in
+// the world, so "replace the fire with smoke" retires the fire instead of
+// stacking a second system and a second per-frame hook on top of it.
+//
+// Everything here is idempotent by construction: applying the same state twice
+// is a no-op, removing something that is already gone is a no-op, and a build
+// that finishes AFTER its own entity was replaced or removed retires itself on
+// arrival rather than leaking into the scene.
+
+/**
+ * Retire one built emitter completely: unhook its per-frame update, release
+ * its GPU resources, detach its mesh. Safe to call twice.
+ *
+ * Hooks come off by IDENTITY, never by index — the array is global and shared
+ * with grass wind and the sky, so an index captured at build time means
+ * unhooking somebody else's emitter.
+ */
+export function retireEmitter(handle, autos) {
+  if (!handle || handle.retired) return;
+  handle.retired = true;
+  const hooks = handle.hooks ?? (handle.update ? [handle.update] : []);
+  if (Array.isArray(autos)) {
+    for (const h of hooks) {
+      const i = autos.indexOf(h);
+      if (i >= 0) autos.splice(i, 1);
+    }
+  }
+  try {
+    handle.dispose?.();
+  } catch { /* a failed teardown must not strand the registry entry */ }
+}
+
+/**
+ * The world's emitter registry.
+ *
+ * `build(emitter, {id})` is the host's (THREE-bound) half: it returns — or
+ * resolves to — a handle `{mesh?, update?, hooks?, dispose()}`. `autos` is the
+ * per-frame hook array the engine drains (`globalThis._autoParticleSystems`).
+ *
+ * `apply(id, emitter)` is the ONLY entry point the fold uses: pass the
+ * normalized emitter to attach or replace, `null` to end it.
+ */
+export function makeEmitterRegistry({ autos, build, onError } = {}) {
+  /** id -> { gen, key, handle|null, emitter } — one live emitter per entity. */
+  const live = new Map();
+  let gen = 0;
+
+  const keyOf = (emitter) => (emitter ? JSON.stringify(emitter) : null);
+
+  async function apply(id, emitter) {
+    const key = keyOf(emitter);
+    const cur = live.get(id);
+    // Idempotence: re-authoring the identical bag (a replay of the same entry,
+    // a snapshot that repeats what the log already said) must not rebuild the
+    // fire — a rebuilt emitter re-rolls nothing (the seed is stable) but it
+    // does churn GPU resources and re-registers a hook.
+    if (cur && cur.key === key) return cur.handle;
+
+    const mine = ++gen;
+    // Retire the old one FIRST. Replacement is not two emitters overlapping
+    // for the duration of an await: the world says one thing is burning there.
+    if (cur) {
+      retireEmitter(cur.handle, autos);
+      live.delete(id);
+    }
+    if (!emitter) return null;
+
+    const slot = { gen: mine, key, handle: null, emitter };
+    live.set(id, slot);
+    let handle = null;
+    try {
+      handle = await build(emitter, { id });
+    } catch (e) {
+      if (live.get(id) === slot) live.delete(id);
+      onError?.(e, id);
+      return null;
+    }
+    // The entity was replaced, removed, or the world was cleared while the
+    // texture downloaded. Whatever we just built belongs to nobody: retire it
+    // here or it is a mesh in the scene with no entry to reach it by.
+    if (live.get(id) !== slot) {
+      retireEmitter(handle, autos);
+      return null;
+    }
+    slot.handle = handle;
+    return handle;
+  }
+
+  function retire(id) {
+    const cur = live.get(id);
+    if (!cur) return false;
+    live.delete(id);           // delete BEFORE retiring: an in-flight build
+    retireEmitter(cur.handle, autos);  // sees the slot is gone and retires itself
+    return true;
+  }
+
+  function retireAll() {
+    for (const id of [...live.keys()]) retire(id);
+  }
+
+  return {
+    apply,
+    retire,
+    retireAll,
+    has: (id) => live.has(id),
+    get: (id) => live.get(id)?.handle ?? null,
+    emitterOf: (id) => live.get(id)?.emitter ?? null,
+    get size() { return live.size; },
+  };
+}

--- a/client/lib/emitter_field.js
+++ b/client/lib/emitter_field.js
@@ -14,6 +14,8 @@
 // that finishes AFTER its own entity was replaced or removed retires itself on
 // arrival rather than leaking into the scene.
 
+import { releaseHook } from './autohooks.js';
+
 /**
  * Retire one built emitter completely: unhook its per-frame update, release
  * its GPU resources, detach its mesh. Safe to call twice.
@@ -26,15 +28,53 @@ export function retireEmitter(handle, autos) {
   if (!handle || handle.retired) return;
   handle.retired = true;
   const hooks = handle.hooks ?? (handle.update ? [handle.update] : []);
-  if (Array.isArray(autos)) {
-    for (const h of hooks) {
-      const i = autos.indexOf(h);
-      if (i >= 0) autos.splice(i, 1);
-    }
-  }
+  for (const h of hooks) releaseHook(h, autos);
   try {
     handle.dispose?.();
   } catch { /* a failed teardown must not strand the registry entry */ }
+}
+
+/**
+ * Give back a RAW upstream system — one that `makeParticles()` has already
+ * allocated but that no handle owns yet.
+ *
+ * This is the window the adapter promised to close and initially did not: the
+ * moment the builder returns, its mesh is in the scene and its update is in
+ * the global hook array. If any host step after that point throws (parenting,
+ * marking, tier), `build()` rejects before a handle exists and the registry's
+ * catch has nothing to retire. Every one of those steps therefore runs inside
+ * `adoptSystem`, and this is what it unwinds to.
+ *
+ * Disposes what the SYSTEM owns — geometry and material — and never the
+ * texture, which is cached and shared (see emitters.js).
+ */
+export function retireRawSystem(sys, autos) {
+  if (!sys || sys.__retired) return;
+  sys.__retired = true;
+  releaseHook(sys.update, autos);
+  const mesh = sys.mesh;
+  if (!mesh) return;
+  try {
+    mesh.parent?.remove?.(mesh);
+    mesh.geometry?.dispose?.();
+    const m = mesh.material;
+    if (Array.isArray(m)) m.forEach((x) => x?.dispose?.()); else m?.dispose?.();
+  } catch { /* a failed teardown must not mask the error that caused it */ }
+}
+
+/**
+ * Run the host's own attach steps over a freshly-built upstream system, and
+ * unwind the raw allocation if any of them throws. The handle it returns is
+ * the first moment anything else can retire this system, so everything before
+ * it belongs here.
+ */
+export function adoptSystem(sys, autos, attach) {
+  try {
+    return attach(sys);
+  } catch (e) {
+    retireRawSystem(sys, autos);
+    throw e;
+  }
 }
 
 /**

--- a/client/lib/emitters.js
+++ b/client/lib/emitters.js
@@ -31,11 +31,8 @@ import { THREE, scene, bus } from './core.js';
 import { loadEidoModule, primeFiles } from './assets.js';
 import { entities } from './world.js';
 import { normalizeParticles, resolvedCount, withSeededRandom, QUALITY_TIERS } from './particles.js';
-import { makeEmitterRegistry, retireEmitter } from './emitter_field.js';
-
-/** The engine's per-frame hook array — grass wind, sky, and now emitters.
- *  Read through a getter, never captured: the toolkit creates it lazily. */
-const autos = () => (globalThis._autoParticleSystems ||= []);
+import { makeEmitterRegistry, retireEmitter, adoptSystem } from './emitter_field.js';
+import { autoHooks as autos, ownHook } from './autohooks.js';
 
 // ---- textures --------------------------------------------------------------
 // Sprite textures are SHARED, immutable, and small; one flame_05 serves every
@@ -94,7 +91,10 @@ async function build(emitter, { id }) {
   if (!parent) throw new Error(`entity ${id} is not in the scene`);
   await loadEidoModule('particles.js');
   const map = await spriteTexture(emitter.texture);
-  const count = Math.min(emitter.count, resolvedCount(emitter, tier));
+  // The AUTHORED cap decides how many instances exist at all — allocating 600
+  // sprites for an emitter its author capped at a quarter wastes the memory on
+  // every machine. The local tier then draws fewer still, without a rebuild.
+  const builtCount = resolvedCount(emitter, 'auto');
 
   // The scoped-determinism seam. `makeParticles` is fully synchronous, so
   // nothing else in this tab can observe the swapped Math.random.
@@ -102,7 +102,7 @@ async function build(emitter, { id }) {
     scene,                       // the builder adds the mesh here…
     preset: emitter.preset,
     map,
-    count: emitter.count,        // built at the AUTHORED count; the tier only draws fewer
+    count: builtCount,
     origin: [0, 0, 0],           // …and we re-parent it, so the origin is the entity's
     ...(emitter.size != null ? { size: emitter.size } : {}),
     ...(emitter.opacity != null ? { opacity: emitter.opacity } : {}),
@@ -112,42 +112,48 @@ async function build(emitter, { id }) {
     name: `particles_${id}_${emitter.preset}`,
   }));
   if (!sys?.mesh) throw new Error('makeParticles returned no mesh');
+  // From here the mesh is in the scene and the update is in the global hook
+  // array — allocated, and owned by nobody until a handle exists. Everything
+  // below therefore runs inside adoptSystem, which unwinds the raw system if
+  // any of it throws.
+  ownHook(sys.update);           // ours, so no diffing subsystem may claim it
 
-  // Entity-relative, not world-origin: the emitter is a CHILD of the thing
-  // that owns it, so it rides every place/mount/motion that thing does. The
-  // authored origin is a local offset in the entity's own frame.
-  sys.mesh.position.set(emitter.origin[0], emitter.origin[1], emitter.origin[2]);
-  parent.add(sys.mesh);
-  sys.mesh.userData.emitterOf = id;
-  // The world owns this, not the sky: an async sky build that happens to
-  // snapshot scene.children mid-flight must never claim (and then dispose)
-  // somebody's hearth. Same marker entities and bodies carry.
-  sys.mesh.userData.entityId = id;
+  return adoptSystem(sys, autos(), () => {
+    // Entity-relative, not world-origin: the emitter is a CHILD of the thing
+    // that owns it, so it rides every place/mount/motion that thing does. The
+    // authored origin is a local offset in the entity's own frame.
+    sys.mesh.position.set(emitter.origin[0], emitter.origin[1], emitter.origin[2]);
+    parent.add(sys.mesh);
+    sys.mesh.userData.emitterOf = id;
+    // The world owns this, not the sky: an async sky build that happens to
+    // snapshot scene.children mid-flight must never claim (and then dispose)
+    // somebody's hearth. Same marker entities and bodies carry.
+    sys.mesh.userData.entityId = id;
 
-  const handle = {
-    id,
-    update: sys.update,
-    mesh: sys.mesh,
-    builtCount: emitter.count,
-    setTier(next) {
-      // InstancedMesh draws `count` of its instances — thinning is a number,
-      // not a rebuild, so the governor can act without a hitch (same lever
-      // flora's density dial pulls).
-      sys.mesh.count = Math.max(1, Math.min(emitter.count, resolvedCount(emitter, next)));
-    },
-    dispose() {
-      handles.delete(handle);
-      (sys.mesh.parent ?? scene).remove(sys.mesh);
-      sys.mesh.geometry?.dispose?.();
-      const m = sys.mesh.material;
-      if (Array.isArray(m)) m.forEach((x) => x?.dispose?.()); else m?.dispose?.();
-      // NOT the texture: see textureCache above.
-    },
-  };
-  handle.setTier(tier);
-  if (count !== emitter.count) sys.mesh.count = count;
-  handles.add(handle);
-  return handle;
+    const handle = {
+      id,
+      update: sys.update,
+      mesh: sys.mesh,
+      builtCount,
+      setTier(next) {
+        // InstancedMesh draws `count` of its instances — thinning is a number,
+        // not a rebuild, so the governor can act without a hitch (same lever
+        // flora's density dial pulls).
+        sys.mesh.count = Math.max(1, Math.min(builtCount, resolvedCount(emitter, next)));
+      },
+      dispose() {
+        handles.delete(handle);
+        (sys.mesh.parent ?? scene).remove(sys.mesh);
+        sys.mesh.geometry?.dispose?.();
+        const m = sys.mesh.material;
+        if (Array.isArray(m)) m.forEach((x) => x?.dispose?.()); else m?.dispose?.();
+        // NOT the texture: see textureCache above.
+      },
+    };
+    handle.setTier(tier);
+    handles.add(handle);         // last: nothing after this can throw and strand it
+    return handle;
+  });
 }
 
 const registry = makeEmitterRegistry({

--- a/client/lib/emitters.js
+++ b/client/lib/emitters.js
@@ -1,0 +1,210 @@
+// emitters — the browser host for the `particles` component.
+//
+// Owns the THREE/DOM-bound half: eval-loading the toolkit's particle builder
+// off the library route, priming and caching sprite textures, building each
+// emitter with a DETERMINISTIC random stream, parenting it to the entity that
+// owns it, and handing the resulting handle to the registry that knows how to
+// take it back out again.
+//
+// The split mirrors flora:
+//   particles.js      — what a `particles` bag MEANS (shared with the mcpl agent)
+//   emitter_field.js  — lifecycle/registry, DOM-free and unit-tested
+//   this file         — hosting
+//
+// Two upstream facts shape everything here, both named in eidoverse-worlds #25:
+//
+//   1. `makeParticles` seeds its per-instance spawn attributes from
+//      `Math.random()`. Two clients would therefore render two different fires
+//      from one authored component, and a reconnect would render a third. The
+//      build call is synchronous, so the seam is a scoped swap of Math.random
+//      (`withSeededRandom`) around exactly that call — and nothing else.
+//   2. It has no `dispose()` and pushes its billboard `update` into the global
+//      `_autoParticleSystems` array with no way to unregister. Retirement is
+//      therefore ours: identity-splice the hook, dispose the geometry and
+//      material we own, detach the mesh.
+//
+// Both are adapter-side ON PURPOSE, in one function each, so that when the
+// engine grows a `seed` option and a `dispose()` (as `createFlora` already
+// did) this file loses code rather than gaining a second path.
+
+import { THREE, scene, bus } from './core.js';
+import { loadEidoModule, primeFiles } from './assets.js';
+import { entities } from './world.js';
+import { normalizeParticles, resolvedCount, withSeededRandom, QUALITY_TIERS } from './particles.js';
+import { makeEmitterRegistry, retireEmitter } from './emitter_field.js';
+
+/** The engine's per-frame hook array — grass wind, sky, and now emitters.
+ *  Read through a getter, never captured: the toolkit creates it lazily. */
+const autos = () => (globalThis._autoParticleSystems ||= []);
+
+// ---- textures --------------------------------------------------------------
+// Sprite textures are SHARED, immutable, and small; one flame_05 serves every
+// hearth in the world. They are therefore cached per path and deliberately NOT
+// disposed when an emitter retires — texture ownership is explicit (#25 item
+// 3): the cache owns them, the emitter borrows. Disposing a borrowed texture
+// is how you blank every other fire in the world by putting one out.
+const textureCache = new Map();
+
+async function spriteTexture(path) {
+  if (!path) return null;
+  if (!textureCache.has(path)) {
+    textureCache.set(path, (async () => {
+      await primeFiles([path]);
+      const bytes = globalThis.Deno.readFileSync(path);
+      return globalThis.loadImageTexture(bytes, { srgb: true });
+    })().catch((e) => {
+      // A missing sprite is not a missing emitter: the builder's procedural
+      // dot always works, and a hearth that reads as fire in text but shows a
+      // soft glow beats a hearth that shows nothing.
+      console.warn(`[emitters] sprite ${path} unavailable — using the preset's own look`, e);
+      textureCache.delete(path);
+      return null;
+    }));
+  }
+  return textureCache.get(path);
+}
+
+// ---- quality ---------------------------------------------------------------
+// One world-wide tier, lowered by the perf governor. It scales DRAWN sprites
+// and nothing else: preset, state, seed and provenance stay identical on every
+// machine, which is what makes two people talking about the same fire be
+// talking about the same fire.
+let tier = 'auto';
+const handles = new Set();
+
+export function setEmitterQuality(next) {
+  if (!Object.hasOwn(QUALITY_TIERS, next) || next === tier) return false;
+  tier = next;
+  for (const h of handles) h.setTier?.(tier);
+  return true;
+}
+export const emitterQuality = () => tier;
+/** Live emitters — the governor's cue to bother at all, and the cleanup test's
+ *  window onto whether anything leaked. */
+export const emitterCount = () => handles.size;
+
+// ---- build -----------------------------------------------------------------
+
+async function build(emitter, { id }) {
+  const parent = entities.get(id);
+  // `null` is a spawn reservation whose GLB is still downloading, and an
+  // absent id is an entity that was removed under us. Either way there is
+  // nothing to hang a local origin off, and a world-origin emitter is the
+  // drift #25 names in requirement 2 — so we don't build one.
+  if (!parent) throw new Error(`entity ${id} is not in the scene`);
+  await loadEidoModule('particles.js');
+  const map = await spriteTexture(emitter.texture);
+  const count = Math.min(emitter.count, resolvedCount(emitter, tier));
+
+  // The scoped-determinism seam. `makeParticles` is fully synchronous, so
+  // nothing else in this tab can observe the swapped Math.random.
+  const sys = withSeededRandom(emitter.seed, () => globalThis.makeParticles({
+    scene,                       // the builder adds the mesh here…
+    preset: emitter.preset,
+    map,
+    count: emitter.count,        // built at the AUTHORED count; the tier only draws fewer
+    origin: [0, 0, 0],           // …and we re-parent it, so the origin is the entity's
+    ...(emitter.size != null ? { size: emitter.size } : {}),
+    ...(emitter.opacity != null ? { opacity: emitter.opacity } : {}),
+    ...(emitter.speed != null ? { speed: emitter.speed } : {}),
+    ...(emitter.lifetime != null ? { lifetime: emitter.lifetime } : {}),
+    ...(emitter.area != null ? { area: emitter.area } : {}),
+    name: `particles_${id}_${emitter.preset}`,
+  }));
+  if (!sys?.mesh) throw new Error('makeParticles returned no mesh');
+
+  // Entity-relative, not world-origin: the emitter is a CHILD of the thing
+  // that owns it, so it rides every place/mount/motion that thing does. The
+  // authored origin is a local offset in the entity's own frame.
+  sys.mesh.position.set(emitter.origin[0], emitter.origin[1], emitter.origin[2]);
+  parent.add(sys.mesh);
+  sys.mesh.userData.emitterOf = id;
+  // The world owns this, not the sky: an async sky build that happens to
+  // snapshot scene.children mid-flight must never claim (and then dispose)
+  // somebody's hearth. Same marker entities and bodies carry.
+  sys.mesh.userData.entityId = id;
+
+  const handle = {
+    id,
+    update: sys.update,
+    mesh: sys.mesh,
+    builtCount: emitter.count,
+    setTier(next) {
+      // InstancedMesh draws `count` of its instances — thinning is a number,
+      // not a rebuild, so the governor can act without a hitch (same lever
+      // flora's density dial pulls).
+      sys.mesh.count = Math.max(1, Math.min(emitter.count, resolvedCount(emitter, next)));
+    },
+    dispose() {
+      handles.delete(handle);
+      (sys.mesh.parent ?? scene).remove(sys.mesh);
+      sys.mesh.geometry?.dispose?.();
+      const m = sys.mesh.material;
+      if (Array.isArray(m)) m.forEach((x) => x?.dispose?.()); else m?.dispose?.();
+      // NOT the texture: see textureCache above.
+    },
+  };
+  handle.setTier(tier);
+  if (count !== emitter.count) sys.mesh.count = count;
+  handles.add(handle);
+  return handle;
+}
+
+const registry = makeEmitterRegistry({
+  autos: autos(),
+  build,
+  onError: (e, id) => console.warn(`[emitters] ${id}: ${e?.message ?? e}`),
+});
+
+// ---- wiring ----------------------------------------------------------------
+// Deferred attach: a `comp` can (and on replay usually does) arrive before the
+// entity's GLB has landed. The bag is already folded — perception is correct
+// the whole time — so the emitter just waits for something to hang off.
+const pending = new Map();
+
+function applyFrom(id, data) {
+  const norm = data == null ? { ok: true, emitter: null } : normalizeParticles(data, { entityId: id });
+  if (!norm.ok) {
+    // Legible, and only once per authoring: the component still folds, still
+    // persists, and still reads as an emitter in every text-tier look().
+    console.warn(`[emitters] ${id}: ${norm.why}`);
+    void registry.apply(id, null);
+    return;
+  }
+  if (norm.notes?.length) console.warn(`[emitters] ${id}: ${norm.notes.join(' · ')}`);
+  if (norm.emitter && !entities.get(id)) {
+    pending.set(id, norm.emitter);
+    return;
+  }
+  pending.delete(id);
+  void registry.apply(id, norm.emitter);
+}
+
+bus.on('comp', ({ id, type, data }) => {
+  if (type !== 'particles') return;
+  applyFrom(id, data);
+});
+
+bus.on('entity', ({ id, kind }) => {
+  if (kind === 'remove') {
+    pending.delete(id);
+    registry.retire(id);
+  } else if (kind === 'spawn' && pending.has(id)) {
+    const emitter = pending.get(id);
+    pending.delete(id);
+    void registry.apply(id, emitter);
+  }
+});
+
+bus.on('world-reset', () => clearEmitters());
+
+/** World teardown (a world switch, a reset): every emitter goes, and the
+ *  global hook array comes back to where it started. */
+export function clearEmitters() {
+  pending.clear();
+  registry.retireAll();
+  for (const h of [...handles]) retireEmitter(h, autos());
+  handles.clear();
+}
+
+export { registry as _registry };

--- a/client/lib/flora.js
+++ b/client/lib/flora.js
@@ -16,6 +16,7 @@ import { myState } from './controller.js';
 import { remotes } from './remotes.js';
 import { mapGrassArgs, presetStrokes } from './flora_args.js';
 import { composeField } from './flora_field.js';
+import { pushHostHook } from './autohooks.js';
 
 export { mapGrassArgs, presetStrokes } from './flora_args.js';
 export { retireField } from './flora_field.js';
@@ -182,7 +183,7 @@ function wirePushers(field) {
     }
     field.setPushers(list);
   };
-  (globalThis._autoParticleSystems ||= []).push(hook);
+  pushHostHook(hook);
   return hook;
 }
 

--- a/client/lib/flora_field.js
+++ b/client/lib/flora_field.js
@@ -2,6 +2,8 @@
 // spec/flora_field.test.ts). A "field" is the setGrass-shaped object the
 // grass verb owns: possibly several engine strokes composed under one group.
 
+import { ownHook, releaseHook } from './autohooks.js';
+
 /** Compose stroke fields (createFlora results) + a clearing mask handle into
  *  ONE setGrass-shaped field. The caller supplies the parent group (THREE
  *  lives with the caller) and appends any host hooks (pushers) to autoHooks. */
@@ -12,7 +14,11 @@ export function composeField({ group, fields, mask }) {
     update: fields[0]?.update,
     setPushers: (list) => { for (const f of fields) f.setPushers?.(list); },
     setDensity: (k) => { for (const f of fields) f.setDensity?.(k); },
-    autoHooks: fields.map((f) => f.update).filter(Boolean),
+    // The engine registered these itself; marking them says the meadow retires
+    // them, so no subsystem that claims per-frame hooks by diffing the global
+    // array may adopt one that appeared while ITS own async build was in
+    // flight (see autohooks.js).
+    autoHooks: fields.map((f) => ownHook(f.update)).filter(Boolean),
     dispose: () => {
       for (const f of fields) f.dispose?.();
       mask?.dispose?.();
@@ -27,9 +33,7 @@ export function composeField({ group, fields, mask }) {
 export function retireField(field, autos, scene) {
   if (!field) return;
   const hooks = field.autoHooks ?? (field.update ? [field.update] : []);
-  if (Array.isArray(autos)) {
-    for (const h of hooks) { const i = autos.indexOf(h); if (i >= 0) autos.splice(i, 1); }
-  }
+  for (const h of hooks) releaseHook(h, autos);
   if (field.dispose) {
     field.dispose();
   } else if (field.mesh) {

--- a/client/lib/particles.js
+++ b/client/lib/particles.js
@@ -1,0 +1,275 @@
+// particles — the `particles` component's MEANING, as one pure module.
+//
+// A `comp {id, type: "particles", data: {...}}` entry declares that an entity
+// EMITS something: a hearth on fire, a lamp shedding embers, a censer smoking.
+// This file owns what that declaration means — which presets exist, which
+// overrides are allowed and inside what bounds, which seed the emitter has,
+// and how the emitter reads in prose. Nothing here touches THREE, the DOM, or
+// the log; it is imported verbatim by
+//
+//   client/lib/emitters.js   the browser host (GPU sprites, lifecycle)
+//   mcpl/agent.ts            text-tier perception: look() + the live percept
+//   server/server.ts         the advisory lint that says why a bag won't render
+//
+// so a renderer client, a late joiner, and a resident who perceives by reading
+// cannot disagree about what is burning. Same discipline as forecast.js: the
+// SHARED FACTS (preset, state, seed, provenance) come out of one function, and
+// only the sprite count is allowed to differ between machines.
+//
+// Unit-tested in tools/particles-test.ts.
+
+/** The presets the upstream engine (`eidoverse/particles.js`) actually ships.
+ *  A `preset` outside this list does not render — but it is never erased
+ *  either: it folds, persists, and still reads as an emitter in look(), the
+ *  same forward-compatibility the component bag has everywhere else. */
+export const PARTICLE_PRESETS = Object.freeze({
+  fire:   { count: 150, reads: 'fire' },
+  sparks: { count: 220, reads: 'sparks' },
+  embers: { count: 140, reads: 'embers' },
+  smoke:  { count: 70,  reads: 'smoke' },
+  dust:   { count: 160, reads: 'drifting dust' },
+  snow:   { count: 320, reads: 'falling snow' },
+  magic:  { count: 180, reads: 'motes of light' },
+  stars:  { count: 420, reads: 'a field of stars' },
+  muzzle: { count: 48,  reads: 'a muzzle flash' },
+});
+
+/** Hard ceiling on sprites per emitter, independent of quality tier. A count
+ *  is a shared-state parameter, so it is bounded in the DECLARATION rather
+ *  than only at the renderer: an authored `count: 5e6` must fail at the door
+ *  of meaning, not silently melt the one client with a good GPU. */
+export const PARTICLE_MAX_COUNT = 600;
+
+/** Quality tiers scale sprite count and NOTHING else. Preset, state, seed and
+ *  provenance are shared facts across clients (#25's "visual quality may
+ *  reduce count, but preset/state/provenance are shared facts"). */
+export const QUALITY_TIERS = Object.freeze({ auto: 1, high: 1, med: 0.5, low: 0.25 });
+
+/** Where an authored texture may point. The library route serves the whole
+ *  eidoverse-video checkout; a component is authored by anyone with builder
+ *  rights, so the texture field names a file in the particle library and
+ *  nowhere else. */
+const TEXTURE_DIR = 'eidoverse/assets/particle_textures/';
+
+/** Every key an authored `particles` bag may carry, with its bound. Anything
+ *  outside this table is reported by name rather than quietly dropped — a
+ *  parameter the evaluator ignores is exactly the class of bug the motion
+ *  lint exists to surface. */
+const NUMERIC_BOUNDS = {
+  count:    [1, PARTICLE_MAX_COUNT],
+  size:     [0.005, 4],
+  opacity:  [0, 1],
+  speed:    [0.05, 8],
+  lifetime: [0.05, 30],
+  area:     [0, 8],
+};
+const KNOWN_KEYS = new Set(['preset', 'seed', 'texture', 'origin', 'quality', ...Object.keys(NUMERIC_BOUNDS)]);
+
+// ---- determinism -----------------------------------------------------------
+
+/** mulberry32 — small, fast, and the same sequence everywhere. The upstream
+ *  builder draws its per-instance spawn attributes from `Math.random()`, so
+ *  "deterministic" for us means: the same seed produces the same DRAWS. The
+ *  host installs this around the (synchronous) build call; see
+ *  `withSeededRandom`. */
+export function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function rnd() {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Run `fn` with `Math.random` replaced by this emitter's own stream, then put
+ *  the real one back — even if `fn` throws. This is the ONE seam where the
+ *  upstream builder's `Math.random()` spawn attributes become replay-stable,
+ *  deliberately kept to a single call site so that when the engine grows a
+ *  first-class `seed` option the shim is a one-line deletion. It is safe only
+ *  because the builder is synchronous: nothing else can observe the swap. */
+export function withSeededRandom(seed, fn) {
+  const real = Math.random;
+  Math.random = mulberry32(seed);
+  try {
+    return fn();
+  } finally {
+    Math.random = real;
+  }
+}
+
+/** FNV-1a over a string → a 32-bit seed. Used only when the author did not
+ *  write one down. */
+export function hashSeed(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < String(str).length; i++) {
+    h ^= String(str).charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** The emitter's seed: the authored one if there is one, otherwise derived
+ *  from the entity id and the preset. Derived is enough for an ORDINARY
+ *  emitter — it is persistent (the id is), it travels with the component, and
+ *  every client and every replay computes the same number without a round
+ *  trip. A resident whose BODY is an emitter field needs more than this: the
+ *  seed then belongs to the body definition and is #14's problem, not this
+ *  file's (#25's scope fence). */
+export function emitterSeed(entityId, data) {
+  const authored = data?.seed;
+  if (typeof authored === 'number' && Number.isFinite(authored)) return Math.floor(authored) >>> 0;
+  return hashSeed(`${entityId}:${data?.preset ?? ''}`);
+}
+
+// ---- validation ------------------------------------------------------------
+
+const clamp = (v, [lo, hi]) => Math.min(hi, Math.max(lo, v));
+
+function normalizeOrigin(origin, problems) {
+  if (origin == null) return [0, 0, 0];
+  if (!Array.isArray(origin) || origin.length !== 3 || !origin.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    problems.push('origin must be [x, y, z] numbers (entity-relative metres)');
+    return [0, 0, 0];
+  }
+  // Entity-RELATIVE by contract: the emitter hangs off the thing that owns it
+  // and travels with it. A 200m offset is not a local origin, it is a second
+  // entity nobody can see, move or remove.
+  if (origin.some((n) => Math.abs(n) > 8)) {
+    problems.push('origin is entity-relative and bounded to ±8m — place a far emitter on its own entity');
+    return origin.map((n) => clamp(n, [-8, 8]));
+  }
+  return origin.slice();
+}
+
+/**
+ * Normalize an authored `particles` bag into the emitter a renderer builds.
+ *
+ * Returns `{ok: true, emitter, notes}` — `notes` naming anything that was
+ * clamped — or `{ok: false, why}` when the bag names no renderable preset.
+ * A failure here is never a fold failure: the component still persists and
+ * still reads as an emitter (`describeParticles`). It only means no sprites.
+ */
+export function normalizeParticles(data, { entityId = '' } = {}) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { ok: false, why: 'particles data must be an object {preset, …}' };
+  }
+  const preset = data.preset;
+  if (typeof preset !== 'string' || !Object.hasOwn(PARTICLE_PRESETS, preset)) {
+    return {
+      ok: false,
+      why: `preset ${JSON.stringify(preset ?? null)} is not one this client can render (${Object.keys(PARTICLE_PRESETS).join('/')}) — it will read as an emitter but show nothing until an evaluator learns it`,
+    };
+  }
+  const notes = [];
+  const unknown = Object.keys(data).filter((k) => !KNOWN_KEYS.has(k) && !k.startsWith('_'));
+  if (unknown.length) notes.push(`ignored by the evaluator: ${unknown.join(', ')} (accepted: ${[...KNOWN_KEYS].join(', ')})`);
+
+  const emitter = {
+    preset,
+    seed: emitterSeed(entityId, data),
+    origin: normalizeOrigin(data.origin, notes),
+    quality: Object.hasOwn(QUALITY_TIERS, data.quality) ? data.quality : 'auto',
+  };
+  if (data.quality != null && !Object.hasOwn(QUALITY_TIERS, data.quality)) {
+    notes.push(`quality ${JSON.stringify(data.quality)} is unknown (${Object.keys(QUALITY_TIERS).join('/')}) — using auto`);
+  }
+  if (data.texture != null) {
+    const t = String(data.texture);
+    if (!t.startsWith(TEXTURE_DIR) || !t.endsWith('.png')) {
+      notes.push(`texture must be a .png under ${TEXTURE_DIR} — using the preset's own look`);
+    } else emitter.texture = t;
+  }
+  for (const [key, bound] of Object.entries(NUMERIC_BOUNDS)) {
+    const v = data[key];
+    if (v == null) continue;
+    // `area` also accepts per-axis extents upstream; both forms are bounded.
+    if (key === 'area' && Array.isArray(v)) {
+      if (v.length !== 3 || !v.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+        notes.push('area must be a number or [x, y, z] numbers — using the preset');
+        continue;
+      }
+      const fixed = v.map((n) => clamp(n, bound));
+      if (fixed.some((n, i) => n !== v[i])) notes.push(`area clamped to [${bound[0]}, ${bound[1]}]`);
+      emitter.area = fixed;
+      continue;
+    }
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      notes.push(`${key} must be a finite number — using the preset`);
+      continue;
+    }
+    const fixed = clamp(v, bound);
+    if (fixed !== v) notes.push(`${key} clamped to [${bound[0]}, ${bound[1]}]`);
+    emitter[key] = key === 'count' ? Math.round(fixed) : fixed;
+  }
+  if (emitter.count == null) emitter.count = PARTICLE_PRESETS[preset].count;
+  return { ok: true, emitter, notes };
+}
+
+/** Sprites this machine will actually draw. The only number allowed to differ
+ *  between two clients looking at the same fire. */
+export function resolvedCount(emitter, tier = 'auto') {
+  const k = QUALITY_TIERS[tier] ?? 1;
+  return Math.max(1, Math.round((emitter?.count ?? 0) * k));
+}
+
+// ---- perception ------------------------------------------------------------
+
+/**
+ * How an emitter reads in prose, from the RAW component bag.
+ *
+ * Deliberately tolerant where `normalizeParticles` is strict: #25 requires
+ * that an unknown preset "remains legible as an emitter rather than
+ * disappearing", so a bag this client cannot render still says what the world
+ * says it is. Names the semantic thing on the owning entity — never a sprite
+ * count first, never a bare `components: particles`.
+ */
+export function describeParticles(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return 'emitting something (particles; malformed declaration)';
+  const preset = typeof data.preset === 'string' ? data.preset : null;
+  const known = preset && Object.hasOwn(PARTICLE_PRESETS, preset);
+  const what = known ? PARTICLE_PRESETS[preset].reads : preset ? `"${preset}"` : 'something';
+  const bits = ['particles'];
+  const o = Array.isArray(data.origin) && data.origin.length === 3 && data.origin.every((n) => typeof n === 'number' && Number.isFinite(n))
+    ? data.origin : null;
+  bits.push(`local origin [${(o ?? [0, 0, 0]).join(', ')}]`);
+  if (!known) bits.push('preset unknown to this client');
+  // "active" is the honest claim: the component IS the emitter's state, and a
+  // present component means it is emitting. Heat, light, sound and contact are
+  // NOT claimed here — separate authored components provide those, and saying
+  // a fire is warm when nothing models warmth is a lie a resident would act on.
+  bits.push('active');
+  return `emitting ${what} (${bits.join('; ')})`;
+}
+
+/** begin / change / end, from the two component states around a live `comp`.
+ *  `null` on either side means the emitter was not there. Returns null when
+ *  nothing perceptible happened (an identical re-author). */
+export function emitterTransition(prev, next) {
+  const p = prev && typeof prev === 'object' ? prev : null;
+  const n = next && typeof next === 'object' ? next : null;
+  if (!p && !n) return null;
+  if (!p) return { kind: 'begin', preset: n.preset ?? null };
+  if (!n) return { kind: 'end', preset: p.preset ?? null };
+  if (JSON.stringify(p) === JSON.stringify(n)) return null;
+  return { kind: 'change', preset: n.preset ?? null, from: p.preset ?? null };
+}
+
+const readsAs = (preset) => (preset && Object.hasOwn(PARTICLE_PRESETS, preset)
+  ? PARTICLE_PRESETS[preset].reads : preset ? `"${preset}"` : 'something');
+
+/**
+ * The one ambient line a live attach/replace/remove produces. Carries the
+ * actor, the entity, the preset and which of begin/change/end happened —
+ * everything #25's live-change contract asks for, and nothing per-particle or
+ * per-frame. `who` is the line's subject; the caller supplies the tags.
+ */
+export function transitionLine(actor, entityId, transition) {
+  if (!transition) return null;
+  if (transition.kind === 'begin') return `${actor} lights ${readsAs(transition.preset)} on [${entityId}] (particles)`;
+  if (transition.kind === 'end') return `${actor} puts out the ${readsAs(transition.preset)} on [${entityId}] (particles)`;
+  return transition.from && transition.from !== transition.preset
+    ? `${actor} changes [${entityId}]'s emitter: ${readsAs(transition.from)} → ${readsAs(transition.preset)} (particles)`
+    : `${actor} retunes the ${readsAs(transition.preset)} on [${entityId}] (particles)`;
+}

--- a/client/lib/particles.js
+++ b/client/lib/particles.js
@@ -42,8 +42,19 @@ export const PARTICLE_MAX_COUNT = 600;
 
 /** Quality tiers scale sprite count and NOTHING else. Preset, state, seed and
  *  provenance are shared facts across clients (#25's "visual quality may
- *  reduce count, but preset/state/provenance are shared facts"). */
+ *  reduce count, but preset/state/provenance are shared facts").
+ *
+ *  Two tiers compose, and they compose as a MINIMUM. The authored `quality` on
+ *  the component is a shared upper bound — the author saying "this emitter is
+ *  never worth more than a quarter of its count anywhere" — and the client's
+ *  own tier is a local budget the perf governor lowers. Neither may raise the
+ *  other: an authored `low` stays low on the strongest GPU in the world, and a
+ *  governor that has dropped to `low` is not overruled by an authored `high`.
+ *  (`auto` is the identity on both sides: no opinion.) */
 export const QUALITY_TIERS = Object.freeze({ auto: 1, high: 1, med: 0.5, low: 0.25 });
+
+/** The scale a tier name asks for; an unknown name asks for nothing. */
+const tierScale = (name) => (Object.hasOwn(QUALITY_TIERS, name) ? QUALITY_TIERS[name] : 1);
 
 /** Where an authored texture may point. The library route serves the whole
  *  eidoverse-video checkout; a component is authored by anyone with builder
@@ -207,10 +218,11 @@ export function normalizeParticles(data, { entityId = '' } = {}) {
   return { ok: true, emitter, notes };
 }
 
-/** Sprites this machine will actually draw. The only number allowed to differ
- *  between two clients looking at the same fire. */
+/** Sprites this machine will actually draw: the authored cap and the local
+ *  tier, whichever asks for less. The only number allowed to differ between
+ *  two clients looking at the same fire. */
 export function resolvedCount(emitter, tier = 'auto') {
-  const k = QUALITY_TIERS[tier] ?? 1;
+  const k = Math.min(tierScale(emitter?.quality ?? 'auto'), tierScale(tier));
   return Math.max(1, Math.round((emitter?.count ?? 0) * k));
 }
 

--- a/client/lib/sky.js
+++ b/client/lib/sky.js
@@ -311,12 +311,12 @@ let building = null;
 // Since upstream cannot tell us what it added, we diff the scene around the
 // build and own the difference.
 let skyOwned = [];
-let autoSystemsMark = 0;
+let autoSystemsOwned = [];
 
 function snapshotSceneOwnership() {
   return {
     before: new Set(scene.children),
-    autos: (globalThis._autoParticleSystems ?? []).length,
+    autos: new Set(globalThis._autoParticleSystems ?? []),
   };
 }
 function claimSkyAdditions(snap) {
@@ -324,7 +324,13 @@ function claimSkyAdditions(snap) {
     // never claim anything the world itself owns — entities and bodies can be
     // added by other code while an async sky build is in flight
     && !c.userData?.entityId && !c.userData?.isBody);
-  autoSystemsMark = snap.autos;
+  // Hooks are claimed by IDENTITY, for the same reason the scene children
+  // above are: the array is global and shared. It used to be a LENGTH mark,
+  // which meant anything that registered a per-frame hook after the sky built
+  // — a `particles` emitter on an entity — was silently truncated away by the
+  // next sky rebuild and stopped billboarding, still in the scene, facing
+  // wherever the camera happened to be.
+  autoSystemsOwned = (globalThis._autoParticleSystems ?? []).filter((h) => !snap.autos.has(h));
 }
 function teardownSky() {
   // Put the parked live domes back first: the diff below claimed them at
@@ -341,9 +347,16 @@ function teardownSky() {
   }
   skyOwned = [];
   // the per-frame hooks the sky registered would otherwise keep running
-  // against a dome that is no longer in the scene
+  // against a dome that is no longer in the scene — and only those: everyone
+  // else's hooks stay where they are (see claimSkyAdditions)
   const autos = globalThis._autoParticleSystems;
-  if (Array.isArray(autos) && autos.length > autoSystemsMark) autos.length = autoSystemsMark;
+  if (Array.isArray(autos)) {
+    for (const h of autoSystemsOwned) {
+      const i = autos.indexOf(h);
+      if (i >= 0) autos.splice(i, 1);
+    }
+  }
+  autoSystemsOwned = [];
 }
 
 async function renderEidoverse(a) {

--- a/client/lib/sky.js
+++ b/client/lib/sky.js
@@ -20,6 +20,10 @@ import { attachBakedDome, detachBakedDome, updateBakedDome, bakedActive, request
   envTexture, adoptEnvironment } from './sky_baked.js';
 import { holdFrames, holdObjectCompiles, beginWork } from './loadwork.js';
 import { WEATHERS, effectiveSky, hoursAt } from './forecast.js';
+// Who owns which per-frame hook. The sky claims by diffing a GLOBAL array
+// around its own async build; anything another subsystem marks as its own is
+// off limits, whenever it appeared.
+import { claimUnowned, releaseHook } from './autohooks.js';
 
 // The environment exists from the first frame — BLACK, contributing nothing —
 // so every material's lighting graph is born with its env branch in place.
@@ -324,13 +328,15 @@ function claimSkyAdditions(snap) {
     // never claim anything the world itself owns — entities and bodies can be
     // added by other code while an async sky build is in flight
     && !c.userData?.entityId && !c.userData?.isBody);
-  // Hooks are claimed by IDENTITY, for the same reason the scene children
-  // above are: the array is global and shared. It used to be a LENGTH mark,
-  // which meant anything that registered a per-frame hook after the sky built
-  // — a `particles` emitter on an entity — was silently truncated away by the
-  // next sky rebuild and stopped billboarding, still in the scene, facing
-  // wherever the camera happened to be.
-  autoSystemsOwned = (globalThis._autoParticleSystems ?? []).filter((h) => !snap.autos.has(h));
+  // Hooks are claimed the same way the scene children above are: by identity,
+  // and never something another owner marked as theirs. It used to be a LENGTH
+  // mark, which meant anything that registered a per-frame hook after the sky
+  // built — a `particles` emitter on an entity — was silently truncated away
+  // by the next sky rebuild and stopped billboarding, still in the scene,
+  // facing wherever the camera happened to be. Identity alone is not enough:
+  // this build is ASYNC, so a hook that appeared while it was in flight is new
+  // but is not therefore ours — hence the host-owned marker.
+  autoSystemsOwned = claimUnowned(snap.autos);
 }
 function teardownSky() {
   // Put the parked live domes back first: the diff below claimed them at
@@ -349,13 +355,7 @@ function teardownSky() {
   // the per-frame hooks the sky registered would otherwise keep running
   // against a dome that is no longer in the scene — and only those: everyone
   // else's hooks stay where they are (see claimSkyAdditions)
-  const autos = globalThis._autoParticleSystems;
-  if (Array.isArray(autos)) {
-    for (const h of autoSystemsOwned) {
-      const i = autos.indexOf(h);
-      if (i >= 0) autos.splice(i, 1);
-    }
-  }
+  for (const h of autoSystemsOwned) releaseHook(h, globalThis._autoParticleSystems);
   autoSystemsOwned = [];
 }
 

--- a/client/lib/world.js
+++ b/client/lib/world.js
@@ -650,4 +650,8 @@ export function resetWorld() {
   pendingMounts.clear();
   lastTerrainArgs = lastGrassArgs = null;
   pendingOps.clear();
+  // Anything hanging off entities that owns GPU resources and per-frame hooks
+  // (emitters, today) retires here. Announced rather than imported so the
+  // owning module stays a leaf — world.js is imported BY it.
+  bus.emit('world-reset', {});
 }

--- a/client/main.js
+++ b/client/main.js
@@ -14,6 +14,9 @@ import { updateSky, updateAutoSystems, skyArgs, skyImpl,
   CLOUD_QUALITY, getCloudQuality, setCloudQuality } from './lib/sky.js';
 import { setSkyArgsSource, entities, liveEntities, buildsPending, roleOf, worldHasOwner, comps, avatarMounts, mountTransform, socketWorldPos } from './lib/world.js';
 import { hasGrass, setGrassDensity } from './lib/terrain.js';
+// side-effecting: the `particles` component's host wires itself to the comp
+// and entity buses on import (it has no boot step of its own)
+import { emitterCount, emitterQuality, setEmitterQuality } from './lib/emitters.js';
 import { tickMotion } from './lib/motion.js';
 import {
   myState, updateMe, updateFollowCamera, updateSpectator, setCamYaw, setPosture,
@@ -1115,11 +1118,27 @@ function shedGrass() {
   return true;
 }
 
+// Emitters are alpha-blended fill like grass is, and a long shared session
+// accumulates them (#25 requirement 5). Thinning is a per-emitter instance
+// count — no rebuild, no hitch — and it changes only how many sprites THIS
+// machine draws: preset, state, seed and provenance stay shared facts, so two
+// people on different tiers are still looking at the same fire.
+const EMITTER_TIERS = ['auto', 'med', 'low'];
+function shedEmitters() {
+  if (!emitterCount()) return false;
+  const i = EMITTER_TIERS.indexOf(emitterQuality());
+  if (i < 0 || i >= EMITTER_TIERS.length - 1) return false;
+  if (!setEmitterQuality(EMITTER_TIERS[i + 1])) return false;
+  toast('particle effects thinned to keep the frame rate', 'warn', 8000);
+  return true;
+}
+
 function governPerformance(f) {
   if (f > 0 && f < 26) {
     slowFor++;
     if (slowFor > 2 && shedClouds(performance.now())) { /* clouds first */ }
     else if (slowFor > 2 && shedLight()) { /* then a light — point lights are costly */ }
+    else if (slowFor > 2 && shedEmitters()) { /* then sprite fill — cheapest to give back */ }
     else if (slowFor > 2 && shedGrass()) { /* then the meadow — fill rate */ }
     else if (slowFor > 2 && pixelRatio > 0.7) {
       pixelRatio = Math.max(0.7, pixelRatio - 0.25);

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -13,10 +13,19 @@ import { HeadlessBody } from "./physics.ts";
 // sequencer run — text-tier perception must land on the SAME hour and
 // weather every renderer shows (issue #29's shared-fact boundary).
 import { foldSkyEntry, describeSky, effectiveSky, dayPhase, hoursAt } from "../client/lib/forecast.js";
+// The `particles` component's meaning, shared verbatim with the browser host:
+// a renderer client and a resident who perceives by reading must agree about
+// what is burning (#25's shared-facts boundary).
+import { describeParticles, emitterTransition, transitionLine } from "../client/lib/particles.js";
 
 (globalThis as any).THREE = Object.assign({}, THREE_W, TSL);
 
 const WALK = 1.55, RUN = 4.0, TICK_MS = 100, ARRIVE = 0.4;
+/** Quiet window for world-change narration, per (entity, component). Tuning a
+ *  live emitter is a burst of `comp` entries; this is how long they fold into
+ *  one line. Long enough to swallow a slider drag, short enough that "puts the
+ *  fire out" still arrives while you are looking at it. */
+const EMITTER_COALESCE_MS = Number(process.env.EW_EMITTER_COALESCE_SEC ?? 4) * 1000;
 
 type Vec2 = { x: number; z: number };
 type Pose = { p: number[]; yaw: number; speed: number; clip: string };
@@ -113,7 +122,10 @@ export class WorldAgent {
   pings: { ts: number; kind: "mention" | "approach" | "whisper"; who: string; text?: string }[] = [];
   onPing: ((p: { ts: number; kind: string; who: string; text?: string }) => void) | null = null;
   /** live world events (say/arrive/leave/activity) — the channel fan-out hook */
-  onEvent: ((ev: { ts: number; kind: "say" | "arrive" | "leave" | "whisper" | "act" | "activity" | "weather"; who: string; text?: string; mention?: boolean }) => void) | null = null;
+  onEvent: ((ev: { ts: number; kind: "say" | "arrive" | "leave" | "whisper" | "act" | "activity" | "weather" | "world-change"; who: string; text?: string; mention?: boolean }) => void) | null = null;
+  /** Open coalescing windows for world-change narration, keyed by entity id.
+   *  See noteEmitter. */
+  private emitterNarration = new Map<string, { announced: unknown; latest: unknown; actor: string; timer: ReturnType<typeof setTimeout> }>();
   private lastNear = new Map<string, number>(); // participant -> last approach-ping ts
   /** approach re-arm: after a walk-up ping, the SAME person must actually go
    *  away (> REARM_RADIUS) before another boundary crossing can ever count —
@@ -220,6 +232,8 @@ export class WorldAgent {
     if (this.ticker) { clearInterval(this.ticker); this.ticker = null; }
     if (this.activityTimer) { clearInterval(this.activityTimer); this.activityTimer = null; }
     this.gate.dispose(); // held narration dies with the session
+    for (const s of this.emitterNarration.values()) clearTimeout(s.timer);
+    this.emitterNarration.clear();
     this.ws?.close();
   }
 
@@ -606,8 +620,16 @@ export class WorldAgent {
       // affordances are components — track them or look() can't tell anyone
       const e = this.entities.get(args.id);
       if (e && typeof args.type === "string") {
+        const before = e.comp?.[args.type] ?? null;
         e.comp ??= {};
         if (args.data == null) delete e.comp[args.type]; else e.comp[args.type] = args.data;
+        // An emitter beginning, changing or ending is something you SEE happen
+        // in the world — the one component type with a live sensory event.
+        // Replay reconstructs the state above and stops there: a fire that was
+        // lit last week is in look(), not in your ears (#25).
+        if (args.type === "particles" && live) {
+          this.noteEmitter(actor, String(args.id), before, args.data ?? null, e.pos, ts);
+        }
       }
     } else if (verb === "motion") {
       const e = this.entities.get(args.id);
@@ -688,6 +710,62 @@ export class WorldAgent {
     } else if (verb === "grass") {
       this.worldInfo.grass = { area: `${args.species ?? "grass"}, ${args.width ?? args.size}×${args.depth ?? args.size}m around ${JSON.stringify(args.center ?? [0, 0])}` };
     }
+  }
+
+  /**
+   * A live `particles` attach / replace / remove near this body — ONE ambient
+   * world-change percept, never per particle and never per frame (#25).
+   *
+   * Coalesced by (entity, component): the first change in a quiet period
+   * speaks at once (someone lighting a fire beside you is news the moment it
+   * happens), and everything inside the following window is folded into at
+   * most one further line describing the NET result. So dragging a parameter
+   * slider — twenty `comp` entries in ten seconds — is one "retunes", not
+   * twenty, while a genuine fire→smoke→out sequence still ends up truthful.
+   *
+   * Radius-gated like every other ambient sense, and silent for this body's
+   * own authoring: the world log echoes your own verbs back to you, and
+   * delivering that echo as an event is the self-echo bug (see `say`).
+   * `nowMs`/`setTimer` are injectable for tests.
+   */
+  private noteEmitter(actor: string | undefined, id: string, before: unknown, after: unknown,
+                      pos: number[] | undefined, ts: number) {
+    if (!actor || actor === this.name || actor === "world") return;
+    if (pos && Math.hypot(pos[0] - this.pos.x, pos[2] - this.pos.z) > this.activityRadiusM) return;
+    const slot = this.emitterNarration.get(id);
+    if (slot) {                       // inside the quiet window — fold, don't speak
+      slot.latest = after;
+      slot.actor = actor;
+      return;
+    }
+    const line = transitionLine(actor, id, emitterTransition(before, after));
+    if (line) {
+      this.act30.builds++;            // it feeds the activity digest like any build
+      this.onEvent?.({ ts, kind: "world-change", who: actor, text: line });
+    }
+    this.openEmitterWindow(id, actor, after);
+  }
+
+  private openEmitterWindow(id: string, actor: string, announced: unknown) {
+    const close = () => {
+      const slot = this.emitterNarration.get(id);
+      if (!slot) return;
+      this.emitterNarration.delete(id);
+      const t = emitterTransition(slot.announced, slot.latest);
+      if (!t) return;                 // the burst netted out to what we already said
+      const line = transitionLine(slot.actor, id, t);
+      if (line) {
+        this.act30.builds++;
+        this.onEvent?.({ ts: Date.now(), kind: "world-change", who: slot.actor, text: line });
+      }
+      // A continuous burst speaks once per window rather than being silenced
+      // forever by its own persistence — same rule the act refractory uses.
+      this.openEmitterWindow(id, slot.actor, slot.latest);
+    };
+    const timer = setTimeout(close, EMITTER_COALESCE_MS);
+    // never hold the process open for a decoration
+    (timer as unknown as { unref?: () => void }).unref?.();
+    this.emitterNarration.set(id, { announced, latest: announced, actor, timer });
   }
 
   /** The push half of sky perception (the pull half is look()). Runs at 1Hz
@@ -1149,7 +1227,13 @@ export class WorldAgent {
       if (c.sockets) aff.push(`sit/mount: ${Object.keys(c.sockets).join(", ")}`);
       if (c.reactions) aff.push(`reacts to: ${Object.keys(c.reactions).join(", ")}`);
       if (c.motion?.type) aff.push(`in motion (${c.motion.type})`);
-      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion"].includes(k));
+      // The emitter is named as the SEMANTIC thing it is on the entity that
+      // owns it — "emitting fire", not a sprite inventory and not a bare
+      // `components: particles`. Nothing is claimed about heat, light, sound
+      // or contact: separate authored components would provide those, and a
+      // resident who reads "warm" acts on it.
+      if (c.particles) aff.push(describeParticles(c.particles));
+      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles"].includes(k));
       if (extra.length) aff.push(`components: ${extra.join(", ")}`);
       const ride = this.mounts.get(e.id);
       if (ride) aff.push(`mounted on ${ride.to}`);

--- a/mcpl/declaration.ts
+++ b/mcpl/declaration.ts
@@ -53,6 +53,8 @@ export const EIDO = {
   activityDigest: "eidoverse:activity-digest",
   weather: "eidoverse:weather",
   catchup: "eidoverse:catchup",
+  worldChange: "eidoverse:world-change",
+  particles: "eidoverse:particles",
 } as const;
 
 /** §16.3 core closure, as the producer's own obligation. Hosts MUST expand these
@@ -189,6 +191,14 @@ const TAG_ONTOLOGY = {
     },
     [EIDO.weather]: {
       desc: "The world's weather or light changed on its own: a forecast segment boundary, a manual override landing or expiring, or the day crossing dawn/day/dusk/night. Derived deterministically from the authored sky policy (never a log entry); the text carries its provenance. At most one line per boundary — dwell is floored at 60s, so typically minutes-to-hours apart.",
+      facet: "lifecycle",
+    },
+    [EIDO.worldChange]: {
+      desc: "Someone changed how the world LOOKS near you — a visible authored change to a thing that is here, carrying who did it, to which entity, and whether it began, changed, or ended. Ambient and radius-gated, at most one line per (entity, component) per quiet window, and never replayed: a reconnect reconstructs the resulting state in look() without re-performing the event.",
+      facet: "lifecycle",
+    },
+    [EIDO.particles]: {
+      desc: "The world-change was an EMITTER: an entity started, retuned, or stopped emitting something visible (fire on a hearth, embers, smoke). Arrives alongside eidoverse:world-change — match the general tag to hear every visual change, this one to hear only emitters.",
       facet: "lifecycle",
     },
     [EIDO.catchup]: {

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -420,6 +420,17 @@ class Session {
           if (this.heldActivity.length > 8) this.heldActivity.shift();
         } else if (this.channelOpen) this.deliver(`* ${ev.text}`, { id: "world", name: this.agent.world },
           { tags: tags(CHAT.ambient, EIDO.weather), metadata: { weather: true } });
+      } else if (ev.kind === "world-change") {
+        // Someone changed what the world LOOKS like near this body — today, an
+        // emitter beginning/changing/ending. Ambient, coalesced producer-side,
+        // and held for pull-only hosts exactly like weather and the activity
+        // digest: a resting agent should not need a renderer to notice that
+        // the hearth beside it was lit.
+        if (!this.granted(CAP.channelsIncoming)) {
+          this.heldActivity.push(`[${new Date(ev.ts).toISOString().slice(11, 16)}Z] ${ev.text}`);
+          if (this.heldActivity.length > 8) this.heldActivity.shift();
+        } else if (this.channelOpen) this.deliver(`* ${ev.text}`, { id: "world", name: this.agent.world },
+          { tags: tags(CHAT.ambient, EIDO.worldChange, EIDO.particles, from), metadata: { worldChange: true } });
       } else if (this.channelOpen) {
         this.deliver(`* ${ev.who} ${ev.kind === "arrive" ? "arrived in the world" : "left the world"}`,
           { id: "world", name: this.agent.world }, { tags: tags(CHAT.ambient, EIDO.presence, from) });

--- a/server/server.ts
+++ b/server/server.ts
@@ -14,6 +14,9 @@ import { summarizeGlb } from "./geometry.ts";
 // Pure and dependency-free — the same fold the browser client and the mcpl
 // agent run, which is what keeps all three planes' skies in agreement.
 import { foldSkyEntry } from "../client/lib/forecast.js";
+// Likewise for the `particles` component: one validator, so the flight
+// recorder's opinion about an emitter is the renderer's own opinion.
+import { normalizeParticles } from "../client/lib/particles.js";
 
 const PORT = Number(process.env.PORT ?? 8940);
 // Show-night door policy. Empty = open (dev on a tailnet). On a public box you
@@ -548,6 +551,27 @@ function lintMotion(w: World, entry: LogEntry): void {
       }
     } catch { /* lint must never hurt anything */ }
   })();
+}
+
+/** The same courtesy for `particles`, from the same shared module the browser
+ *  host and the mcpl agent validate with — so what the recorder says is
+ *  exactly what a renderer will do, not a second opinion about it. Advisory:
+ *  the component has already folded, and an unrenderable emitter still
+ *  persists and still reads as an emitter in text-tier perception. */
+function lintParticles(w: World, entry: LogEntry): void {
+  try {
+    const a = entry.args as Record<string, unknown>;
+    const id = String(a.id ?? "");
+    if (a.data == null) return;                      // put out — nothing to lint
+    const r = normalizeParticles(a.data, { entityId: id });
+    if (!r.ok) {
+      w.debug("particles-lint", { entity: id, by: entry.actor, why: r.why });
+      return;
+    }
+    if (r.notes.length) {
+      w.debug("particles-lint", { entity: id, by: entry.actor, why: r.notes.join(" · ") });
+    }
+  } catch { /* lint must never hurt anything */ }
 }
 
 // ---------------------------------------------------------------- reactions
@@ -2249,6 +2273,12 @@ const server = Bun.serve({
           // at 4am — lint it into the recorder while the fold is still warm
           if (msg.verb === "motion" || (msg.verb === "comp" && /^motion(:|$)/.test(String((args as any).type ?? "")))) {
             lintMotion(c.world, entry);
+          }
+          // Same courtesy for an emitter that won't emit: an unknown preset or
+          // a clamped parameter is a silence the author would otherwise have
+          // to discover by asking someone with a GPU what they can see.
+          if (msg.verb === "comp" && String((args as any).type ?? "") === "particles") {
+            lintParticles(c.world, entry);
           }
           // A ban or kick lands NOW on every matching body, not at some future
           // join — the fold recorded the fact; this is the fact taking effect.

--- a/tools/comptest.ts
+++ b/tools/comptest.ts
@@ -158,6 +158,22 @@ alice.verb("comp", { id: "swing1", type: "blob", data: { big: "x".repeat(9000) }
 await alice.settle();
 check("component data is bounded (8KB)", alice.errors.length === 2, alice.errors.join("; "));
 
+// ---- emitters: an ordinary component with a client-side evaluator --------------
+// The full matrix (perception, lifecycle, the lint) lives in
+// tools/particles-test.ts + tools/particles-probe.ts; these are the door's own
+// obligations — rights, fold, and that nothing per-particle reaches the log.
+const beforeParticles = alice.msgs.filter((m) => m.type === "log").length;
+alice.verb("comp", { id: "swing1", type: "particles",
+  data: { preset: "fire", seed: 1234, origin: [0, 0.25, 0] } });
+await alice.settle();
+check("owner can author an emitter", alice.errors.length === 2, alice.errors.join("; "));
+check("an emitter is ONE log entry, never one per particle",
+  alice.msgs.filter((m) => m.type === "log").length === beforeParticles + 1);
+bob.verb("comp", { id: "swing1", type: "particles", data: { preset: "smoke" } });
+await bob.settle();
+check("a visitor cannot light a fire on someone's swing",
+  bob.errors.length === 4 && /builder rights/.test(bob.errors.at(-1) ?? ""), bob.errors.join("; "));
+
 // ---- a fresh join folds all of it back ----------------------------------------
 const eye = await open({ id: "eye1", world: WORLD, spectate: true });
 const snap = eye.msgs.find((m) => m.type === "snapshot");

--- a/tools/emitter-percept-test.ts
+++ b/tools/emitter-percept-test.ts
@@ -1,0 +1,167 @@
+// emitter-percept-test — text-tier perception of the `particles` component,
+// serverless.
+//
+// The contract (eidoverse-worlds #25's agent-perception comment): a resident
+// who perceives by reading must (a) find the emitter named semantically on the
+// entity that owns it when they look, and (b) HEAR a live attach/replace/
+// remove near them — once, coalesced, never per particle or per frame, and
+// never re-performed by a replay.
+//
+// Run: bun tools/emitter-percept-test.ts
+
+// The coalescing window agent.ts reads from the environment, set SHORT so the
+// suite doesn't sit for four seconds a leg — the behaviour under test is the
+// folding, not the duration. agent.ts reads it at module load, so the import
+// has to happen AFTER this line: a static import would be hoisted above it.
+process.env.EW_EMITTER_COALESCE_SEC = "0.25";
+const WINDOW = 250;
+const { WorldAgent } = await import("../mcpl/agent.ts");
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`  ok  ${name}`); }
+  else { fail++; console.log(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const T0 = 1_754_000_000_000;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function rig(name = "emitters", at: [number, number] = [0, 0]) {
+  const ag = new WorldAgent({ name });
+  ag.pos.x = at[0]; ag.pos.z = at[1];
+  const events: any[] = [];
+  ag.onEvent = (ev) => { if (ev.kind === "world-change") events.push(ev); };
+  const A = ag as any;
+  const spawn = (id: string, pos = [0, 0, 0]) =>
+    A.applyEntry({ verb: "spawn", args: { id, lib: "deco/hearth.glb", pos }, ts: T0, seq: 1, actor: "antra" }, false);
+  const comp = (id: string, data: unknown, live = true, actor = "antra", ts = T0) =>
+    A.applyEntry({ verb: "comp", args: { id, type: "particles", data }, ts, seq: 2, actor }, live);
+  return { ag, A, events, spawn, comp };
+}
+
+const FIRE = { preset: "fire", origin: [0, 0.25, 0], texture: "eidoverse/assets/particle_textures/flame_05.png" };
+const SMOKE = { preset: "smoke", origin: [0, 0.25, 0] };
+
+// ---------------------------------------------------------------- A: pull perception (look)
+{
+  const { ag, spawn, comp } = rig();
+  spawn("hearth", [2, 0, 0]);
+  comp("hearth", FIRE, false);
+  const out = ag.look();
+  check("look() names the emitter on the owning entity", /\[hearth\][^\n]*emitting fire/.test(out), out.split("\n").find((l) => l.includes("hearth")));
+  check("...with the local origin it was authored at", out.includes("local origin [0, 0.25, 0]"));
+  check("...and does not fall back to `components: particles`", !/components:[^\n]*particles/.test(out));
+  check("...and enumerates no sprites", !/\b150\b/.test(out));
+  check("...and claims no heat, light, sound or contact",
+    !/(warm|heat\b|crackl|glow|smell)/i.test(out));
+
+  comp("hearth", { preset: "plasma" }, false);
+  const unknown = ag.look();
+  check("an unrenderable preset is still legible as an emitter",
+    /\[hearth\][^\n]*emitting "plasma"/.test(unknown) && unknown.includes("preset unknown"));
+
+  comp("hearth", null, false);
+  check("a removed emitter is gone from look()", !ag.look().includes("emitting"));
+
+  // an ordinary component is untouched by any of this
+  const A = ag as any;
+  A.applyEntry({ verb: "comp", args: { id: "hearth", type: "recipe", data: { by: "fc" } }, ts: T0, seq: 3, actor: "antra" }, false);
+  check("other component types still read as they did", ag.look().includes("components: recipe"));
+}
+
+// ---------------------------------------------------------------- B: live change perception
+{
+  const { events, spawn, comp } = rig();
+  spawn("hearth", [2, 0, 0]);
+
+  comp("hearth", FIRE);
+  check("lighting a fire nearby is heard once", events.length === 1, `got ${events.length}`);
+  check("...carrying actor, entity and preset",
+    events[0].who === "antra" && events[0].text.includes("[hearth]") && events[0].text.includes("fire"));
+  check("...as a world-change, not a mention", events[0].kind === "world-change" && !events[0].mention);
+
+  await sleep(WINDOW * 2);
+  comp("hearth", SMOKE);
+  check("replacing it with smoke is heard once more", events.length === 2, `got ${events.length}`);
+  check("...and says what it became", events[1].text.includes("smoke"));
+
+  await sleep(WINDOW * 2);
+  comp("hearth", null);
+  check("putting it out is heard", events.length === 3 && events[2].text.includes("puts out"));
+}
+
+// ---------------------------------------------------------------- C: coalescing a tuning burst
+{
+  const { events, spawn, comp } = rig();
+  spawn("hearth", [1, 0, 0]);
+  comp("hearth", FIRE);
+  check("the first change speaks at once", events.length === 1);
+  for (let i = 0; i < 20; i++) comp("hearth", { ...FIRE, size: 0.4 + i * 0.01 });
+  check("twenty tuning entries add NOTHING inside the window", events.length === 1, `got ${events.length}`);
+  await sleep(WINDOW * 2);
+  check("the window closes with one summary of the net result", events.length === 2, `got ${events.length}`);
+  check("...which is a retune, not a second lighting", events[1].text.includes("retunes"));
+  await sleep(WINDOW * 2);
+  check("a settled emitter then goes quiet", events.length === 2);
+}
+{
+  // A burst that nets out to nothing must not narrate at all.
+  const { events, spawn, comp } = rig();
+  spawn("hearth", [1, 0, 0]);
+  comp("hearth", FIRE);
+  comp("hearth", SMOKE);
+  comp("hearth", FIRE);              // back to where the first line already said
+  await sleep(WINDOW * 3);
+  check("a burst that returns to the announced state stays silent", events.length === 1, `got ${events.length}`);
+}
+{
+  // …but a burst that ENDS in the window still gets told, at the window's edge.
+  const { events, spawn, comp } = rig();
+  spawn("hearth", [1, 0, 0]);
+  comp("hearth", FIRE);
+  comp("hearth", null);
+  await sleep(WINDOW * 3);
+  check("an emitter put out inside the window is still reported", events.length === 2 && events[1].text.includes("puts out"));
+}
+
+// ---------------------------------------------------------------- D: replay, distance, self
+{
+  const { events, spawn, comp } = rig();
+  spawn("hearth", [2, 0, 0]);
+  comp("hearth", FIRE, false);       // replay / late join
+  comp("hearth", SMOKE, false);
+  check("replay reconstructs state without re-performing the event", events.length === 0);
+}
+{
+  const { ag, events, spawn, comp } = rig("emitters", [0, 0]);
+  spawn("bonfire", [400, 0, 0]);
+  comp("bonfire", FIRE);
+  check("a fire lit across the world is not a percept", events.length === 0);
+  check("...but it is still in look()", ag.look().includes("emitting fire"));
+}
+{
+  const { events, spawn, comp } = rig("antra");
+  spawn("hearth", [1, 0, 0]);
+  comp("hearth", FIRE, true, "antra");
+  check("your own authoring is not delivered back to you as an event", events.length === 0);
+}
+{
+  // Two residents beside the same hearth each hear it once — and derive the
+  // same emitter, because the seed is the entity's, not the session's.
+  const one = rig("one", [1, 0]);
+  const two = rig("two", [-1, 0]);
+  for (const r of [one, two]) { r.spawn("hearth", [0, 0, 0]); r.comp("hearth", FIRE); }
+  check("two residents each receive exactly one event",
+    one.events.length === 1 && two.events.length === 1);
+  check("...and the same text about the same fire", one.events[0].text === two.events[0].text);
+}
+{
+  // Nothing about a NON-particles component changed.
+  const { events, spawn, A } = rig();
+  spawn("swing", [1, 0, 0]);
+  A.applyEntry({ verb: "comp", args: { id: "swing", type: "sockets", data: { seat: { pos: [0, 0.5, 0] } } }, ts: T0, seq: 4, actor: "antra" }, true);
+  check("other component types narrate nothing (scope fence)", events.length === 0);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/tools/particles-probe.ts
+++ b/tools/particles-probe.ts
@@ -1,0 +1,115 @@
+// particles-probe — the `particles` component end-to-end through a REAL
+// sequencer and a REAL embodied body: author an emitter over websockets,
+// watch the flight recorder explain an unrenderable one, and confirm that a
+// resident who joins afterwards SEES the fire in look() without being told it
+// was just lit. Scratch use only (not part of the pure suite).
+//
+//   WORLDS_DIR=$(mktemp -d) JOIN_TOKEN=test-door PORT=8996 bun run server/server.ts &
+//   WORLD_URL=ws://localhost:8996/ws JOIN_TOKEN=test-door bun tools/particles-probe.ts
+
+// Shorten the world-change coalescing window so the probe doesn't wait four
+// seconds per leg. agent.ts reads it at module load, so the import must come
+// after (a static import would hoist above this line).
+process.env.EW_EMITTER_COALESCE_SEC = "1";
+const WINDOW = 1000;
+const { WorldAgent } = await import("../mcpl/agent.ts");
+
+const URL = process.env.WORLD_URL ?? "ws://localhost:8996/ws";
+const TOKEN = process.env.JOIN_TOKEN ?? "test-door";
+const world = `partprobe-${Math.random().toString(36).slice(2, 8)}`;
+
+function connect(id: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(URL);
+    const state: any = { ws, entries: [], snapshot: null, live: [], debug: [] };
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", token: TOKEN, world, id }));
+    ws.onmessage = (m: MessageEvent) => {
+      const msg = JSON.parse(String(m.data));
+      if (msg.type === "snapshot") { state.snapshot = msg.state; state.entries = msg.entries ?? []; resolve(state); }
+      if (msg.type === "log") state.live.push(msg.entry);
+      if (msg.type === "debug") state.debug = msg.events ?? [];
+    };
+    ws.onerror = (e: unknown) => reject(e);
+  });
+}
+const send = (c: any, verb: string, args: unknown) => c.ws.send(JSON.stringify({ type: "verb", verb, args }));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let fails = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  console.log(`${ok ? "  ok  " : "FAIL  "}${name}${!ok && detail ? ` — ${detail}` : ""}`);
+  if (!ok) fails++;
+};
+
+const FIRE = {
+  preset: "fire", seed: 1234, origin: [0, 0.25, 0], count: 150, quality: "auto",
+  texture: "eidoverse/assets/particle_textures/flame_05.png",
+};
+
+// ---- author -----------------------------------------------------------------
+const author = await connect("probe-author");
+send(author, "spawn", { id: "hearth", lib: "deco/bench.glb", pos: [0, 0, 0], yaw: 0 });
+send(author, "comp", { id: "hearth", type: "particles", data: FIRE });
+await sleep(400);
+
+const compEntry = author.live.find((e: any) => e.verb === "comp" && e.args?.type === "particles");
+check("the emitter is an ordinary logged component", Boolean(compEntry));
+check("...authored by whoever authored it", compEntry?.actor === "probe-author");
+check("...and the log carries the bag verbatim, no per-particle entries",
+  JSON.stringify(compEntry?.args?.data) === JSON.stringify(FIRE)
+  && author.live.filter((e: any) => e.verb === "comp").length === 1);
+
+// ---- a body that arrives afterwards -----------------------------------------
+// Everything below rides the REAL join: snapshot → entries → fold, exactly the
+// path a resident's body takes.
+const body = new WorldAgent({ url: URL, name: "probe-body", world });
+(process.env as Record<string, string>).WORLD_TOKEN ??= TOKEN;
+const heard: any[] = [];
+body.onEvent = (ev: any) => { if (ev.kind === "world-change") heard.push(ev); };
+await body.connect();
+await sleep(600);
+
+const seen = body.look();
+check("a late joiner's look() names the emitter semantically", /\[hearth\][^\n]*emitting fire/.test(seen),
+  seen.split("\n").find((l: string) => l.includes("hearth")));
+check("...with the authored local origin", seen.includes("local origin [0, 0.25, 0]"));
+check("...and the replay did NOT re-perform the lighting as a live event", heard.length === 0);
+
+// ---- a live change, with a body standing there -------------------------------
+send(author, "comp", { id: "hearth", type: "particles", data: { ...FIRE, preset: "smoke" } });
+await sleep(600);
+check("a live change IS heard, once", heard.length === 1, `got ${heard.length}`);
+check("...carrying actor, entity and both states",
+  heard[0]?.text?.includes("probe-author") && heard[0]?.text?.includes("[hearth]")
+  && heard[0]?.text?.includes("smoke"), heard[0]?.text);
+check("the body's look() now reports smoke", /\[hearth\][^\n]*emitting smoke/.test(body.look()));
+
+// ---- the flight recorder explains an emitter that will not emit --------------
+send(author, "comp", { id: "hearth", type: "particles", data: { preset: "plasma", glow: true } });
+await sleep(500);
+author.ws.send(JSON.stringify({ type: "debug", limit: 30 }));
+await sleep(400);
+const lint = author.debug.filter((d: any) => d.kind === "particles-lint");
+check("an unrenderable preset lands in the flight recorder", lint.length >= 1, JSON.stringify(author.debug.slice(-3)));
+check("...naming the preset and what would have worked",
+  lint.some((d: any) => String(d.why).includes("plasma") && String(d.why).includes("fire")));
+check("...and it is advisory: the component still folded",
+  Boolean(author.live.find((e: any) => e.args?.data?.preset === "plasma")));
+check("...and still reads as an emitter to a resident",
+  /\[hearth\][^\n]*emitting "plasma"/.test(body.look()));
+
+// ---- put it out --------------------------------------------------------------
+// Past the open coalescing window first: the plasma change above is still
+// folding, and an ending inside that window is (correctly) reported when the
+// window closes rather than the instant it lands.
+await sleep(WINDOW * 2);
+heard.length = 0;
+send(author, "comp", { id: "hearth", type: "particles", data: null });
+await sleep(WINDOW * 2);
+check("removing the component ends the emitter in perception", !body.look().includes("emitting"));
+check("...and is heard as an ending", heard.length === 1 && heard[0].text.includes("puts out"), heard[0]?.text);
+
+body.close();
+author.ws.close();
+console.log(fails ? `\n${fails} FAILED` : "\nall probe checks passed");
+process.exit(fails ? 1 : 0);

--- a/tools/particles-test.ts
+++ b/tools/particles-test.ts
@@ -1,0 +1,245 @@
+// The `particles` component's meaning + lifecycle, without a browser.
+//
+//   bun run tools/particles-test.ts
+//
+// Three legs, matching eidoverse-worlds #25's acceptance list:
+//
+//   1. DECLARATION  — declared presets, bounded overrides, unknown values that
+//      fail LEGIBLY, and a seed that is deterministic, persistent and shared.
+//   2. LIFECYCLE    — attach → replace → remove → late join, with no duplicate
+//      per-frame hooks and no leaked GPU resources, driven against a stand-in
+//      for the upstream builder that behaves exactly as it does today
+//      (pushes its update into the global array, hands back no dispose).
+//   3. PERCEPTION   — what look() says, and what a live change narrates as.
+//
+// Every check here fails against the old behavior by construction: none of
+// this existed.
+
+import {
+  PARTICLE_PRESETS, PARTICLE_MAX_COUNT, normalizeParticles, resolvedCount,
+  describeParticles, emitterTransition, transitionLine, emitterSeed,
+  mulberry32, withSeededRandom,
+} from "../client/lib/particles.js";
+import { makeEmitterRegistry, retireEmitter } from "../client/lib/emitter_field.js";
+
+let passed = 0, failed = 0;
+function check(name: string, ok: unknown, detail = "") {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+// ---- 1. declaration --------------------------------------------------------
+console.log("\ndeclaration — presets, bounds, legible failure\n");
+
+const fire = normalizeParticles({ preset: "fire", origin: [0, 0.25, 0] }, { entityId: "hearth" });
+check("a declared preset normalizes", fire.ok === true);
+check("count defaults from the preset", fire.ok && fire.emitter.count === PARTICLE_PRESETS.fire.count);
+check("origin is carried verbatim", fire.ok && JSON.stringify(fire.emitter.origin) === "[0,0.25,0]");
+
+const bogus = normalizeParticles({ preset: "plasma" }, { entityId: "hearth" });
+check("an unknown preset does not render", bogus.ok === false);
+check("...and says WHY, by name, listing what would work",
+  !bogus.ok && bogus.why.includes("plasma") && bogus.why.includes("fire"));
+check("...and stays legible as an emitter anyway",
+  describeParticles({ preset: "plasma" }).startsWith("emitting")
+  && describeParticles({ preset: "plasma" }).includes("unknown"));
+
+const huge = normalizeParticles({ preset: "fire", count: 5_000_000 }, { entityId: "hearth" });
+check("an absurd count is clamped, not honoured", huge.ok && huge.emitter.count === PARTICLE_MAX_COUNT);
+check("...and the clamp is reported", huge.ok && huge.notes.some((n: string) => n.includes("count clamped")));
+
+const far = normalizeParticles({ preset: "fire", origin: [0, 0, 400] }, { entityId: "hearth" });
+check("origin stays entity-relative (bounded)", far.ok && far.emitter.origin[2] === 8);
+check("...and says so", far.ok && far.notes.some((n: string) => n.includes("entity-relative")));
+
+const junk = normalizeParticles({ preset: "fire", wobble: 3, spin: true }, { entityId: "hearth" });
+check("params the evaluator ignores are named, not dropped in silence",
+  junk.ok && junk.notes.some((n: string) => n.includes("wobble") && n.includes("spin")));
+
+const badTex = normalizeParticles({ preset: "fire", texture: "../../etc/passwd" }, { entityId: "hearth" });
+check("a texture outside the particle library is refused", badTex.ok && badTex.emitter.texture === undefined);
+const goodTex = normalizeParticles(
+  { preset: "fire", texture: "eidoverse/assets/particle_textures/flame_05.png" }, { entityId: "hearth" });
+check("a texture inside it is kept", goodTex.ok && goodTex.emitter.texture!.endsWith("flame_05.png"));
+
+check("a non-object bag fails legibly", normalizeParticles(42 as unknown as object).ok === false);
+check("origin nonsense degrades to the entity's own origin",
+  (() => { const r = normalizeParticles({ preset: "fire", origin: "here" }, { entityId: "h" });
+    return r.ok && JSON.stringify(r.emitter.origin) === "[0,0,0]"; })());
+
+// determinism / persistence / sharedness of the seed
+check("an authored seed is the seed",
+  emitterSeed("hearth", { preset: "fire", seed: 1234 }) === 1234);
+check("an unauthored seed is derived, not rolled",
+  emitterSeed("hearth", { preset: "fire" }) === emitterSeed("hearth", { preset: "fire" }));
+check("...and is per-entity (two hearths are not the same fire)",
+  emitterSeed("hearth", { preset: "fire" }) !== emitterSeed("brazier", { preset: "fire" }));
+check("...and survives a re-author of the same bag (replay-stable)",
+  normalizeParticles({ preset: "fire" }, { entityId: "hearth" }).emitter.seed
+  === normalizeParticles({ preset: "fire" }, { entityId: "hearth" }).emitter.seed);
+
+const drawA: number[] = [], drawB: number[] = [];
+withSeededRandom(99, () => { for (let i = 0; i < 8; i++) drawA.push(Math.random()); });
+withSeededRandom(99, () => { for (let i = 0; i < 8; i++) drawB.push(Math.random()); });
+check("the same seed draws the same spawn attributes on two clients",
+  JSON.stringify(drawA) === JSON.stringify(drawB));
+check("a different seed does not", (() => {
+  const c: number[] = [];
+  withSeededRandom(100, () => { for (let i = 0; i < 8; i++) c.push(Math.random()); });
+  return JSON.stringify(c) !== JSON.stringify(drawA);
+})());
+const realRandom = Math.random;
+withSeededRandom(1, () => {});
+check("Math.random is put back afterwards", Math.random === realRandom);
+try { withSeededRandom(1, () => { throw new Error("boom"); }); } catch { /* expected */ }
+check("...even when the build throws", Math.random === realRandom);
+check("the seeded stream is in range",
+  Array.from({ length: 200 }, mulberry32(7)).every((v) => v >= 0 && v < 1));
+
+// quality reduces DRAWN sprites only
+const emitter = normalizeParticles({ preset: "fire", count: 200 }, { entityId: "hearth" }).emitter;
+check("a low tier draws fewer sprites", resolvedCount(emitter, "low") === 50);
+check("...while the declared count is unchanged (a shared fact)", emitter.count === 200);
+check("an unknown tier draws everything", resolvedCount(emitter, "ludicrous") === 200);
+
+// ---- 2. lifecycle ----------------------------------------------------------
+console.log("\nlifecycle — attach, replace, remove, late join, no hook growth\n");
+
+// Stand-in for eidoverse/particles.js AS IT IS TODAY: it makes a thing, pushes
+// its update into the global hook array, and offers no way back out. If
+// upstream grows a dispose(), this stub is what has to change first.
+type Sys = { update: () => void; disposed: number; count: number; inScene: boolean };
+function makeUpstreamStub(autos: (() => void)[]) {
+  const built: Sys[] = [];
+  return {
+    built,
+    build(emitter: { count: number }) {
+      const sys: Sys = { update: () => {}, disposed: 0, count: emitter.count, inScene: true };
+      autos.push(sys.update);                     // exactly what makeParticles does
+      built.push(sys);
+      return {
+        update: sys.update,
+        dispose() { sys.disposed++; sys.inScene = false; },
+        sys,
+      };
+    },
+  };
+}
+
+{
+  const autos: (() => void)[] = [() => {}];       // the sky already has one
+  const up = makeUpstreamStub(autos);
+  const reg = makeEmitterRegistry({ autos, build: (e: any) => up.build(e) });
+  const base = autos.length;
+
+  const fireE = normalizeParticles({ preset: "fire" }, { entityId: "hearth" }).emitter;
+  await reg.apply("hearth", fireE);
+  check("attach registers exactly one hook", autos.length === base + 1);
+  check("attach builds exactly one system", up.built.length === 1);
+
+  await reg.apply("hearth", fireE);
+  check("re-authoring the identical bag rebuilds nothing", up.built.length === 1);
+  check("...and does not grow hooks", autos.length === base + 1);
+
+  const smokeE = normalizeParticles({ preset: "smoke" }, { entityId: "hearth" }).emitter;
+  await reg.apply("hearth", smokeE);
+  check("replace builds the new emitter", up.built.length === 2);
+  check("replace RETIRES the old one", up.built[0].disposed === 1);
+  check("replace leaves one hook, not two", autos.length === base + 1);
+  check("...and only the survivor is in the scene", up.built[0].inScene === false && up.built[1].inScene === true);
+
+  reg.retire("hearth");
+  check("remove disposes", up.built[1].disposed === 1);
+  check("remove unhooks — the array is back where it started", autos.length === base);
+  check("remove is idempotent", reg.retire("hearth") === false && autos.length === base);
+  check("the registry is empty", reg.size === 0);
+
+  // late join: the whole log replays, every entry through the same path
+  await reg.apply("hearth", fireE);
+  check("a late joiner folding the same log gets one emitter", reg.size === 1 && up.built.length === 3);
+  check("...with the same seed the live clients have", up.built.length === 3 && fireE.seed === emitterSeed("hearth", { preset: "fire" }));
+  check("...and one hook", autos.length === base + 1);
+
+  // ten replaces in a row — the shape of someone tuning a live emitter
+  for (let i = 0; i < 10; i++) {
+    await reg.apply("hearth", normalizeParticles({ preset: "fire", size: 0.4 + i * 0.01 }, { entityId: "hearth" }).emitter);
+  }
+  check("ten tuning passes leave ONE hook", autos.length === base + 1);
+  check("...and one live system", up.built.filter((s) => s.disposed === 0).length === 1);
+  reg.retireAll();
+  check("retireAll returns the hook array to the sky's own", autos.length === base);
+}
+
+{
+  // A build that finishes after its entity was already replaced or removed.
+  const autos: (() => void)[] = [];
+  const up = makeUpstreamStub(autos);
+  let release: (() => void) | null = null;
+  const slow = new Promise<void>((r) => { release = r; });
+  const reg = makeEmitterRegistry({
+    autos,
+    build: async (e: any) => { await slow; return up.build(e); },
+  });
+  const p = reg.apply("hearth", normalizeParticles({ preset: "fire" }, { entityId: "hearth" }).emitter);
+  reg.retire("hearth");                            // removed while the texture downloads
+  release!();
+  await p;
+  check("a build that lands after removal retires itself", up.built[0]?.disposed === 1);
+  check("...and leaves no hook behind", autos.length === 0);
+  check("...and no registry entry", reg.size === 0);
+}
+
+{
+  // A failing build must not strand a slot or a hook.
+  const autos: (() => void)[] = [];
+  const reg = makeEmitterRegistry({ autos, build: () => { throw new Error("no scene"); }, onError: () => {} });
+  await reg.apply("hearth", normalizeParticles({ preset: "fire" }, { entityId: "hearth" }).emitter);
+  check("a failed build leaves nothing behind", reg.size === 0 && autos.length === 0);
+}
+
+{
+  // Hooks come off by identity — an emitter must never unhook the sky's.
+  const skyHook = () => {};
+  const autos: (() => void)[] = [skyHook];
+  const handle = { update: () => {}, dispose() {} };
+  autos.unshift(handle.update);                    // registered BEFORE the sky's
+  retireEmitter(handle as any, autos);
+  check("retirement removes its own hook by identity", autos.length === 1 && autos[0] === skyHook);
+  retireEmitter(handle as any, autos);
+  check("retiring twice is a no-op", autos.length === 1 && autos[0] === skyHook);
+}
+
+// ---- 3. perception ---------------------------------------------------------
+console.log("\nperception — what look() names, and what a change narrates as\n");
+
+const desc = describeParticles({ preset: "fire", origin: [0, 0.25, 0] });
+check("look() names the semantic emitter", desc.startsWith("emitting fire"));
+check("...says where on the entity it is, in local coordinates", desc.includes("local origin [0, 0.25, 0]"));
+check("...says it is active", desc.includes("active"));
+check("...does NOT enumerate sprites", !/\d{2,}\s*(sprites|particles\b\s*\d)/.test(desc) && !desc.includes("count"));
+check("...and claims no heat, light, sound or contact",
+  !/(warm|heat|hot|light|glow|sound|crackl|touch)/i.test(desc));
+check("a bare `components: particles` is not what anyone sees", !desc.includes("components:"));
+
+check("begin/change/end are distinguished",
+  emitterTransition(null, { preset: "fire" })!.kind === "begin"
+  && emitterTransition({ preset: "fire" }, { preset: "smoke" })!.kind === "change"
+  && emitterTransition({ preset: "fire" }, null)!.kind === "end");
+check("an identical re-author is not a change", emitterTransition({ preset: "fire" }, { preset: "fire" }) === null);
+check("nothing to nothing is nothing", emitterTransition(null, null) === null);
+
+const beginLine = transitionLine("antra", "hearth", emitterTransition(null, { preset: "fire" }));
+check("the live line carries actor, entity and preset",
+  beginLine!.includes("antra") && beginLine!.includes("[hearth]") && beginLine!.includes("fire"));
+const changeLine = transitionLine("antra", "hearth", emitterTransition({ preset: "fire" }, { preset: "smoke" }));
+check("a preset swap narrates as a change with both states",
+  changeLine!.includes("fire") && changeLine!.includes("smoke"));
+const tuneLine = transitionLine("antra", "hearth",
+  emitterTransition({ preset: "fire", size: 0.5 }, { preset: "fire", size: 0.6 }));
+check("a same-preset retune narrates as a retune", tuneLine!.includes("retunes"));
+const endLine = transitionLine("antra", "hearth", emitterTransition({ preset: "fire" }, null));
+check("an end narrates as an end", endLine!.includes("puts out"));
+check("no line for a non-change", transitionLine("antra", "hearth", null) === null);
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed) process.exit(1);

--- a/tools/particles-test.ts
+++ b/tools/particles-test.ts
@@ -20,7 +20,12 @@ import {
   describeParticles, emitterTransition, transitionLine, emitterSeed,
   mulberry32, withSeededRandom,
 } from "../client/lib/particles.js";
-import { makeEmitterRegistry, retireEmitter } from "../client/lib/emitter_field.js";
+import {
+  makeEmitterRegistry, retireEmitter, retireRawSystem, adoptSystem,
+} from "../client/lib/emitter_field.js";
+import {
+  autoHooks, ownHook, pushHostHook, releaseHook, isHostOwned, claimUnowned,
+} from "../client/lib/autohooks.js";
 
 let passed = 0, failed = 0;
 function check(name: string, ok: unknown, detail = "") {
@@ -101,6 +106,21 @@ const emitter = normalizeParticles({ preset: "fire", count: 200 }, { entityId: "
 check("a low tier draws fewer sprites", resolvedCount(emitter, "low") === 50);
 check("...while the declared count is unchanged (a shared fact)", emitter.count === 200);
 check("an unknown tier draws everything", resolvedCount(emitter, "ludicrous") === 200);
+
+// The two tiers COMPOSE, and neither may raise the other: the authored
+// `quality` is a shared upper bound, the client tier a local budget.
+const authoredLow = normalizeParticles({ preset: "fire", count: 200, quality: "low" }, { entityId: "h" }).emitter;
+check("authored quality is carried", authoredLow.quality === "low");
+check("authored low + client high stays low (an author's cap is not local)",
+  resolvedCount(authoredLow, "high") === 50);
+check("authored low + client auto stays low", resolvedCount(authoredLow, "auto") === 50);
+const authoredHigh = normalizeParticles({ preset: "fire", count: 200, quality: "high" }, { entityId: "h" }).emitter;
+check("authored high + client low obeys the LOCAL budget (the governor is not overruled)",
+  resolvedCount(authoredHigh, "low") === 50);
+check("authored med + client med does not compound", resolvedCount(
+  normalizeParticles({ preset: "fire", count: 200, quality: "med" }, { entityId: "h" }).emitter, "med") === 100);
+check("authored auto is an opinion-free identity",
+  resolvedCount(emitter, "med") === 100 && resolvedCount(emitter, "auto") === 200);
 
 // ---- 2. lifecycle ----------------------------------------------------------
 console.log("\nlifecycle — attach, replace, remove, late join, no hook growth\n");
@@ -207,6 +227,93 @@ function makeUpstreamStub(autos: (() => void)[]) {
   check("retirement removes its own hook by identity", autos.length === 1 && autos[0] === skyHook);
   retireEmitter(handle as any, autos);
   check("retiring twice is a no-op", autos.length === 1 && autos[0] === skyHook);
+}
+
+// ---- 2b. a throw AFTER upstream allocation --------------------------------
+console.log("\npost-allocation faults — the window between makeParticles() and a handle\n");
+
+{
+  // The exact shape of the leak: makeParticles has already added its mesh to
+  // the scene and pushed its update; a host step after that throws, so no
+  // handle is ever returned and the registry's catch has nothing to retire.
+  const autos: (() => void)[] = [];
+  const parent = { children: [] as unknown[], remove(o: unknown) { this.children = this.children.filter((c) => c !== o); } };
+  let geoDisposed = 0, matDisposed = 0, texDisposed = 0;
+  const texture = { dispose() { texDisposed++; } };            // BORROWED, cached, shared
+  const makeRaw = () => {
+    const update = () => {};
+    const mesh: any = {
+      parent, geometry: { dispose() { geoDisposed++; } },
+      material: { dispose() { matDisposed++; }, map: texture },
+      userData: {}, position: { set() {} },
+    };
+    parent.children.push(mesh);
+    autos.push(update);                                        // upstream registers itself
+    return { mesh, update };
+  };
+
+  for (const [name, failing] of [
+    ["parenting", (s: any) => { throw new Error("parent.add failed"); }],
+    ["the tier dial", (s: any) => { s.mesh.count = 1; throw new Error("setTier failed"); }],
+    ["handle construction", (_s: any) => { throw new Error("handle failed"); }],
+  ] as const) {
+    const sys = makeRaw();
+    const before = { autos: autos.length, kids: parent.children.length };
+    let threw = false;
+    try { adoptSystem(sys, autos, failing); } catch { threw = true; }
+    check(`a throw in ${name} propagates`, threw);
+    check(`...unhooks the raw system (${name})`, autos.length === before.autos - 1);
+    check(`...detaches its mesh (${name})`, parent.children.length === before.kids - 1);
+  }
+  check("...and disposes the geometry and material it owns", geoDisposed === 3 && matDisposed === 3);
+  check("...but NEVER the borrowed texture", texDisposed === 0);
+
+  // and the happy path is untouched
+  const good = makeRaw();
+  const handle = adoptSystem(good, autos, (s: any) => ({ update: s.update, dispose() {} }));
+  check("a build that succeeds keeps its hook and its mesh",
+    autos.length === 1 && parent.children.length === 1 && handle.update === good.update);
+  retireRawSystem(good, autos);
+  check("retireRawSystem is idempotent", (retireRawSystem(good, autos), autos.length === 0));
+}
+
+// ---- 2c. hook OWNERSHIP across an async build ------------------------------
+console.log("\nhook ownership — a subsystem that claims by diff must not adopt someone else's\n");
+
+{
+  // The interleaving Mica named: the sky snapshots, THEN an emitter registers
+  // while the build is still awaiting, THEN the sky's own hook lands. An
+  // identity diff alone calls both of them the sky's.
+  const autos = autoHooks();
+  autos.length = 0;
+  const skyHookOld = () => {};
+  autos.push(skyHookOld);                                   // a previous sky's hook
+
+  const before = new Set(autos);                            // snapshotSceneOwnership()
+  const emitterHook = pushHostHook(() => {});               // …registers DURING the build
+  const skyHook = () => {}; autos.push(skyHook);            // …and the build finishes
+
+  const claimed = claimUnowned(before, autos);
+  check("the sky claims its own new hook", claimed.includes(skyHook));
+  check("...and NOT the emitter's, which arrived during the build", !claimed.includes(emitterHook));
+  check("...and not the one it already had", !claimed.includes(skyHookOld));
+
+  for (const h of claimed) releaseHook(h, autos);            // teardownSky()
+  check("teardown removes only the sky's hook",
+    autos.length === 2 && autos.includes(skyHookOld) && autos.includes(emitterHook));
+  check("the emitter is still registered and still ticking", autos.includes(emitterHook));
+  check("...and still marked as its own", isHostOwned(emitterHook));
+
+  releaseHook(emitterHook, autos);
+  check("releasing drops the mark too", !isHostOwned(emitterHook) && !autos.includes(emitterHook));
+  check("releasing twice is a no-op", releaseHook(emitterHook, autos) === false);
+
+  // ownHook marks a hook upstream registered on our behalf (makeParticles)
+  const upstreamRegistered = () => {}; autos.push(upstreamRegistered);
+  ownHook(upstreamRegistered);
+  check("a hook upstream pushed for us can still be claimed as ours",
+    !claimUnowned(new Set([skyHookOld]), autos).includes(upstreamRegistered));
+  autos.length = 0;
 }
 
 // ---- 3. perception ---------------------------------------------------------


### PR DESCRIPTION
Slice 1 of #25 — one authored `particles` component on an entity, with the lifecycle and the perception the issue asks for, and nothing beyond them. Built in a clean worktree off `main`; the shared checkout was not touched.

## What lands

The component is ordinary: builder rights, blind fold, ≤8KB, **one log entry per authoring and never one per particle**. What it declares is an emitter that hangs off the entity that owns it and rides every `place` / `mount` / `motion` that entity does.

```
comp {id: "hearth", type: "particles",
      data: {preset: "fire", seed: 1234, origin: [0, 0.25, 0], count: 150,
             texture: "eidoverse/assets/particle_textures/flame_05.png", quality: "auto"}}
comp {id: "hearth", type: "particles", data: null}      # put it out
```

Three modules, split the way flora is:

| file | role |
|---|---|
| `client/lib/particles.js` | what a `particles` bag MEANS — presets, bounded overrides, the seed, how an emitter reads in prose. Imported **verbatim** by the browser host, the mcpl agent and the sequencer's lint |
| `client/lib/emitter_field.js` | lifecycle/registry — DOM-free, THREE-free, unit-tested |
| `client/lib/emitters.js` | the browser hosting |

## The upstream seam (please read — there is a decision here)

Both gaps #25 names are still true of `eidoverse/particles.js` **on `origin/main`** (byte-identical to our pinned checkout): `makeParticles` seeds every instance from `Math.random()`, and it has no `dispose()` — it pushes its billboard `update` into the global `_autoParticleSystems` and hands back no way out.

Per the fences I was given, `particles.js` is **not** copied or forked into worlds. Instead the adapter owns both facts, each at exactly **one call site**:

- **determinism** — a scoped `Math.random` swap around the (fully synchronous) build, restored in a `finally`;
- **retirement** — the returned `update` identity-spliced out of the hook array, geometry + material disposed, mesh detached. The sprite **texture is explicitly not disposed**: it is cached and shared across every emitter in the world, so disposing a borrowed one blanks every other fire.

This is option (b) of the three I put to the steward. When the engine grows a `seed` option and a `dispose()` — as `createFlora` already did upstream — this file **loses** code rather than gaining a second path. A narrow upstream PR remains the cleaner long-term home; I have no push access to `SkyeShark/eidoverse-video` on this credential, so opening one means a fork and is a call for a human, not for me.

## Agent perception

- `look()` names the **semantic emitter on the owning entity** — `[hearth] … — emitting fire (particles; local origin [0, 0.25, 0]; active)`. Never a sprite inventory, never a bare `components: particles`, and **no claim of heat, light, sound or contact**: nothing models those, and a resident who reads "warm" would act on it.
- A live attach/replace/remove near you is **one** ambient percept, tagged `eidoverse:world-change` + `eidoverse:particles` (both declared in the ontology with descriptions), carrying actor, entity, preset and begin/change/end. Coalesced per `(entity, component)`: the first change speaks at once, everything in the following quiet window folds into at most one further line describing the net result — twenty slider drags are one "retunes", a fire→smoke→out sequence still ends up truthful, and a burst that returns to the announced state stays silent. It feeds the activity digest and is held for pull-only hosts exactly as weather is.
- **Replay reconstructs state and stops there.** A fire lit last week is in `look()`, not in your ears.
- An **unrenderable preset stays legible as an emitter**, and the flight recorder says why (`world_debug`, kind `particles-lint`, from the same validator the renderer uses) instead of leaving the author to ask someone with a GPU what they can see.

## Quality

Tiers scale **drawn** sprites only — an `InstancedMesh.count`, no rebuild, no hitch (the lever flora's density dial pulls). Preset, state, seed and provenance are shared facts across clients. Wired into the perf governor after clouds and lights, before the meadow.

## One fix outside the feature, with a receipt

The sky claimed its per-frame hooks by array **length**, so anything registering a hook after a sky build was truncated away by the next rebuild. Reproduced in a real browser: with the old code the hearth's fire stayed in the scene and **stopped billboarding** (`_autoParticleSystems.length` went 1 → 0 across a sky build and again across a teardown); with the fix it stays 1 → 1. Hooks are now claimed by identity — exactly how the sky already claims its scene children two lines above.

## Receipts

| suite | result |
|---|---|
| `tools/particles-test.ts` (new) | 65/65 — declaration, determinism, lifecycle, perception |
| `tools/emitter-percept-test.ts` (new) | 28/28 — look(), live percept, coalescing, replay/distance/self |
| `tools/particles-probe.ts` (new) | 15/15 — end-to-end through a real sequencer and a real embodied body |
| `tools/comptest.ts` (+3) | 28/28 |
| permtest / forecast / skywatch / look / approach-seed / flora / collide-fold / denoise / manifest | 23 / 40 / 27 / 4 / 8 / 42 / 6 / all / 28 — all green |
| `mcpl/playtest.ts` | all checks passed |
| client bundle | builds; only the two pre-existing `three` export warnings |

Each new test fails against the old behaviour by construction — none of this existed.

**Visual acceptance, done, not deferred:** authored a fire on a scratch sequencer and looked at it in Chrome with real WebGPU at 61fps. Flame renders (camera-facing, no square quads, no GTAO rectangles), the emitter is a child of the entity at the authored local origin, attach → replace(fire→smoke) → remove leaves **one** system and **one** hook throughout and returns the hook array to zero, and a page reload rebuilds the identical emitter from the log. What still wants a human's eyes is FC's actual hearth in the commons — a crate stood in for it here, since no live world was touched.

**Not in this slice**, per the scope fence: fireflies/embers composition, porchlight breathing, authored brushes, and anything about a resident whose *body* is an emitter field (that needs #14's identity-bearing seed and body/contact contract — an ordinary emitter's persistent per-entity seed is not a person).

No live-world mutation, no deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)