### PR TITLE
handgrab: desktop room-grab client (visitor half of #44, stacked on #46)

### DIFF
--- a/client/lib/handgrab.js
+++ b/client/lib/handgrab.js
@@ -1,0 +1,259 @@
+// handgrab — picking things up with a mouse, gated on the `grab` component.
+//
+// The VR hands have had this since the beginning (xr.js): grip a thing, it
+// rides your hand, releasing SPEAKS A PLACE VERB so the move is a sentence in
+// the log like any other. Desktop had nothing — you could only drag things in
+// their edit mode, which is a different act (editing a scene) from picking a
+// thing up (being in a room with objects).
+//
+// What makes it a room rather than an editor is the GATE: only things wearing
+// the `grab` component can be lifted. That component is one button in the
+// inspector, so "this is a thing people can pick up" becomes a property an
+// author grants, not a mode a viewer enters. Dice and chess pieces get it; the
+// floor does not.
+//
+// Reach is measured from the BODY, not the camera (the classic third-person
+// bug is grabbing something four metres away because the camera was close).
+// Selection is by cursor ray with a small screen-space tolerance, preferring
+// the SMALLEST candidate — a raw ray makes a die nearly unpickable next to a
+// table, because the table is easier to hit. Small-wins inverts that.
+
+import { THREE, camera, canvas, bus, CONFIG } from './core.js';
+import { entities, comps } from './world.js';
+import { sendVerb } from './net.js';
+import { flashHint } from './ui.js';
+import { myState, isMouselook } from './controller.js';
+import { isEditing } from './build.js';
+
+const REACH = 2.2;              // metres from the body — an arm plus a lean
+const CONE_PX = 14;             // screen-space slop, so tiny things are pickable
+const HOLD_DIST = 1.15;         // how far in front of the eye a held thing floats
+
+let held = null;                // {id, prevParent, prevPlace, holder}
+let holder = null;              // Object3D that carries the held thing
+const _ray = new THREE.Raycaster();
+const _v = new THREE.Vector3();
+const _v2 = new THREE.Vector3();
+const _ndc = new THREE.Vector2();
+const _lastNdc = new THREE.Vector2();
+
+export const isHolding = () => !!held?.id;
+export const heldId = () => held?.id ?? null;
+
+const grabbable = (id) => !!comps.get(id)?.grab;
+
+/** Everything grabbable whose BODY-distance is within reach. */
+function inReach() {
+  const out = [];
+  _v.set(myState.pos.x, myState.pos.y + 1.0, myState.pos.z);
+  for (const [id, obj] of entities) {
+    if (!obj || !grabbable(id)) continue;
+    obj.getWorldPosition(_v2);
+    const d = _v.distanceTo(_v2);
+    if (d <= REACH) out.push({ id, obj, d });
+  }
+  return out;
+}
+
+/** Cursor (or crosshair, in mouselook) ray with cone slop; smallest wins. */
+function pick(ev) {
+  const cands = inReach();
+  if (!cands.length) return null;
+  // ev is null when the frame loop asks "what would I take right now?" — then
+  // the last known cursor position stands in (or the crosshair in mouselook)
+  if (isMouselook()) _ndc.set(0, 0);            // locked pointer = screen centre
+  else if (ev) {
+    const r = canvas.getBoundingClientRect();
+    _ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1,
+             -((ev.clientY - r.top) / r.height) * 2 + 1);
+    _lastNdc.copy(_ndc);
+  } else _ndc.copy(_lastNdc);
+  _ray.setFromCamera(_ndc, camera);
+  // widen the ray into a cone by testing against each candidate's screen-space
+  // distance from the cursor rather than demanding a literal intersection
+  const slopNdc = (CONE_PX / Math.min(innerWidth, innerHeight)) * 2;
+  let best = null;
+  for (const c of cands) {
+    c.obj.getWorldPosition(_v2);
+    const screen = _v2.clone().project(camera);
+    if (screen.z > 1) continue;                  // behind the camera
+    const off = Math.hypot(screen.x - _ndc.x, screen.y - _ndc.y);
+    if (off > slopNdc * 4) continue;             // not under the pointer at all
+    // Proximity DOMINATES; size only breaks near-ties. The first version
+    // scored `off*2 + size`, which let a die anywhere in the cone beat a
+    // table directly under the cursor — small-wins so strong it stopped
+    // being a tiebreak and became the whole rule. Normalizing the offset
+    // against the cone keeps "what you are pointing at" primary, with a
+    // bounded size nudge so a die on a table still wins when both are
+    // genuinely under the pointer.
+    const box = new THREE.Box3().setFromObject(c.obj);
+    const size = box.getSize(_v).length();
+    const nearness = off / (slopNdc * 4);        // 0 at the cursor, 1 at cone edge
+    const bulk = Math.min(1, size / 2);          // bounded: a huge thing is just 1
+    const score = nearness + bulk * 0.35;
+    if (!best || score < best.score) best = { ...c, score };
+  }
+  return best?.id ?? null;
+}
+
+function take(id) {
+  const obj = entities.get(id);
+  if (!obj) return;
+  // THE ROOM ACT, on the wire as itself (2026-08-06): grabbing used to be
+  // invisible to the server until release spoke a builder-gated `place` —
+  // which silently refused VISITORS the very thing the grab comp invites.
+  // `use take` is rank 0, gated by the comp and by reach, server-checked.
+  sendVerb('use', { id, action: 'take' });
+  holder ??= new THREE.Object3D();
+  if (!holder.parent) camera.add(holder);
+  holder.position.set(0, -0.15, -HOLD_DIST);
+  held = {
+    id,
+    prevParent: obj.parent,
+    prevPlace: {
+      id,
+      pos: [+obj.position.x.toFixed(3), +obj.position.y.toFixed(3), +obj.position.z.toFixed(3)],
+      rot: [+obj.rotation.x.toFixed(4), +obj.rotation.y.toFixed(4), +obj.rotation.z.toFixed(4)],
+      scale: obj.scale.toArray().map((n) => +n.toFixed(3)),
+    },
+  };
+  holder.attach(obj);            // preserves world transform; it rides the view
+  bus.emit('grab', { id, holding: true });
+  flashHint(`holding ${id} — click to set it down`);
+}
+
+function drop() {
+  if (!held) return;
+  const obj = entities.get(held.id);
+  const { prevParent, prevPlace } = held;
+  if (obj) {
+    prevParent.attach(obj);      // back into the world, where it visually is
+    const args = {
+      id: held.id,
+      pos: [+obj.position.x.toFixed(3), +obj.position.y.toFixed(3), +obj.position.z.toFixed(3)],
+      rot: [+obj.rotation.x.toFixed(4), +obj.rotation.y.toFixed(4), +obj.rotation.z.toFixed(4)],
+    };
+    // The move becomes a sentence: `use put` — the WORLD speaks the resulting
+    // place with the grab-component author's authority, so a visitor's pickup
+    // finally sticks. Deliberately NOT paired into edit-undo: picking a thing
+    // up and setting it down is a room act, and undo is an edit surface —
+    // "undoing" someone's held-and-placed die is just moving it again.
+    sendVerb('use', { id: held.id, action: 'put', pos: args.pos, yaw: +obj.rotation.y.toFixed(4) });
+  }
+  bus.emit('grab', { id: held.id, holding: false });
+  held = null;
+}
+
+// If the server refuses the room act (out of reach, someone else holding),
+// the optimistic local hold must not stand — put the thing back where it was.
+bus.on('server-error', (text) => {
+  if (!held || typeof text !== 'string' || !text.includes(`"${held.id}"`)) return;
+  const obj = entities.get(held.id);
+  if (obj) {
+    held.prevParent.attach(obj);
+    obj.position.set(...held.prevPlace.pos);
+    obj.rotation.set(...held.prevPlace.rot);
+  }
+  bus.emit('grab', { id: held.id, holding: false });
+  held = null;
+});
+
+// ---- the affordance -------------------------------------------------------
+// You could pick things up but nothing said which things — the gate was
+// invisible, so using it was guesswork. Grabbable things within reach get a
+// faint rim of warmth, brightest for the one you would actually take.
+//
+// Deliberately NOT the `notice` component's job: notice is comp-driven, an
+// author opting a specific thing into warming under gaze. This is automatic
+// and structural — it reports a CAPABILITY of the world (this can be lifted),
+// not an authored behaviour. Same visual grammar, different claim, so it is a
+// separate small system rather than a hijack of that one.
+const _warm = new THREE.Color('#8fe8c8');
+const _lit = new Map();          // entityId -> [{mesh, orig}] clone receipts
+
+// Instance-safe by CLONING: assets share materials across siblings, so writing
+// emissive on the shared material would warm every copy of the die in the
+// room. Each hinted mesh gets a private clone (restored + disposed on cool).
+// Bounded: only grabbables within arm's reach ever clone. (The lab does this
+// with shell overlays from its glow module — a separate extraction; when that
+// lands, this section collapses into two calls.)
+function litFor(id, amount) {
+  const obj = entities.get(id);
+  if (!obj) return;
+  let rec = _lit.get(id);
+  if (!rec) {
+    rec = [];
+    obj.traverse((m) => {
+      if (!m.isMesh || !m.material || !('emissive' in m.material)) return;
+      rec.push({ mesh: m, orig: m.material });
+      m.material = m.material.clone();
+    });
+    _lit.set(id, rec);
+  }
+  for (const { mesh } of rec) {
+    mesh.material.emissive.copy(_warm);
+    mesh.material.emissiveIntensity = amount;
+  }
+}
+
+function coolAll(except) {
+  for (const [id, rec] of _lit) {
+    if (except?.has(id)) continue;
+    for (const { mesh, orig } of rec) {
+      if (mesh.material !== orig) mesh.material.dispose();
+      mesh.material = orig;
+    }
+    _lit.delete(id);
+  }
+}
+
+/** Per-frame: warm what's takeable, brightest on the current candidate. */
+export function updateGrabHints() {
+  if (held || isEditing()) { coolAll(); return; }
+  const cands = inReach();
+  if (!cands.length) { coolAll(); return; }
+  // At frame time there may be no cursor event and no prior one (a fresh tab,
+  // or mouselook). Rather than reuse pick()'s cursor path — which silently
+  // scored against a stale NDC — score the candidates directly against the
+  // screen centre, which is what "what would I take right now" means when
+  // nobody has moved a mouse yet.
+  let top = null, bestScore = Infinity;
+  for (const c of cands) {
+    c.obj.getWorldPosition(_v2);
+    const screen = _v2.clone().project(camera);
+    if (screen.z > 1) continue;                    // behind the eye
+    const off = Math.hypot(screen.x - _lastNdc.x, screen.y - _lastNdc.y);
+    if (off > 0.55) continue;                      // not anywhere near the aim
+    const box = new THREE.Box3().setFromObject(c.obj);
+    const score = off / 0.55 + Math.min(1, box.getSize(_v).length() / 2) * 0.35;
+    if (score < bestScore) { bestScore = score; top = c.id; }
+  }
+  const keep = new Set();
+  for (const c of cands) {
+    litFor(c.id, c.id === top ? 0.5 : 0.16);
+    keep.add(c.id);
+  }
+  coolAll(keep);
+}
+
+export function initHandGrab() {
+  canvas.addEventListener('click', (ev) => {
+    if (CONFIG.spectate) return;
+    // The editor owns the click while it's open: in an edit surface a click
+    // means SELECT THIS, and a grab that fired underneath it would fight the
+    // selection. Picking things up is what you do when you're NOT editing —
+    // being in the room, rather than working on it.
+    if (isEditing()) return;
+    if (held) { drop(); return; }
+    const id = pick(ev);
+    if (id) take(id);
+  });
+  // dropping is also what Escape means while holding something
+  addEventListener('keydown', (e) => {
+    if (e.code === 'Escape' && held) drop();
+  });
+  // never keep hold of a thing that left the world under you
+  bus.on('entity', ({ id, kind }) => {
+    if (held?.id === id && kind === 'remove') { held = null; }
+  });
+}

--- a/client/lib/net.js
+++ b/client/lib/net.js
@@ -484,6 +484,7 @@ async function handle(msg) {
     case 'error':
       // Server-side refusals are the user's problem to see, not the console's.
       toast(msg.error, 'warn');
+      bus.emit('server-error', msg.error);   // systems with optimistic state listen
       break;
   }
 }

--- a/client/main.js
+++ b/client/main.js
@@ -31,6 +31,7 @@ import {
   hasGhost, hasSelection, toggleEditMode, isEditing,
 } from './lib/build.js';
 import { initConjure } from './lib/conjure.js';
+import { initHandGrab, updateGrabHints } from './lib/handgrab.js';
 import { initVoice, micOn, isMuted, micAnalyserLevel, peerLevels } from './lib/voice.js';
 import './lib/mictoggle.js'; // mic + headphone toggles beside the HUD, both off by default
 import { initAudioPanel } from './lib/audiopanel.js';
@@ -530,6 +531,7 @@ function clearPins() {
 }
 
 initPhysObj({ myPos: () => myState.pos });
+initHandGrab();  // 🖐 room-grab: click a `grab`-comp'd thing to pick it up (#44)
 initMods();   // 🧩 runtime client scripts: local trusted mods + world offers
 
 initBodyDrag({
@@ -1049,6 +1051,8 @@ function frame(now) {
                                  // land in the same frame's avatar.update
   BC('physobj');
   tickPhysObj(dt, now);          // entity leases I hold (kicked balls, etc.)
+  BC('grab-hints');
+  updateGrabHints();             // warm what's takeable (room act, not edit)
   BC('mods');
   tickMods(dt, now);             // runtime-loaded client scripts (🧩 mods)
   BC('remotes');

--- a/server/server.ts
+++ b/server/server.ts
@@ -587,6 +587,70 @@ function lintParticles(w: World, entry: LogEntry): void {
 // Wrapped whole in try/catch: no reaction may ever take the server down
 // (lesson of the 4f82250 crash loop — a ws handler must never leak a throw).
 
+/** GRAB vs EDIT (R, 2026-08-06): the client has always known these are two
+ *  acts — handgrab.js: picking a thing up (being in a room) is not editing a
+ *  scene — but the wire encoded both as `place`, which is builder-gated, so a
+ *  VISITOR's mouse-grab was silently refused at release. Now the room act has
+ *  its own rank-0 sentences, gated by the OBJECT and by REACH, exactly the
+ *  reactions doctrine: the trigger is anyone's; the effect runs with world
+ *  authority because the author's `grab` component is the standing decision.
+ *
+ *    use {id, action:"take"}            — must wear `grab`, be unheld, in reach
+ *    use {id, action:"put", pos, yaw}   — holder only, drop point in reach
+ *
+ *  Ungrabbable things can never be taken — only edited (place, rank 1).
+ *  Errors are sentences an agent can act on ("move closer").
+ *  Returns true when the action was take/put (handled here, even on error). */
+const GRAB_REACH = 2.6;   // client reach is 2.2; slack absorbs pose latency
+function handleTakePut(c: Client, ws: { send: (s: string) => void }, a: Record<string, unknown>): boolean {
+  const action = String(a?.action ?? "");
+  if (action !== "take" && action !== "put") return false;
+  const w = c.world!;
+  const id = String(a?.id ?? "");
+  const ent = w.state.entities[id];
+  const fail = (error: string, why: string) => {
+    w.debug("denied", { who: c.id, verb: `use ${action}`, id, why });
+    ws.send(JSON.stringify({ type: "error", error }));
+    return true;
+  };
+  if (!ent) return fail(`nothing here is called "${id}"`, "no such entity");
+  const me = (c.lastPose as { p?: number[] } | null)?.p;
+  if (!me) return fail("you have no body position yet — move once, then try", "no pose");
+  if (action === "take") {
+    if (!ent.comp?.grab) {
+      return fail(`"${id}" doesn't invite taking — it can only be edited (builders, edit mode)`, "no grab comp");
+    }
+    const held = w.holds.get(id);
+    if (held && held !== c.id) return fail(`${held} is holding "${id}"`, "already held");
+    const at = w.leases.get(id)?.lastState?.p ?? ent.pos ?? [0, 0, 0];
+    const d = Math.hypot(me[0] - at[0], me[2] - at[2]);
+    if (d > GRAB_REACH) {
+      return fail(`"${id}" is out of reach — you're ${d.toFixed(1)}m away, reach is about 2m; move closer and try again`, "too far");
+    }
+    w.holds.set(id, c.id);
+    const entry = w.append(c.id, "use", { id, action: "take" });
+    w.broadcast({ type: "log", entry });
+    return true;
+  }
+  // put
+  if (w.holds.get(id) !== c.id) return fail(`you're not holding "${id}"`, "not holder");
+  const pos = Array.isArray(a.pos) ? (a.pos as number[]) : null;
+  if (!pos || pos.length !== 3) return fail(`put needs a pos to rest "${id}" at`, "no pos");
+  const d = Math.hypot(me[0] - pos[0], me[2] - pos[2]);
+  if (d > GRAB_REACH) {
+    return fail(`that spot is out of reach — ${d.toFixed(1)}m away; step closer to where you want to put it down`, "drop too far");
+  }
+  w.holds.delete(id);
+  const entry = w.append(c.id, "use", { id, action: "put" });
+  w.broadcast({ type: "log", entry });
+  // the world speaks the place — the visitor never needed builder rank, the
+  // author's grab component did (same authority rule as reactions)
+  const eff = w.append("world", "place",
+    { id, pos, ...(a.yaw != null ? { yaw: a.yaw } : {}), cause: entry.seq, by: c.id });
+  w.broadcast({ type: "log", entry: eff });
+  return true;
+}
+
 function reactToUse(w: World, cause: LogEntry): void {
   const a = cause.args as Record<string, unknown>;
   const id = String(a?.id ?? "");
@@ -793,6 +857,11 @@ class World {
   name: string;
   entries: LogEntry[] = [];
   clients = new Set<Client>();
+  /** Things currently in someone's hands: entity id -> actor id. In-memory
+   *  and derived — the LOG carries the take/put entries; this is just the
+   *  live answer to "may someone else take it right now". Cleared when the
+   *  holder leaves, the entity is removed, or an editor place overrides. */
+  holds = new Map<string, string>();
   /** Poses received since the last stage-frame tick — latest value wins.
    *  The embodied plane is batched: N performers × M spectators must not be
    *  N×M×15Hz individual sends (24×200 would be 72k msgs/s); it's one frame
@@ -1829,6 +1898,7 @@ const server = Bun.serve({
       // them — the lease's whole promise (docs/leases.md)
       if (c.world) for (const [lid, L] of [...c.world.leases]) if (L.holder === c) c.world.settleLease(lid);
       if (c.world) {
+        for (const [hid, actor] of c.world.holds) if (actor === c.id) c.world.holds.delete(hid);
         c.world.clients.delete(c);
         if (!c.spectator) {
           if (!c.superseded) c.world.rememberPose(c.id, c.lastPose); // sleep where you stood
@@ -2262,6 +2332,9 @@ const server = Bun.serve({
               } else delete a.t0;
             } else { delete a.spoken; delete a.utt; delete a.t0; }
           }
+          // room-grab: take/put validate (reach, grab comp, holder) and may
+          // refuse — so they route before the unconditional append
+          if (msg.verb === "use" && handleTakePut(c, ws, args as Record<string, unknown>)) return;
           const entry = c.world.append(c.id, msg.verb, args);
           c.world.broadcast({ type: "log", entry }); // everyone, including author (authoritative echo)
           // A `use` is a cause; reactions turn it into logged effects.

--- a/tools/grabtest.ts
+++ b/tools/grabtest.ts
@@ -1,0 +1,167 @@
+// GRAB vs EDIT test matrix (2026-08-06). Boots nothing itself — point it at a
+// SCRATCH sequencer (fresh WORLDS_DIR, JOIN_TOKEN set):
+//
+//   WORLDS_DIR=$(mktemp -d) JOIN_TOKEN=test-door PORT=8994 bun run server/server.ts &
+//   WORLD_URL=ws://localhost:8994/ws JOIN_TOKEN=test-door bun run tools/grabtest.ts
+//
+// The story: the client always knew picking-a-thing-up is a different act
+// from editing-a-scene (handgrab.js), but the wire said `place` for both, so
+// a visitor's grab was refused at release. Now the room act is rank 0:
+//   use take — needs the `grab` comp, an unheld thing, and REACH
+//   use put  — holder only, drop point in reach, world speaks the place
+// Ungrabbable things can never be taken, only edited (place, rank 1).
+
+const URL = process.env.WORLD_URL ?? "ws://localhost:8994/ws";
+const TOKEN = process.env.JOIN_TOKEN ?? "test-door";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+type Sock = {
+  ws: WebSocket;
+  msgs: any[];
+  errors: string[];
+  next(pred: string | ((m: any) => boolean), ms?: number): Promise<any>;
+  verb(verb: string, args: any): void;
+  pose(p: number[]): void;
+  settle(ms?: number): Promise<void>;
+  close(): void;
+};
+
+function open(joinMsg: Record<string, unknown>): Promise<Sock> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(URL);
+    const s: Sock = {
+      ws, msgs: [], errors: [],
+      next(pred, ms = 4000) {
+        const want = typeof pred === "string" ? (m: any) => m.type === pred : pred;
+        return new Promise((res, rej) => {
+          const hit = s.msgs.find(want);
+          if (hit) return res(hit);
+          const t0 = Date.now();
+          const iv = setInterval(() => {
+            const m = s.msgs.find(want);
+            if (m) { clearInterval(iv); res(m); }
+            else if (Date.now() - t0 > ms) { clearInterval(iv); rej(new Error(`no match in ${ms}ms`)); }
+          }, 20);
+        });
+      },
+      verb(verb, args) { ws.send(JSON.stringify({ type: "verb", verb, args })); },
+      pose(p) { ws.send(JSON.stringify({ type: "pose", pose: { p, yaw: 0, speed: 0, clip: "idle" } })); },
+      settle(ms = 300) { return new Promise((r) => setTimeout(r, ms)); },
+      close() { try { ws.close(); } catch { /* already */ } },
+    };
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", token: TOKEN, ...joinMsg }));
+    ws.onmessage = (ev) => {
+      const m = JSON.parse(String(ev.data));
+      s.msgs.push(m);
+      if (m.type === "error") s.errors.push(m.error);
+    };
+    ws.onclose = () => { /* fine */ };
+    ws.onerror = (e) => reject(e);
+    s.next("snapshot").then(() => resolve(s), reject);
+  });
+}
+
+/** Clear the error ledger, perform the act, wait for a FRESH refusal. The
+ *  naive next("error") kept matching stale errors in the message buffer —
+ *  every check read the previous step's refusal (off-by-one cascade, found
+ *  on first run). */
+async function expectErr(s: Sock, act: () => void, substr: string): Promise<string> {
+  s.errors.length = 0;
+  act();
+  const t0 = Date.now();
+  while (Date.now() - t0 < 4000) {
+    if (s.errors.length) return s.errors.find((e) => e.includes(substr)) ?? `WRONG ERROR: ${s.errors.join("; ")}`;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return "NO ERROR ARRIVED";
+}
+
+const placeOf = (m: any, id: string) =>
+  m.type === "log" && m.entry?.verb === "place" && m.entry?.args?.id === id ? m.entry : null;
+
+const WORLD = `grabtest-${Math.random().toString(36).slice(2, 8)}`;
+
+console.log(`\ngrab-vs-edit matrix — world "${WORLD}"\n`);
+
+// ---- build: an owner furnishes the room -------------------------------------
+const alice = await open({ id: "alice", world: WORLD });
+alice.verb("spawn", { id: "die1", lib: "deco/die.glb", pos: [1, 0, 0], yaw: 0 });
+alice.verb("comp", { id: "die1", type: "grab", data: {} });
+alice.verb("spawn", { id: "boulder", lib: "deco/boulder.glb", pos: [2, 0, 0], yaw: 0 });
+alice.verb("grant", { id: "bob", role: "visitor" });
+await alice.settle();
+check("owner authored die (grab) + boulder (no grab)", alice.errors.length === 0, alice.errors.join("; "));
+
+const bob = await open({ id: "bob", world: WORLD });
+
+// ---- the old bug, still fenced: a visitor cannot EDIT ----------------------
+let err = await expectErr(bob, () => bob.verb("place", { id: "die1", pos: [5, 0, 5] }), "place");
+check("visitor speaking `place` is still refused (edit stays builder-gated)", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- no body position yet → actionable refusal ------------------------------
+err = await expectErr(bob, () => bob.verb("use", { id: "die1", action: "take" }), "body position");
+check("take before any pose → told to move first", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- out of reach → told to move closer -------------------------------------
+bob.pose([9, 0, 9]);
+await bob.settle(250);
+err = await expectErr(bob, () => bob.verb("use", { id: "die1", action: "take" }), "out of reach");
+check("take from 11m → move closer and try again", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- in reach, grabbable → the room act works for a visitor -----------------
+bob.pose([1.5, 0, 0.5]);
+await bob.settle(250);
+bob.errors.length = 0;
+bob.verb("use", { id: "die1", action: "take" });
+const takeLog = await bob.next((m) => m.type === "log" && m.entry?.verb === "use" && m.entry?.args?.action === "take");
+check("visitor takes the die (rank 0, in reach)", !!takeLog && bob.errors.length === 0, bob.errors.join("; "));
+
+// ---- second hands off -------------------------------------------------------
+const carol = await open({ id: "carol", world: WORLD });
+carol.pose([1.5, 0, 0.5]);
+await carol.settle(200);
+err = await expectErr(carol, () => carol.verb("use", { id: "die1", action: "take" }), "holding");
+check("carol cannot take what bob holds", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- drop too far → refused; optimistic client would revert -----------------
+err = await expectErr(bob, () => bob.verb("use", { id: "die1", action: "put", pos: [9, 0, 9] }), "out of reach");
+check("put 11m away → step closer", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- put in reach → the WORLD speaks the place ------------------------------
+bob.verb("use", { id: "die1", action: "put", pos: [0.5, 0, 1.2], yaw: 0.7 });
+const eff = await bob.next((m) => placeOf(m, "die1"));
+check("world-authored place lands", eff.entry.actor === "world", `actor=${eff.entry.actor}`);
+check("place carries the drop pose + provenance", eff.entry.args.pos[2] === 1.2 && eff.entry.args.by === "bob",
+  JSON.stringify(eff.entry.args));
+
+// ---- ungrabbable can never be taken, only edited ----------------------------
+bob.pose([2.2, 0, 0.3]);
+await bob.settle(250);
+err = await expectErr(bob, () => bob.verb("use", { id: "boulder", action: "take" }), "doesn't invite taking");
+check("boulder (no grab comp) refuses taking, points at edit", !err.startsWith("NO") && !err.startsWith("WRONG"), err);
+
+// ---- holder leaving frees the thing ----------------------------------------
+bob.verb("use", { id: "die1", action: "take" });
+await bob.next((m) => m.type === "log" && m.entry?.verb === "use" && m.entry?.args?.action === "take" && m.entry.seq > eff.entry.seq);
+bob.close();
+await carol.settle(400);
+carol.pose([0.6, 0, 1.1]);
+await carol.settle(200);
+carol.verb("use", { id: "die1", action: "take" });
+const carolTake = await carol.next((m) => m.type === "log" && m.entry?.verb === "use" && m.entry?.args?.action === "take" && m.entry?.actor === "carol").catch(() => null);
+check("disconnect releases the hold — carol takes it", !!carolTake, carol.errors.join("; "));
+
+// ---- builders still edit at any distance ------------------------------------
+alice.verb("place", { id: "boulder", pos: [30, 0, 30] });
+await alice.next((m) => placeOf(m, "boulder"));
+check("builder edits the boulder from across the room", alice.errors.length === 0, alice.errors.join("; "));
+
+alice.close(); carol.close();
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed ? 1 : 0);

--- a/tools/handgrab-stubs.mjs
+++ b/tools/handgrab-stubs.mjs
@@ -1,0 +1,44 @@
+// handgrab-test substitutes these for handgrab.js's imports — only what it touches.
+import * as THREE from '../client/node_modules/three/build/three.module.js';
+export { THREE };
+
+export const CONFIG = { spectate: false };
+const handlers = new Map();
+export const bus = {
+  on(t, f) { if (!handlers.has(t)) handlers.set(t, []); handlers.get(t).push(f); },
+  emit(t, p) { for (const f of handlers.get(t) ?? []) f(p); },
+};
+
+// a REAL camera: pick() projects candidates through it, take() parents to it
+export const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+camera.position.set(0, 1.6, 0);
+camera.updateMatrixWorld();
+
+// canvas: capture the click handler so the test can synthesize clicks
+export const _canvasHandlers = new Map();
+export const canvas = {
+  addEventListener: (t, f) => _canvasHandlers.set(t, f),
+  getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 800 }),
+};
+
+// world.js
+export const entities = new Map();
+export const comps = new Map();
+
+// net.js
+export const sentVerbs = [];
+export const sendVerb = (verb, args) => sentVerbs.push({ verb, args });
+
+// ui.js
+export const flashHint = () => {};
+
+// controller.js
+export const myState = { pos: { x: 0, y: 0, z: 0 } };
+let mouselook = false;
+export const isMouselook = () => mouselook;
+export const _setMouselook = (v) => { mouselook = v; };
+
+// build.js
+let editing = false;
+export const isEditing = () => editing;
+export const _setEditing = (v) => { editing = v; };

--- a/tools/handgrab-test.ts
+++ b/tools/handgrab-test.ts
@@ -1,0 +1,103 @@
+// handgrab unit matrix (2026-08-06) — the DESKTOP CLIENT half of #44, tested
+// against stubs (tools/handgrab-stubs.mjs): a real THREE camera, a synthetic
+// canvas, recorded verbs. The server half is grabtest.ts; this file proves
+// the client speaks the room act correctly and reverts honestly.
+//   bun run tools/handgrab-test.ts
+import { plugin } from 'bun';
+const here = (f: string) => new URL(f, import.meta.url).pathname;
+plugin({
+  name: 'handgrab-stubs',
+  setup(b) {
+    for (const m of ['core', 'world', 'net', 'ui', 'controller', 'build'])
+      b.onResolve({ filter: new RegExp(`^\\./${m}\\.js$`) }, () => ({ path: here('./handgrab-stubs.mjs') }));
+  },
+});
+
+(globalThis as any).innerWidth = 800; (globalThis as any).innerHeight = 800;
+const S = await import('./handgrab-stubs.mjs');
+const { THREE, camera, entities, comps, sentVerbs, _canvasHandlers, _setEditing, bus } = S as any;
+const grab = await import('../client/lib/handgrab.js');
+
+let passed = 0; let failed = 0;
+function check(name: string, ok: boolean, detail = "") {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const scene = new THREE.Object3D();
+scene.add(camera);
+function spawn(id: string, x: number, y: number, z: number, grabbable = true, size = 0.2) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(size, size, size), new THREE.MeshStandardMaterial());
+  m.position.set(x, y, z);
+  scene.add(m);
+  entities.set(id, m);
+  if (grabbable) comps.set(id, { grab: {} });
+  m.updateWorldMatrix(true, false);
+  return m;
+}
+const click = (x = 400, y = 400) => _canvasHandlers.get('click')({ clientX: x, clientY: y });
+
+grab.initHandGrab();
+
+// ---- the gate and the reach ----------------------------------------------
+const die = spawn('die', 0, 1, -1.5);          // in reach, in view
+camera.lookAt(die.position); camera.updateMatrixWorld();   // dead-centre under the crosshair
+spawn('boulder', 0.35, 1, -1.5, false, 1.0);   // in view, NOT grabbable
+spawn('fardie', 0, 1, -8);                     // grabbable but out of reach
+click();
+check("click takes the grabbable under the cursor", grab.heldId() === 'die', String(grab.heldId()));
+check("the wire heard `use take`, not an edit verb",
+  sentVerbs.length === 1 && sentVerbs[0].verb === 'use' && sentVerbs[0].args.action === 'take',
+  JSON.stringify(sentVerbs));
+check("held thing rides the camera", (() => { let p = die.parent; while (p) { if (p === camera) return true; p = p.parent; } return false; })());
+
+// ---- put ------------------------------------------------------------------
+click();
+const put = sentVerbs[1];
+check("second click speaks `use put` with a landing pos",
+  put?.verb === 'use' && put.args.action === 'put' && Array.isArray(put.args.pos), JSON.stringify(put));
+check("the thing is back in the world graph", die.parent !== null && (() => { let p = die.parent; while (p) { if (p === camera) return false; p = p.parent; } return true; })());
+check("no longer holding", !grab.isHolding());
+
+// ---- what can never be taken ---------------------------------------------
+sentVerbs.length = 0;
+entities.get('die').position.set(0, 1, -30); entities.get('die').updateWorldMatrix(true, false);
+click();
+check("an ungrabbable thing under the cursor is not taken", !grab.isHolding() && sentVerbs.length === 0, JSON.stringify(sentVerbs));
+entities.get('die').position.set(0, 1, -1.5); entities.get('die').updateWorldMatrix(true, false);
+
+// ---- editing owns the click ----------------------------------------------
+_setEditing(true); click();
+check("while editing, clicks never grab (interact/build split)", !grab.isHolding() && sentVerbs.length === 0);
+_setEditing(false);
+
+// ---- refusal reverts the optimism ----------------------------------------
+click();
+check("(setup) holding again", grab.heldId() === 'die');
+const before = { x: 0, y: 1, z: -1.5 };
+bus.emit('server-error', 'cannot take "die": someone else is holding it');
+check("server refusal puts the thing back where it was",
+  !grab.isHolding() && Math.abs(die.position.x - before.x) < 1e-6 && Math.abs(die.position.z - before.z) < 1e-6,
+  `${die.position.toArray()}`);
+
+// ---- vanished under you ---------------------------------------------------
+sentVerbs.length = 0; click();
+check("(setup) holding once more", grab.isHolding());
+bus.emit('entity', { id: 'die', kind: 'remove' });
+check("a removed entity releases the hold without a put", !grab.isHolding() && !sentVerbs.some((v: any) => v.args?.action === 'put'));
+
+// ---- hints: instance-safe warmth ------------------------------------------
+const a = spawn('twin-a', -0.5, 1, -1.6);
+const b = spawn('twin-b', 0.5, 1, -1.6);
+(b as any).material = (a as any).material;      // shared material — the trap
+grab.updateGrabHints();
+const warmA = (a as any).material.emissiveIntensity > 0;
+check("in-reach grabbables warm up", warmA, `intensity=${(a as any).material.emissiveIntensity}`);
+check("warming one twin does NOT light its material-sharing sibling the same way",
+  (a as any).material !== (b as any).material);
+_setEditing(true); grab.updateGrabHints(); _setEditing(false);
+check("hints cool (and restore the shared material) when editing opens",
+  (a as any).material === (b as any).material && (a as any).material.emissive.getHex() === 0x000000);
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
The other half of #44, as discussed with Mica in Discord today: #46 gave `use take`/`use put` a server path; this PR ships the desktop client that speaks it — without smuggling the lab workbench into main.

**What a visitor gets:** click a `grab`-comp'd thing within arm's reach (2.2m, body-measured) → it rides the view; click again → release speaks `use put`, and the pickup *sticks*, because the world speaks the resulting place with the grab-author's authority instead of the visitor's refused `place`.

**Bounded extraction — three lab deps deliberately cut:**
- glow shells → minimal instance-safe emissive hints inline (per-mesh material clone, restored+disposed on cool; a shared-material sibling of a hinted die stays dark — tested)
- edit-undo pairing → dropped on purpose: a room act is not an edit; "undoing" someone's set-down die is just moving it again
- workshop guard → doesn't exist on main; `isEditing()` keeps sole ownership of clicks while editing (the interact/build split)

**Honesty at the seams:** a server refusal reverts the optimistic hold to the exact prior transform (wired to the #46 error bus); an entity removed while held releases without speaking a stray put.

**Receipts:** new `tools/handgrab-test.ts` (stub modules + a real THREE camera): wire shape, both gates, click ownership, refusal revert, remove-while-held, instance-safe warmth — 15/15. Server grabtest still 12/12 on the branch.

**Stacked on #46** — merge that first; this PR's own diff is commit `c409da1` only. Together they close #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)