### PR TITLE
audiopanel: mic-sensitivity meter collapsed to a 2px line (orphaned lab CSS)

### DIFF
--- a/client/lib/audiopanel.js
+++ b/client/lib/audiopanel.js
@@ -19,6 +19,24 @@ import { audioPrefs, setVolume, receivingVoice, setReceiveVoice,
 import { micAnalyserLevel } from './voice.js';
 import { bus } from './core.js';
 
+// The panel's row layout, carried BY THE MODULE. Found live 2026-08-06 (R,
+// in-headset): the sp-row/sp-label classes came from the lab's panel
+// framework and were never extracted with this file, so nothing upstream
+// defined them — the mic meter (an inline span with flex:1) collapsed to a
+// 2px vertical line, which is just its threshold marker with zero meter
+// behind it. A module's markup and its layout must travel together.
+const SP_CSS = `
+.sp-row { display: flex; align-items: center; gap: 8px; margin: 5px 0; }
+.sp-label { opacity: 0.75; min-width: 64px; flex-shrink: 0; }
+`;
+function ensureCss() {
+  if (document.getElementById('sp-audio-css')) return;
+  const st = document.createElement('style');
+  st.id = 'sp-audio-css';
+  st.textContent = SP_CSS;
+  document.head.appendChild(st);
+}
+
 const ROWS = [
   ['voices', 'voices', 'other people speaking, and agent speech'],
   ['world', 'world', 'ambience and place-sound — the 🎧 toggle never touches this'],
@@ -138,6 +156,7 @@ function paint(body) {
 }
 
 export function initAudioPanel() {
+  ensureCss();
   makeSection('🔊 audio', (body) => paint(body), { id: 'audio' });
   // either control moving repaints the other's row — one truth, two surfaces
   bus.on('audio:hush', () => paint());

--- a/tools/audiopanel-css-probe.html
+++ b/tools/audiopanel-css-probe.html
@@ -1,0 +1,18 @@
+<!doctype html><meta charset="utf-8"><title>audiopanel css probe</title>
+<body>
+<script type="importmap">
+{ "imports": {
+  "/client/lib/ui.js": "data:text/javascript,export const makeSection = (t, paint) => { const b = document.createElement('div'); b.style.width='320px'; document.body.appendChild(b); paint(b); };",
+  "/client/lib/voiceconsent.js": "data:text/javascript,export const audioPrefs=()=>({voices:1,world:1,tts:1});export const setVolume=()=>{};export const receivingVoice=()=>true;export const setReceiveVoice=()=>{};export const sttConsented=()=>true;export const setSttConsent=()=>{};export const isHushed=()=>false;export const setHush=()=>{};export const micFloor=()=>0.04;export const setMicFloor=()=>{};",
+  "/client/lib/voice.js": "data:text/javascript,export const micAnalyserLevel=()=>0.08;",
+  "/client/lib/core.js": "data:text/javascript,const h=new Map();export const bus={on:(t,f)=>{h.set(t,[...(h.get(t)??[]),f])},emit:(t,p)=>{(h.get(t)??[]).forEach(f=>f(p))}};"
+} }
+</script>
+<script type="module">
+  const { initAudioPanel } = await import('/client/lib/audiopanel.js');
+  initAudioPanel();
+  await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  const meter = document.querySelector('[data-meter]');
+  const w = meter ? meter.getBoundingClientRect().width : -1;
+  window.__probe = { meterWidth: w, hasCss: !!document.getElementById('sp-audio-css') };
+</script>


### PR DESCRIPTION
Live bug, found by R in-headset an hour ago: the mic-sensitivity meter in the audio panel renders as a single vertical line of pixels.

**Root cause is my own #26 extraction debt:** `micFloorRow` (and the volume rows) use `sp-row`/`sp-label` classes that belong to my lab's panel framework — the CSS never rode along, nothing upstream defines them, and an inline span with `flex:1` in a non-flex parent collapses to zero width. The 2px line is the threshold marker, absolutely positioned over a meter of width 0.

**Fix:** the module injects its own two-rule style block at init — markup and layout travel together, so the panel is self-contained no matter what page hosts it.

**Receipt:** `tools/audiopanel-css-probe.html` renders the real module over data-URI import stubs and measures `[data-meter]` via playwright: broken **0px** → fixed **176.2px**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)