### PR TITLE
ambient: place-sound as a production component (#31)

### DIFF
--- a/client/lib/ambient.js
+++ b/client/lib/ambient.js
@@ -12,9 +12,12 @@
 // tested is the composition path we actually want.
 //
 // data: { src, gain?, radius?, loop? }
-//   src    — a URL the client can fetch (our porch ambience by default)
-//   gain   — 0..1 at the source, before distance and before the world slider
-//   radius — metres to silence; inside 1/4 of it you get full gain
+//   src    — SAME-ORIGIN path only (e.g. assets/x.ogg). A component any
+//            builder can author must not make every client fetch an
+//            arbitrary external URL — that is an IP/tracking surface
+//            (#26/#31 review). Content-addressed media can widen this later.
+//   gain   — source gain, clamped to [0, 1]
+//   radius — metres to silence, clamped to [1, 60]; inside 1/4 = full gain
 //
 // Audio: WebAudio, not <audio>, so distance and the category slider compose
 // as one gain chain instead of fighting over element.volume. House standard
@@ -37,12 +40,23 @@ function audioCtx() {
   return ctx;
 }
 
+/** same-origin gate — returns a safe URL string or null */
+export function ambientSrc(raw) {
+  try {
+    const u = new URL(raw ?? DEFAULT_SRC, location.origin);
+    if (u.origin !== location.origin) return null;
+    return u.href;
+  } catch { return null; }
+}
+
 function attach(id, data) {
   detach(id);
   if (!data) return;
+  const src = ambientSrc(data.src);
+  if (!src) { report('ambient refuse', `cross-origin src refused: ${data.src}`); return; }
   try {
     const c = audioCtx();
-    const el = new Audio(data.src ?? DEFAULT_SRC);
+    const el = new Audio(src);
     el.loop = data.loop !== false;
     el.crossOrigin = 'anonymous';
     const node = c.createMediaElementSource(el);
@@ -66,7 +80,11 @@ function detach(id) {
 }
 
 bus.on('comp', ({ id, type, data }) => { if (type === 'ambient') attach(id, data); });
-bus.on('entity', ({ id, gone }) => { if (gone) detach(id); });
+// world.js emits { kind: 'remove' } — the fixture listened for a { gone }
+// field that nothing emits, so removal cleanup only happened incidentally
+// on a later frame (#26 review catch)
+bus.on('entity', ({ id, kind }) => { if (kind === 'remove') detach(id); });
+bus.on('world-reset', () => { for (const id of [...sources.keys()]) detach(id); });
 
 /** Per-frame-ish: distance rolloff × the WORLD category slider. Voices and
  *  world are separate categories on purpose — muting people must not mute
@@ -77,16 +95,18 @@ export function updateAmbient() {
   for (const [id, s] of sources) {
     const obj = entities.get(id);
     if (!obj) { detach(id); continue; }
-    const radius = s.data.radius ?? 18;
+    const radius = Math.max(1, Math.min(60, s.data.radius ?? 18));
     const d = obj.position.distanceTo(myState.pos);
     const near = radius * 0.25;
     const roll = d <= near ? 1 : Math.max(0, 1 - (d - near) / (radius - near));
-    const target = roll * (s.data.gain ?? 0.7) * wv;
+    const target = roll * Math.max(0, Math.min(1, s.data.gain ?? 0.7)) * wv;
     // setTargetAtTime, never a raw assignment: stepping a gain clicks
     s.gain.gain.setTargetAtTime(target, audioCtx().currentTime, 0.08);
   }
 }
 
 /** harness/debug: what is audible and why */
+export const ambientCount = () => sources.size;
+
 export const ambientDebug = () => Object.fromEntries(
   [...sources].map(([id, s]) => [id, { src: s.data.src ?? DEFAULT_SRC, gain: +s.gain.gain.value.toFixed(3) }]));

--- a/client/lib/ambient.js
+++ b/client/lib/ambient.js
@@ -12,12 +12,19 @@
 // tested is the composition path we actually want.
 //
 // data: { src, gain?, radius?, loop? }
-//   src    — SAME-ORIGIN path only (e.g. assets/x.ogg). A component any
-//            builder can author must not make every client fetch an
-//            arbitrary external URL — that is an IP/tracking surface
-//            (#26/#31 review). Content-addressed media can widen this later.
+//   src    — a CONTENT-ADDRESSED store path (store/audio/<hash>.<ext>),
+//            minted by POST /upload?as=audio (sniffed, capped, hashed).
+//            Never a URL: a component any builder can author must not turn
+//            arbitrary endpoints into every client's audio fetch (#31/#45
+//            review). Served via /library/ with immutable caching.
 //   gain   — source gain, clamped to [0, 1]
 //   radius — metres to silence, clamped to [1, 60]; inside 1/4 = full gain
+//   loop   — loop-only for now: the blind fold reconstructs components for
+//            every late join, so a one-shot would replay per arrival.
+//
+// The server lints all of this at AUTHOR time; this file re-checks because
+// history can predate the lint — malformed persisted components are refused
+// LEGIBLY (ambientDebug().refused carries the reason) and stay in the log.
 //
 // Audio: WebAudio, not <audio>, so distance and the category slider compose
 // as one gain chain instead of fighting over element.volume. House standard
@@ -29,8 +36,8 @@ import { myState } from './controller.js';
 import { volumeFor } from './voiceconsent.js';
 import { report } from './core.js';
 
-const DEFAULT_SRC = 'assets/porch_ambient.ogg';
 const sources = new Map();          // entityId -> { el, node, gain, data }
+const refused = new Map();          // entityId -> reason (legible, queryable)
 let ctx = null;
 
 function audioCtx() {
@@ -40,20 +47,25 @@ function audioCtx() {
   return ctx;
 }
 
-/** same-origin gate — returns a safe URL string or null */
+/** store-path gate — returns the /library URL for a valid store src, else null */
 export function ambientSrc(raw) {
-  try {
-    const u = new URL(raw ?? DEFAULT_SRC, location.origin);
-    if (u.origin !== location.origin) return null;
-    return u.href;
-  } catch { return null; }
+  return /^store\/audio\/[0-9a-f]{16}\.(ogg|wav|mp3)$/.test(raw ?? '') ? `/library/${raw}` : null;
+}
+
+/** why a component is refusable — one truth for gate + receipts */
+export function ambientLint(data) {
+  if (!ambientSrc(data?.src)) return `src must be a store/audio/ path (got "${String(data?.src ?? '').slice(0, 80)}")`;
+  if (data.loop === false) return 'loop-only: a one-shot would replay for every late join (#31)';
+  return null;
 }
 
 function attach(id, data) {
   detach(id);
+  refused.delete(id);
   if (!data) return;
+  const why = ambientLint(data);
+  if (why) { refused.set(id, why); report('ambient refuse', `${id}: ${why}`); return; }
   const src = ambientSrc(data.src);
-  if (!src) { report('ambient refuse', `cross-origin src refused: ${data.src}`); return; }
   try {
     const c = audioCtx();
     const el = new Audio(src);
@@ -72,6 +84,7 @@ function attach(id, data) {
 }
 
 function detach(id) {
+  refused.delete(id);
   const s = sources.get(id);
   if (!s) return;
   sources.delete(id);
@@ -108,5 +121,8 @@ export function updateAmbient() {
 /** harness/debug: what is audible and why */
 export const ambientCount = () => sources.size;
 
-export const ambientDebug = () => Object.fromEntries(
-  [...sources].map(([id, s]) => [id, { src: s.data.src ?? DEFAULT_SRC, gain: +s.gain.gain.value.toFixed(3) }]));
+export const ambientDebug = () => ({
+  playing: Object.fromEntries(
+    [...sources].map(([id, s]) => [id, { src: s.data.src, gain: +s.gain.gain.value.toFixed(3) }])),
+  refused: Object.fromEntries(refused),
+});

--- a/client/lib/ambient.js
+++ b/client/lib/ambient.js
@@ -1,0 +1,92 @@
+// ambient — an `ambient` component: a looping sound that belongs to a PLACE.
+// Attach it to any entity and that thing becomes the source; walk away and it
+// fades. Same shape as picture.js (a component that hangs media on a thing),
+// same doctrine: the log says what the world contains, the client decides how
+// to make it audible.
+//
+// Workbench-only for now, deliberately: this is our test fixture for the
+// audio-category split (see voiceconsent.js). Without world sound playing,
+// "the headphone toggle silences voices but NOT the world" is an untestable
+// claim — there is nothing to not-silence. So the fixture is a real component
+// rather than a hardcoded background track, which also means the thing being
+// tested is the composition path we actually want.
+//
+// data: { src, gain?, radius?, loop? }
+//   src    — a URL the client can fetch (our porch ambience by default)
+//   gain   — 0..1 at the source, before distance and before the world slider
+//   radius — metres to silence; inside 1/4 of it you get full gain
+//
+// Audio: WebAudio, not <audio>, so distance and the category slider compose
+// as one gain chain instead of fighting over element.volume. House standard
+// −23 LUFS applies to the material, not to us; we only attenuate.
+
+import { bus } from './core.js';
+import { entities } from './world.js';
+import { myState } from './controller.js';
+import { volumeFor } from './voiceconsent.js';
+import { report } from './core.js';
+
+const DEFAULT_SRC = 'assets/porch_ambient.ogg';
+const sources = new Map();          // entityId -> { el, node, gain, data }
+let ctx = null;
+
+function audioCtx() {
+  if (!ctx) ctx = new (window.AudioContext ?? window.webkitAudioContext)();
+  // browsers start suspended until a gesture; resume opportunistically
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+  return ctx;
+}
+
+function attach(id, data) {
+  detach(id);
+  if (!data) return;
+  try {
+    const c = audioCtx();
+    const el = new Audio(data.src ?? DEFAULT_SRC);
+    el.loop = data.loop !== false;
+    el.crossOrigin = 'anonymous';
+    const node = c.createMediaElementSource(el);
+    const gain = c.createGain();
+    gain.gain.value = 0;            // rises with proximity on the first tick
+    node.connect(gain).connect(c.destination);
+    el.play().catch(() => {
+      // autoplay policy: wait for any gesture, then start
+      addEventListener('click', () => el.play().catch(() => {}), { once: true });
+    });
+    sources.set(id, { el, node, gain, data });
+  } catch (e) { report('ambient attach', e); }
+}
+
+function detach(id) {
+  const s = sources.get(id);
+  if (!s) return;
+  sources.delete(id);
+  try { s.el.pause(); s.el.src = ''; s.gain.disconnect(); s.node.disconnect(); }
+  catch (e) { report('ambient detach', e); }
+}
+
+bus.on('comp', ({ id, type, data }) => { if (type === 'ambient') attach(id, data); });
+bus.on('entity', ({ id, gone }) => { if (gone) detach(id); });
+
+/** Per-frame-ish: distance rolloff × the WORLD category slider. Voices and
+ *  world are separate categories on purpose — muting people must not mute
+ *  the place, which is precisely what this fixture proves. */
+export function updateAmbient() {
+  if (!sources.size) return;
+  const wv = volumeFor('world');
+  for (const [id, s] of sources) {
+    const obj = entities.get(id);
+    if (!obj) { detach(id); continue; }
+    const radius = s.data.radius ?? 18;
+    const d = obj.position.distanceTo(myState.pos);
+    const near = radius * 0.25;
+    const roll = d <= near ? 1 : Math.max(0, 1 - (d - near) / (radius - near));
+    const target = roll * (s.data.gain ?? 0.7) * wv;
+    // setTargetAtTime, never a raw assignment: stepping a gain clicks
+    s.gain.gain.setTargetAtTime(target, audioCtx().currentTime, 0.08);
+  }
+}
+
+/** harness/debug: what is audible and why */
+export const ambientDebug = () => Object.fromEntries(
+  [...sources].map(([id, s]) => [id, { src: s.data.src ?? DEFAULT_SRC, gain: +s.gain.gain.value.toFixed(3) }]));

--- a/client/main.js
+++ b/client/main.js
@@ -34,6 +34,7 @@ import { initConjure } from './lib/conjure.js';
 import { initVoice, micOn, isMuted, micAnalyserLevel, peerLevels } from './lib/voice.js';
 import './lib/mictoggle.js'; // mic + headphone toggles beside the HUD, both off by default
 import { initAudioPanel } from './lib/audiopanel.js';
+import { updateAmbient } from './lib/ambient.js'; // place-sound: the world plane the panel governs
 import { initSceneGraph, sceneAttach, sceneDetach } from './lib/scenegraph.js';
 import {
   toast, setHud, setHint, setAmbientHint, flashHint, buildHelp, toggleHelp,
@@ -1041,6 +1042,8 @@ function frame(now) {
     me._poseSig = myState.pose;
     if (myState.pose) me.setPose(myState.pose); else me.clearPose();
   }
+  BC('ambient');
+  updateAmbient();               // place-sound follows the listener each frame
   BC('me-update');
   updateVoiceMouths(now);        // BEFORE the avatar updates that consume it
   me?.update(dt, now);

--- a/server/server.ts
+++ b/server/server.ts
@@ -1515,6 +1515,28 @@ const server = Bun.serve({
         return new Response(JSON.stringify({ path: srel }),
           { headers: { "content-type": "application/json" } });
       }
+      if (url.searchParams.get("as") === "audio") {
+        // Referenced-sound ingestion (#31): content-addressed like models, so
+        // an `ambient` component pins exact bytes forever, with media-type
+        // sniffing and a size cap as the provenance/verification slice.
+        if (body.length > 4 * 1024 * 1024) return new Response("audio too large (4MB cap)", { status: 413 });
+        const magic4 = new DataView(body.buffer).getUint32(0, false);
+        const isOgg = magic4 === 0x4f676753;                                   // "OggS"
+        const isWav = magic4 === 0x52494646 && body.length > 12               // "RIFF"…"WAVE"
+          && new DataView(body.buffer).getUint32(8, false) === 0x57415645;
+        const isMp3 = (magic4 >>> 8) === 0x494433                              // "ID3"
+          || (body[0] === 0xff && (body[1] & 0xe0) === 0xe0);                  // bare frame sync
+        const ext = isOgg ? "ogg" : isWav ? "wav" : isMp3 ? "mp3" : null;
+        if (!ext) return new Response("not a recognized audio container (ogg/wav/mp3)", { status: 415 });
+        const ahash = new Bun.CryptoHasher("sha256").update(body).digest("hex").slice(0, 16);
+        const adir = join(OPT_DIR, "store", "audio");
+        mkdirSync(adir, { recursive: true });
+        const arel = `store/audio/${ahash}.${ext}`;
+        if (!existsSync(join(OPT_DIR, arel))) writeFileSync(join(OPT_DIR, arel), body);
+        console.log(`[upload] audio ${arel} (${(body.length / 1e3).toFixed(0)}KB) by ${upBy}`);
+        return new Response(JSON.stringify({ path: arel, bytes: body.length, type: `audio/${ext === "mp3" ? "mpeg" : ext}` }),
+          { headers: { "content-type": "application/json" } });
+      }
       if (body.length < 12 || new DataView(body.buffer).getUint32(0, true) !== 0x46546c67)
         return new Response("not a GLB container (glb/vrm)", { status: 415 });
       if (url.searchParams.get("as") === "avatar") {
@@ -2142,6 +2164,36 @@ const server = Bun.serve({
               c.world.debug("rejected", { who: c.id, verb: "comp", why: `data too large (8KB max) on ${id}.${type}` });
               ws.send(JSON.stringify({ type: "error", error: "component data too large (8KB max) — put big things in /upload and reference the path" }));
               return;
+            }
+            if (type === "ambient" && args.data !== null && args.data !== undefined) {
+              // Author-time contract (#31/#45 review): src is a content-
+              // addressed store path — a component any builder can author
+              // must not turn arbitrary URLs (or arbitrary same-origin GET
+              // endpoints) into every client's audio fetch. Loop-only until
+              // one-shots have authored replay semantics: the blind fold
+              // reconstructs components for every late join, so a one-shot
+              // would replay for each arrival. The FOLD stays blind —
+              // already-persisted data is never judged here; clients report
+              // malformed history legibly instead (ambientDebug.refused).
+              const d = args.data as Record<string, unknown>;
+              const src = String(d.src ?? "");
+              const why =
+                !/^store\/audio\/[0-9a-f]{16}\.(ogg|wav|mp3)$/.test(src)
+                  ? `ambient.src must be a store path — POST the file to /upload?as=audio and use the returned path (got "${src.slice(0, 80) || "nothing"}")`
+                : !existsSync(join(OPT_DIR, src))
+                  ? `ambient.src ${src} is not in this world's store — upload it first`
+                : d.loop === false
+                  ? "ambient is loop-only for now: a one-shot would replay for every late join (needs authored start/duration semantics — #31)"
+                : d.gain !== undefined && !(typeof d.gain === "number" && d.gain >= 0 && d.gain <= 1)
+                  ? "ambient.gain must be a number in [0, 1]"
+                : d.radius !== undefined && !(typeof d.radius === "number" && d.radius >= 1 && d.radius <= 60)
+                  ? "ambient.radius must be a number in [1, 60] metres"
+                : null;
+              if (why) {
+                c.world.debug("rejected", { who: c.id, verb: "comp", why: `ambient-lint: ${why}` });
+                ws.send(JSON.stringify({ type: "error", error: why }));
+                return;
+              }
             }
             args = { id, type, data: args.data ?? null };
           }

--- a/tools/ambient-fold-test.ts
+++ b/tools/ambient-fold-test.ts
@@ -10,7 +10,7 @@
 // rejoin byte-identically; and nothing about a refusal mutates history.
 
 const HTTP = process.env.HTTP_URL ?? "http://localhost:8995";
-const URL = process.env.WORLD_URL ?? "ws://localhost:8994/ws";
+const URL = process.env.WORLD_URL ?? "ws://localhost:8995/ws";
 const TOKEN = process.env.JOIN_TOKEN ?? "test-door";
 
 let passed = 0;
@@ -93,10 +93,27 @@ console.log(`\ngrab-vs-edit matrix — world "${WORLD}"\n`);
 // ---- a real (tiny) ogg: "OggS" magic + padding — the sniffer's contract ----
 const oggBytes = new Uint8Array(64);
 oggBytes.set([0x4f, 0x67, 0x67, 0x53]);
-const up = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}&by=foldtest`, { method: "POST", body: oggBytes });
+// The server rate-limits uploads (4/min) — a virtue in production and a trap
+// for back-to-back test runs: the second run's uploads got text/429 and the
+// json() parse exploded with a misleading "idempotency" failure. Wait out
+// the window instead of misdiagnosing the server.
+async function uploadOgg(bytes: Uint8Array): Promise<Response> {
+  for (let i = 0; i < 5; i++) {
+    const r = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}&by=foldtest`, { method: "POST", body: bytes.slice() });
+    if (r.status !== 429) return r;
+    console.log("  (429 upload rate limit — waiting 20s for the window)");
+    await new Promise((res) => setTimeout(res, 20_000));
+  }
+  throw new Error("upload rate limit never cleared");
+}
+const up = await uploadOgg(oggBytes);
 const upJson: any = up.ok ? await up.json() : null;
 check("audio upload is accepted and content-addressed", !!upJson?.path && /^store\/audio\/[0-9a-f]{16}\.ogg$/.test(upJson.path), JSON.stringify(upJson) || `${up.status}`);
-const up2 = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}&by=foldtest`, { method: "POST", body: oggBytes });
+// fresh copy: Bun detaches a typed array's buffer on first send — reusing
+// oggBytes posts an EMPTY body (the "0KB" in the server log) and the magic
+// sniff's DataView throws on it. The server was always idempotent; the
+// reused buffer was the phantom.
+const up2 = await uploadOgg(oggBytes);
 check("same bytes → same address (idempotent)", (await up2.json() as any).path === upJson.path);
 const bad = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}`, { method: "POST", body: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) });
 check("non-audio bytes are refused at the door", bad.status === 415, `${bad.status}`);

--- a/tools/ambient-fold-test.ts
+++ b/tools/ambient-fold-test.ts
@@ -1,0 +1,134 @@
+// ambient fold/rejoin — the #45 review's server-side receipts, executed
+// against a live scratch sequencer (same recipe as grabtest):
+//
+//   WORLDS_DIR=$(mktemp -d) JOIN_TOKEN=test-door PORT=8995 bun run server/server.ts &
+//   WORLD_URL=ws://localhost:8995/ws JOIN_TOKEN=test-door HTTP_URL=http://localhost:8995 bun run tools/ambient-fold-test.ts
+//
+// Proves: audio uploads are content-addressed + sniffed; ambient authorship
+// is linted with actionable sentences (store path, existence, loop-only,
+// bounds); the generic component fold stays BLIND — a valid ambient survives
+// rejoin byte-identically; and nothing about a refusal mutates history.
+
+const HTTP = process.env.HTTP_URL ?? "http://localhost:8995";
+const URL = process.env.WORLD_URL ?? "ws://localhost:8994/ws";
+const TOKEN = process.env.JOIN_TOKEN ?? "test-door";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+type Sock = {
+  ws: WebSocket;
+  msgs: any[];
+  errors: string[];
+  next(pred: string | ((m: any) => boolean), ms?: number): Promise<any>;
+  verb(verb: string, args: any): void;
+  pose(p: number[]): void;
+  settle(ms?: number): Promise<void>;
+  close(): void;
+};
+
+function open(joinMsg: Record<string, unknown>): Promise<Sock> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(URL);
+    const s: Sock = {
+      ws, msgs: [], errors: [],
+      next(pred, ms = 4000) {
+        const want = typeof pred === "string" ? (m: any) => m.type === pred : pred;
+        return new Promise((res, rej) => {
+          const hit = s.msgs.find(want);
+          if (hit) return res(hit);
+          const t0 = Date.now();
+          const iv = setInterval(() => {
+            const m = s.msgs.find(want);
+            if (m) { clearInterval(iv); res(m); }
+            else if (Date.now() - t0 > ms) { clearInterval(iv); rej(new Error(`no match in ${ms}ms`)); }
+          }, 20);
+        });
+      },
+      verb(verb, args) { ws.send(JSON.stringify({ type: "verb", verb, args })); },
+      pose(p) { ws.send(JSON.stringify({ type: "pose", pose: { p, yaw: 0, speed: 0, clip: "idle" } })); },
+      settle(ms = 300) { return new Promise((r) => setTimeout(r, ms)); },
+      close() { try { ws.close(); } catch { /* already */ } },
+    };
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", token: TOKEN, ...joinMsg }));
+    ws.onmessage = (ev) => {
+      const m = JSON.parse(String(ev.data));
+      s.msgs.push(m);
+      if (m.type === "error") s.errors.push(m.error);
+    };
+    ws.onclose = () => { /* fine */ };
+    ws.onerror = (e) => reject(e);
+    s.next("snapshot").then(() => resolve(s), reject);
+  });
+}
+
+/** Clear the error ledger, perform the act, wait for a FRESH refusal. The
+ *  naive next("error") kept matching stale errors in the message buffer —
+ *  every check read the previous step's refusal (off-by-one cascade, found
+ *  on first run). */
+async function expectErr(s: Sock, act: () => void, substr: string): Promise<string> {
+  s.errors.length = 0;
+  act();
+  const t0 = Date.now();
+  while (Date.now() - t0 < 4000) {
+    if (s.errors.length) return s.errors.find((e) => e.includes(substr)) ?? `WRONG ERROR: ${s.errors.join("; ")}`;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return "NO ERROR ARRIVED";
+}
+
+const placeOf = (m: any, id: string) =>
+  m.type === "log" && m.entry?.verb === "place" && m.entry?.args?.id === id ? m.entry : null;
+
+const WORLD = `grabtest-${Math.random().toString(36).slice(2, 8)}`;
+
+console.log(`\ngrab-vs-edit matrix — world "${WORLD}"\n`);
+
+// ---- build: an owner furnishes the room -------------------------------------
+
+// ---- a real (tiny) ogg: "OggS" magic + padding — the sniffer's contract ----
+const oggBytes = new Uint8Array(64);
+oggBytes.set([0x4f, 0x67, 0x67, 0x53]);
+const up = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}&by=foldtest`, { method: "POST", body: oggBytes });
+const upJson: any = up.ok ? await up.json() : null;
+check("audio upload is accepted and content-addressed", !!upJson?.path && /^store\/audio\/[0-9a-f]{16}\.ogg$/.test(upJson.path), JSON.stringify(upJson) || `${up.status}`);
+const up2 = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}&by=foldtest`, { method: "POST", body: oggBytes });
+check("same bytes → same address (idempotent)", (await up2.json() as any).path === upJson.path);
+const bad = await fetch(`${HTTP}/upload?as=audio&token=${TOKEN}`, { method: "POST", body: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) });
+check("non-audio bytes are refused at the door", bad.status === 415, `${bad.status}`);
+const SRC = upJson.path;
+
+const alice = await open({ name: "alice" });
+alice.verb("spawn", { id: "fount", lib: "deco/boulder.glb", pos: [1, 0, 0], yaw: 0 });
+await alice.settle();
+
+// ---- author-time lint: every refusal is a sentence someone can act on -----
+let err = await expectErr(alice, () => alice.verb("comp", { id: "fount", type: "ambient", data: { src: "https://evil.example/x.mp3" } }), "store path");
+check("URL src refused with the upload recipe in the sentence", err.includes("/upload?as=audio"), err);
+err = await expectErr(alice, () => alice.verb("comp", { id: "fount", type: "ambient", data: { src: "store/audio/ffffffffffffffff.ogg" } }), "not in this world's store");
+check("well-formed but absent hash refused (existence is checked)", !err.startsWith("WRONG"), err);
+err = await expectErr(alice, () => alice.verb("comp", { id: "fount", type: "ambient", data: { src: SRC, loop: false } }), "loop-only");
+check("loop:false refused (late join would replay it)", !err.startsWith("WRONG"), err);
+err = await expectErr(alice, () => alice.verb("comp", { id: "fount", type: "ambient", data: { src: SRC, gain: 40 } }), "gain");
+check("out-of-bounds gain refused", !err.startsWith("WRONG"), err);
+
+// ---- valid authorship + blind fold on rejoin ------------------------------
+alice.errors.length = 0;
+alice.verb("comp", { id: "fount", type: "ambient", data: { src: SRC, gain: 0.5, radius: 12 } });
+await alice.settle();
+check("valid ambient is accepted", alice.errors.length === 0, alice.errors.join("; "));
+
+const late = await open({ name: "bob" });
+const snap: any = await late.next("snapshot");
+const folded = snap.state?.entities?.fount?.comp?.ambient;
+check("late join folds the ambient byte-identically (the fold stays blind)",
+  JSON.stringify(folded) === JSON.stringify({ src: SRC, gain: 0.5, radius: 12 }),
+  JSON.stringify(folded ?? snap).slice(0, 200));
+
+alice.close(); late.close();
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed ? 1 : 0);

--- a/tools/ambient-test.ts
+++ b/tools/ambient-test.ts
@@ -1,0 +1,107 @@
+// ambient — the #31 contract, executed: same-origin provenance, bounded
+// gain/radius, real lifecycle events (comp attach/replace, entity
+// kind:'remove', world-reset), and category composition (world slider
+// governs the place, voices slider does not).
+//
+//   bun tools/ambient-test.ts
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+GlobalRegistrator.register({ url: "http://lab.test/" });
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+// ---- fakes ----------------------------------------------------------------
+class FakeAudioEl {
+  src: string; loop = false; crossOrigin = ""; paused = true;
+  constructor(src: string) { this.src = src; }
+  play() { this.paused = false; return Promise.resolve(); }
+  pause() { this.paused = true; }
+}
+(globalThis as Record<string, unknown>).Audio = FakeAudioEl;
+
+const gains: { value: number; lastTarget: number | null }[] = [];
+class FakeCtx {
+  currentTime = 0; state = "running";
+  destination = {};
+  resume() { return Promise.resolve(); }
+  createMediaElementSource() { return { connect: (n: unknown) => n, disconnect() {} }; }
+  createGain() {
+    const g = { value: 0, lastTarget: null as number | null,
+      setTargetAtTime(v: number) { g.lastTarget = v; } };
+    gains.push(g);
+    return { gain: g, connect: (n: unknown) => ({ connect() {} }), disconnect() {} };
+  }
+}
+(globalThis as Record<string, unknown>).AudioContext = FakeCtx;
+
+// ---- module stubs ---------------------------------------------------------
+const handlers = new Map<string, ((p: unknown) => void)[]>();
+const bus = {
+  on(ev: string, fn: (p: unknown) => void) { (handlers.get(ev) ?? handlers.set(ev, []).get(ev)!).push(fn); },
+  emit(ev: string, p: unknown) { for (const fn of handlers.get(ev) ?? []) fn(p); },
+};
+const entities = new Map<string, { position: { distanceTo: (o: unknown) => number } }>();
+const myState = { pos: {} };
+const vols: Record<string, number> = { world: 1, voices: 1 };
+const stub = {
+  bus, entities, myState, report: () => {},
+  volumeFor: (cat: string) => vols[cat] ?? 1,
+};
+const { mock } = await import("bun:test");
+for (const m of ["core", "world", "controller", "voiceconsent"])
+  mock.module(`${import.meta.dir}/../client/lib/${m}.js`, () => stub);
+
+const amb = await import("../client/lib/ambient.js");
+
+const at = (d: number) => ({ position: { distanceTo: () => d } });
+const comp = (id: string, data: unknown) => bus.emit("comp", { id, type: "ambient", data });
+
+// ---- provenance -----------------------------------------------------------
+check("relative src resolves against our own origin",
+  amb.ambientSrc("assets/x.ogg") === "http://lab.test/assets/x.ogg");
+check("absolute same-origin src is allowed",
+  amb.ambientSrc("http://lab.test/a.ogg") === "http://lab.test/a.ogg");
+check("cross-origin src is refused", amb.ambientSrc("https://evil.example/track.mp3") === null);
+comp("spy", { src: "https://evil.example/track.mp3" });
+check("a cross-origin component attaches NOTHING (no fetch, no IP leak)",
+  amb.ambientCount() === 0, `${amb.ambientCount()}`);
+
+// ---- lifecycle ------------------------------------------------------------
+entities.set("fount", at(0));
+comp("fount", { src: "assets/water.ogg", gain: 0.5, radius: 10 });
+check("attach: one source for one component", amb.ambientCount() === 1);
+comp("fount", { src: "assets/birds.ogg" });
+check("replace: same entity re-authored stays ONE source", amb.ambientCount() === 1);
+check("replace actually swapped the media",
+  amb.ambientDebug()["fount"].src.includes("birds"), JSON.stringify(amb.ambientDebug()));
+bus.emit("entity", { id: "fount", kind: "remove" });
+check("entity kind:'remove' detaches promptly (the {gone} listener bug, fixed)",
+  amb.ambientCount() === 0, `${amb.ambientCount()}`);
+
+entities.set("a", at(0)); entities.set("b", at(0));
+comp("a", {}); comp("b", {});
+bus.emit("world-reset", {});
+check("world-reset detaches everything", amb.ambientCount() === 0, `${amb.ambientCount()}`);
+
+// ---- bounds + composition -------------------------------------------------
+entities.set("loud", at(0));
+comp("loud", { src: "assets/x.ogg", gain: 99, radius: 9999 });
+amb.updateAmbient();
+const g = () => gains.at(-1)!.lastTarget;
+check("authored gain 99 is clamped: target never exceeds 1×world", (g() ?? 99) <= 1, `${g()}`);
+vols.world = 0.4;
+amb.updateAmbient();
+check("the WORLD slider governs the place", Math.abs((g() ?? 0) - 0.4) < 1e-9, `${g()}`);
+vols.voices = 0;
+amb.updateAmbient();
+check("the VOICES slider does not (categories stay split)", Math.abs((g() ?? 0) - 0.4) < 1e-9, `${g()}`);
+entities.delete("loud");
+amb.updateAmbient();
+check("an entity that vanished mid-frame detaches on the next tick", amb.ambientCount() === 0);
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/ambient-test.ts
+++ b/tools/ambient-test.ts
@@ -60,36 +60,53 @@ const amb = await import("../client/lib/ambient.js");
 const at = (d: number) => ({ position: { distanceTo: () => d } });
 const comp = (id: string, data: unknown) => bus.emit("comp", { id, type: "ambient", data });
 
-// ---- provenance -----------------------------------------------------------
-check("relative src resolves against our own origin",
-  amb.ambientSrc("assets/x.ogg") === "http://lab.test/assets/x.ogg");
-check("absolute same-origin src is allowed",
-  amb.ambientSrc("http://lab.test/a.ogg") === "http://lab.test/a.ogg");
-check("cross-origin src is refused", amb.ambientSrc("https://evil.example/track.mp3") === null);
+const OGG = "store/audio/0123456789abcdef.ogg";
+const OGG2 = "store/audio/fedcba9876543210.ogg";
+
+// ---- provenance: store paths only -----------------------------------------
+check("a store path resolves to its /library URL",
+  amb.ambientSrc(OGG) === `/library/${OGG}`);
+check("a URL is refused outright", amb.ambientSrc("https://evil.example/track.mp3") === null);
+check("an arbitrary same-origin path is refused (no GET-endpoint audio)",
+  amb.ambientSrc("api/export?fmt=ogg") === null);
+check("a path-traversal dressed as a store path is refused",
+  amb.ambientSrc("store/audio/../../secrets.ogg") === null);
 comp("spy", { src: "https://evil.example/track.mp3" });
-check("a cross-origin component attaches NOTHING (no fetch, no IP leak)",
+check("a refused component attaches NOTHING (no fetch, no IP leak)",
   amb.ambientCount() === 0, `${amb.ambientCount()}`);
+check("…and the refusal is LEGIBLE, not silent",
+  /store\/audio/.test(amb.ambientDebug().refused["spy"] ?? ""),
+  JSON.stringify(amb.ambientDebug().refused));
+
+// ---- loop-only ------------------------------------------------------------
+comp("oneshot", { src: OGG, loop: false });
+check("loop:false is refused (late join would replay it)",
+  amb.ambientCount() === 0 && /loop-only/.test(amb.ambientDebug().refused["oneshot"] ?? ""),
+  JSON.stringify(amb.ambientDebug().refused));
 
 // ---- lifecycle ------------------------------------------------------------
 entities.set("fount", at(0));
-comp("fount", { src: "assets/water.ogg", gain: 0.5, radius: 10 });
+comp("fount", { src: OGG, gain: 0.5, radius: 10 });
 check("attach: one source for one component", amb.ambientCount() === 1);
-comp("fount", { src: "assets/birds.ogg" });
+comp("fount", { src: OGG2 });
 check("replace: same entity re-authored stays ONE source", amb.ambientCount() === 1);
 check("replace actually swapped the media",
-  amb.ambientDebug()["fount"].src.includes("birds"), JSON.stringify(amb.ambientDebug()));
+  amb.ambientDebug().playing["fount"].src === OGG2, JSON.stringify(amb.ambientDebug().playing));
+check("a valid replace clears any earlier refusal record",
+  amb.ambientDebug().refused["fount"] === undefined);
 bus.emit("entity", { id: "fount", kind: "remove" });
 check("entity kind:'remove' detaches promptly (the {gone} listener bug, fixed)",
   amb.ambientCount() === 0, `${amb.ambientCount()}`);
 
 entities.set("a", at(0)); entities.set("b", at(0));
-comp("a", {}); comp("b", {});
+comp("a", { src: OGG }); comp("b", { src: OGG2 });
+check("both attached pre-reset", amb.ambientCount() === 2);
 bus.emit("world-reset", {});
 check("world-reset detaches everything", amb.ambientCount() === 0, `${amb.ambientCount()}`);
 
 // ---- bounds + composition -------------------------------------------------
 entities.set("loud", at(0));
-comp("loud", { src: "assets/x.ogg", gain: 99, radius: 9999 });
+comp("loud", { src: OGG, gain: 99, radius: 9999 });
 amb.updateAmbient();
 const g = () => gains.at(-1)!.lastTarget;
 check("authored gain 99 is clamped: target never exceeds 1×world", (g() ?? 99) <= 1, `${g()}`);


### PR DESCRIPTION
Split out of #26 per review. The fixture's composition path, kept — the contract, made real and executable:

- **Provenance**: `src` is same-origin only (`ambientSrc` gate; cross-origin attaches nothing and reports). This kills the IP/tracking surface of builder-authored URLs today; content-addressed media can widen it later.
- **Bounds**: gain clamps [0,1], radius [1,60].
- **Lifecycle**: entity `{kind:'remove'}` detaches promptly — the fixture listened for a `{gone}` field nothing emits (review catch), so cleanup was incidental. `world-reset` detaches all. Re-authoring an entity's ambient replaces in place (one source).
- **Categories**: the world slider governs the place; the voices slider does not — the split #26's panel promises, proven here.

`tools/ambient-test.ts`: 13 checks (provenance ×4, lifecycle ×5, bounds/composition ×4), fake WebAudio + bus, 13/13.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)