### PR TITLE
version: stamp the sequencer with its build, answer /version

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -50,7 +50,7 @@ import { initDebug, updateDebug, toggleDebug } from './lib/debug.js';
 // agents the answer is the same public GET /version, one curl away; an
 // agent-surface (join/look) exposure would be its own explicit slice.
 fetch('/version').then((r) => r.json())
-  .then(({ sha, commitTime, dirty, startedAt }) => console.log(`[eidoverse] server build ${sha}${dirty === true ? ' (DIRTY TREE)' : ''} (code from ${commitTime}), up since ${startedAt}`))
+  .then(({ sha, commitTime, dirty, startedAt }) => console.log(`[eidoverse] server build ${sha}${dirty === true ? ' (DIRTY TREE)' : dirty === false ? '' : ' (dirty: unknown)'} (code from ${commitTime}), up since ${startedAt}`))
   .catch(() => console.log('[eidoverse] server build unknown (/version unavailable)'));
 import { dragSim } from './lib/bodydrag.js';
 import { initChat, logChat, chat, openConvo } from './lib/chat.js';

--- a/client/main.js
+++ b/client/main.js
@@ -46,7 +46,7 @@ import { initDebug, updateDebug, toggleDebug } from './lib/debug.js';
 // mystery: fixes merged upstream for hours, prod still on the old code,
 // nothing anywhere said so). Server route: GET /version.
 fetch('/version').then((r) => r.json())
-  .then(({ sha, startedAt }) => console.log(`[eidoverse] server build ${sha}, up since ${startedAt}`))
+  .then(({ sha, commitTime, startedAt }) => console.log(`[eidoverse] server build ${sha} (code from ${commitTime}), up since ${startedAt}`))
   .catch(() => console.log('[eidoverse] server build unknown (/version unavailable)'));
 import { dragSim } from './lib/bodydrag.js';
 import { initChat, logChat, chat, openConvo } from './lib/chat.js';

--- a/client/main.js
+++ b/client/main.js
@@ -45,8 +45,12 @@ import { initDebug, updateDebug, toggleDebug } from './lib/debug.js';
 // deployed here" is a glance instead of an inference (the 2026-08-07 audio
 // mystery: fixes merged upstream for hours, prod still on the old code,
 // nothing anywhere said so). Server route: GET /version.
+// SCOPE, honestly (review): this line serves BROWSER humans and render-host
+// logs. An ordinary headless/MCPL agent never sees a browser console — for
+// agents the answer is the same public GET /version, one curl away; an
+// agent-surface (join/look) exposure would be its own explicit slice.
 fetch('/version').then((r) => r.json())
-  .then(({ sha, commitTime, startedAt }) => console.log(`[eidoverse] server build ${sha} (code from ${commitTime}), up since ${startedAt}`))
+  .then(({ sha, commitTime, dirty, startedAt }) => console.log(`[eidoverse] server build ${sha}${dirty === true ? ' (DIRTY TREE)' : ''} (code from ${commitTime}), up since ${startedAt}`))
   .catch(() => console.log('[eidoverse] server build unknown (/version unavailable)'));
 import { dragSim } from './lib/bodydrag.js';
 import { initChat, logChat, chat, openConvo } from './lib/chat.js';

--- a/client/main.js
+++ b/client/main.js
@@ -40,6 +40,14 @@ import {
   openDoor, toggleRoster, initRoster, initDock, paintRoster, panelFrame, el,
 } from './lib/ui.js';
 import { initDebug, updateDebug, toggleDebug } from './lib/debug.js';
+
+// Which build is this world running? One console line at boot, so "what's
+// deployed here" is a glance instead of an inference (the 2026-08-07 audio
+// mystery: fixes merged upstream for hours, prod still on the old code,
+// nothing anywhere said so). Server route: GET /version.
+fetch('/version').then((r) => r.json())
+  .then(({ sha, startedAt }) => console.log(`[eidoverse] server build ${sha}, up since ${startedAt}`))
+  .catch(() => console.log('[eidoverse] server build unknown (/version unavailable)'));
 import { dragSim } from './lib/bodydrag.js';
 import { initChat, logChat, chat, openConvo } from './lib/chat.js';
 import { makeFrame } from './lib/frames.js';

--- a/server/server.ts
+++ b/server/server.ts
@@ -1389,14 +1389,24 @@ const BUILD = (() => {
         Bun.spawnSync(["git", ...args], { cwd: import.meta.dir }).stdout).trim();
     } catch { return ""; /* no git in the deploy image */ }
   };
-  const sha = process.env.BUILD_SHA || gitLine("rev-parse", "--short", "HEAD");
+  const sha = process.env.BUILD_SHA
+    || (process.env.BUILD_TIME ? "unknown" : gitLine("rev-parse", "--short", "HEAD") || "unknown");
   // WHEN the code is from, not just which commit. A sha is opaque to anyone
   // without the repo in front of them; "code from 2026-08-10T14:32Z" lets a
   // participant answer "did the deploy pick up this afternoon's fix?" without
   // resolving hashes. Distinct from startedAt on purpose: startedAt says the
   // PROCESS is fresh, commitTime says the CODE is — a restart of stale code
   // looks healthy on the first and stale on the second.
-  const commitTime = process.env.BUILD_TIME || gitLine("show", "-s", "--format=%cI", "HEAD");
+  // SHA AND TIME ARE ONE PROVENANCE PAIR (r3, Antra's re-review): r2 fixed
+  // this class for dirty and left its sibling open — BUILD_SHA without
+  // BUILD_TIME paired the image's sha with the LOCAL checkout's HEAD
+  // timestamp (and vice versa). Both from env, or both from the same git
+  // HEAD, or the missing partner is "unknown" — never filled from another
+  // identity.
+  const envSha = process.env.BUILD_SHA || "";
+  const envTime = process.env.BUILD_TIME || "";
+  const commitTime = envTime
+    || (envSha ? "unknown" : gitLine("show", "-s", "--format=%cI", "HEAD") || "unknown");
   // A sha identifies HEAD — not the bytes actually executing. A tree with
   // uncommitted edits reports a clean-looking sha while running modified
   // code, which is exactly the deployment mystery this endpoint exists to
@@ -1409,7 +1419,7 @@ const BUILD = (() => {
     // the process happens to sit in would report one identity's sha with
     // another's dirtiness. Env-driven sha without env-driven dirty is
     // honestly unknown.
-    if (process.env.BUILD_SHA) return "unknown";
+    if (process.env.BUILD_SHA || process.env.BUILD_TIME) return "unknown";
     const out = gitLine("status", "--porcelain");
     // gitLine returns "" both for a clean tree and for no-git; disambiguate
     // by whether HEAD resolves — no sha from git means no git to trust.

--- a/server/server.ts
+++ b/server/server.ts
@@ -1383,14 +1383,22 @@ function serveFrom(base: string, rel: string, cache = false, req?: Request, immu
 // deployed tree without .git falls back to BUILD_SHA (deploy scripts can set
 // it) and then to "unknown", honestly.
 const BUILD = (() => {
-  let sha = process.env.BUILD_SHA ?? "";
-  if (!sha) {
+  const gitLine = (...args: string[]) => {
     try {
-      sha = new TextDecoder().decode(
-        Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], { cwd: import.meta.dir }).stdout).trim();
-    } catch { /* no git in the deploy image */ }
-  }
-  return { sha: sha || "unknown", startedAt: new Date().toISOString() };
+      return new TextDecoder().decode(
+        Bun.spawnSync(["git", ...args], { cwd: import.meta.dir }).stdout).trim();
+    } catch { return ""; /* no git in the deploy image */ }
+  };
+  const sha = process.env.BUILD_SHA || gitLine("rev-parse", "--short", "HEAD");
+  // WHEN the code is from, not just which commit. A sha is opaque to anyone
+  // without the repo in front of them; "code from 2026-08-10T14:32Z" lets a
+  // participant answer "did the deploy pick up this afternoon's fix?" without
+  // resolving hashes. Distinct from startedAt on purpose: startedAt says the
+  // PROCESS is fresh, commitTime says the CODE is — a restart of stale code
+  // looks healthy on the first and stale on the second.
+  const commitTime = process.env.BUILD_TIME || gitLine("show", "-s", "--format=%cI", "HEAD");
+  return { sha: sha || "unknown", commitTime: commitTime || "unknown",
+           startedAt: new Date().toISOString() };
 })();
 
 const server = Bun.serve({

--- a/server/server.ts
+++ b/server/server.ts
@@ -1390,7 +1390,7 @@ const BUILD = (() => {
     } catch { return ""; /* no git in the deploy image */ }
   };
   const sha = process.env.BUILD_SHA
-    || (process.env.BUILD_TIME ? "unknown" : gitLine("rev-parse", "--short", "HEAD") || "unknown");
+    || ((process.env.BUILD_TIME || process.env.BUILD_DIRTY != null) ? "unknown" : gitLine("rev-parse", "--short", "HEAD") || "unknown");
   // WHEN the code is from, not just which commit. A sha is opaque to anyone
   // without the repo in front of them; "code from 2026-08-10T14:32Z" lets a
   // participant answer "did the deploy pick up this afternoon's fix?" without
@@ -1405,21 +1405,26 @@ const BUILD = (() => {
   // identity.
   const envSha = process.env.BUILD_SHA || "";
   const envTime = process.env.BUILD_TIME || "";
+  // envIdentity computed below governs all three; forward-declare the parts it needs.
+  const envDirtyPresent = process.env.BUILD_DIRTY != null;
   const commitTime = envTime
-    || (envSha ? "unknown" : gitLine("show", "-s", "--format=%cI", "HEAD") || "unknown");
+    || ((envSha || envDirtyPresent) ? "unknown" : gitLine("show", "-s", "--format=%cI", "HEAD") || "unknown");
   // A sha identifies HEAD — not the bytes actually executing. A tree with
   // uncommitted edits reports a clean-looking sha while running modified
   // code, which is exactly the deployment mystery this endpoint exists to
   // end. So say so: dirty=true|false from `git status --porcelain`, or the
   // BUILD_DIRTY env for image builds, or "unknown" when neither can answer —
   // never a silent default that reads as clean.
+  // WHOLE-IDENTITY MATCH (r3+, adversarial review): sha, commitTime and dirty
+  // are ONE provenance triple. If ANY of the three comes from the environment
+  // (an image build), the other two are env-or-unknown — never filled from the
+  // local git tree, in any direction. So a lone BUILD_DIRTY no more licenses a
+  // git-derived sha/time than a lone BUILD_SHA licenses a git-derived dirty:
+  // the local tree is trusted for dirtiness ONLY when the whole identity is
+  // git-derived (no BUILD_SHA, BUILD_TIME, or BUILD_DIRTY set).
+  const envIdentity = !!(process.env.BUILD_SHA || process.env.BUILD_TIME || process.env.BUILD_DIRTY);
   const dirtyRaw = process.env.BUILD_DIRTY ?? (() => {
-    // IDENTITY MATCH (r2 self-review): with BUILD_SHA set, the reported sha
-    // is the IMAGE's — pairing it with `git status` of whatever local tree
-    // the process happens to sit in would report one identity's sha with
-    // another's dirtiness. Env-driven sha without env-driven dirty is
-    // honestly unknown.
-    if (process.env.BUILD_SHA || process.env.BUILD_TIME) return "unknown";
+    if (envIdentity) return "unknown";        // BUILD_SHA or BUILD_TIME set, DIRTY not: image sha, no coherent local partner
     const out = gitLine("status", "--porcelain");
     // gitLine returns "" both for a clean tree and for no-git; disambiguate
     // by whether HEAD resolves — no sha from git means no git to trust.

--- a/server/server.ts
+++ b/server/server.ts
@@ -1376,6 +1376,23 @@ function serveFrom(base: string, rel: string, cache = false, req?: Request, immu
   return new Response(f, { headers });
 }
 
+// Build identity, resolved once at boot. "What is production running?" must be
+// a lookup, not an inference from merge timestamps (2026-08-07: voice fixes
+// were merged for hours while the running sequencer predated them, and nobody
+// could tell from inside the world). Git is queried at startup only — a
+// deployed tree without .git falls back to BUILD_SHA (deploy scripts can set
+// it) and then to "unknown", honestly.
+const BUILD = (() => {
+  let sha = process.env.BUILD_SHA ?? "";
+  if (!sha) {
+    try {
+      sha = new TextDecoder().decode(
+        Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], { cwd: import.meta.dir }).stdout).trim();
+    } catch { /* no git in the deploy image */ }
+  }
+  return { sha: sha || "unknown", startedAt: new Date().toISOString() };
+})();
+
 const server = Bun.serve({
   port: PORT,
   hostname: "0.0.0.0",
@@ -1454,6 +1471,12 @@ const server = Bun.serve({
       if (m && hnSessions.delete(m[1]!)) saveSessions();
       return new Response(JSON.stringify({ ok: true }), {
         headers: { "content-type": "application/json", "set-cookie": "ew_sess=; Path=/; HttpOnly; Max-Age=0" },
+      });
+    }
+    if (url.pathname === "/version") {
+      // Public, cheap, cache-hostile: the whole point is knowing what runs NOW.
+      return new Response(JSON.stringify(BUILD), {
+        headers: { "content-type": "application/json", "cache-control": "no-store" },
       });
     }
     if (url.pathname === "/geom") {

--- a/server/server.ts
+++ b/server/server.ts
@@ -1404,10 +1404,15 @@ const BUILD = (() => {
   // BUILD_DIRTY env for image builds, or "unknown" when neither can answer —
   // never a silent default that reads as clean.
   const dirtyRaw = process.env.BUILD_DIRTY ?? (() => {
+    // IDENTITY MATCH (r2 self-review): with BUILD_SHA set, the reported sha
+    // is the IMAGE's — pairing it with `git status` of whatever local tree
+    // the process happens to sit in would report one identity's sha with
+    // another's dirtiness. Env-driven sha without env-driven dirty is
+    // honestly unknown.
+    if (process.env.BUILD_SHA) return "unknown";
     const out = gitLine("status", "--porcelain");
     // gitLine returns "" both for a clean tree and for no-git; disambiguate
-    // by whether HEAD resolved — no sha from git means no git to trust.
-    if (!process.env.BUILD_SHA && !sha) return "unknown";
+    // by whether HEAD resolves — no sha from git means no git to trust.
     return gitLine("rev-parse", "HEAD") ? (out ? "true" : "false") : "unknown";
   })();
   return { sha: sha || "unknown", commitTime: commitTime || "unknown",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1397,7 +1397,21 @@ const BUILD = (() => {
   // PROCESS is fresh, commitTime says the CODE is — a restart of stale code
   // looks healthy on the first and stale on the second.
   const commitTime = process.env.BUILD_TIME || gitLine("show", "-s", "--format=%cI", "HEAD");
+  // A sha identifies HEAD — not the bytes actually executing. A tree with
+  // uncommitted edits reports a clean-looking sha while running modified
+  // code, which is exactly the deployment mystery this endpoint exists to
+  // end. So say so: dirty=true|false from `git status --porcelain`, or the
+  // BUILD_DIRTY env for image builds, or "unknown" when neither can answer —
+  // never a silent default that reads as clean.
+  const dirtyRaw = process.env.BUILD_DIRTY ?? (() => {
+    const out = gitLine("status", "--porcelain");
+    // gitLine returns "" both for a clean tree and for no-git; disambiguate
+    // by whether HEAD resolved — no sha from git means no git to trust.
+    if (!process.env.BUILD_SHA && !sha) return "unknown";
+    return gitLine("rev-parse", "HEAD") ? (out ? "true" : "false") : "unknown";
+  })();
   return { sha: sha || "unknown", commitTime: commitTime || "unknown",
+           dirty: dirtyRaw === "true" ? true : dirtyRaw === "false" ? false : "unknown",
            startedAt: new Date().toISOString() };
 })();
 

--- a/tools/version-route-test.ts
+++ b/tools/version-route-test.ts
@@ -56,6 +56,9 @@ async function spawnServer(env: Record<string, string | undefined>): Promise<{ p
   const own = await fetch(`http://127.0.0.1:${port}/${nonce}.txt`).then((r) => r.ok && r.text()).catch(() => false);
   if (own !== nonce) throw new Error(`listener on :${port} is not our child — refusing to test it`);
   return { port };
+  // (freePort's probe can false-positive "free" on a slow listener; the nonce
+  // check above is the backstop that turns that race into a loud abort
+  // rather than a wrong-server receipt — abort over false testimony.)
 }
 
 const HOME = process.env.HOME; const BUNPATH = process.env.PATH;
@@ -96,7 +99,13 @@ console.log("\n— B. git-driven identity (dev checkout case) —");
   const body = await (await fetch(`http://127.0.0.1:${port}/version`)).json();
   check("sha resolved from git (not unknown)", body.sha !== "unknown" && body.sha.length >= 7, body.sha);
   check("commitTime resolved from git", body.commitTime !== "unknown" && !Number.isNaN(Date.parse(body.commitTime)));
-  check("dirty is a real boolean when git can answer", body.dirty === true || body.dirty === false, String(body.dirty));
+  // The nonce file this harness plants in client/ is UNTRACKED, so during
+  // any spawned-server's lifetime the checkout is guaranteed dirty — which
+  // makes this the executable proof of the git-derived TRUE path (a
+  // hardcoded `dirty: false` fails here; review caught that the boolean
+  // check alone could not tell them apart).
+  check("git-derived dirty is TRUE while the tree holds the nonce (real detection, not a hardcode)",
+    body.dirty === true, String(body.dirty));
 }
 
 console.log("\n— C. no env, no git: honest unknowns, never fake-clean —");

--- a/tools/version-route-test.ts
+++ b/tools/version-route-test.ts
@@ -1,0 +1,120 @@
+// version-route-test — /version, actually fetched (#51 review ask 1).
+//
+//   bun tools/version-route-test.ts
+//
+// Three spawns of the real server, each proving one leg of the contract:
+//   A. env-driven: BUILD_SHA/BUILD_TIME/BUILD_DIRTY → exact body echo
+//   B. git-driven: no env, repo present → sha/commitTime from git, dirty bool
+//   C. neither: no env, git unreachable → honest "unknown"s, never fake-clean
+// Plus: cache-control:no-store, and startedAt stable across repeated requests
+// (fresh process ≠ fresh code — the field distinction this PR exists for).
+// Port discipline per the stale-listener incident: verified-free random port
+// + a nonce file served from THIS tree before any assertion counts.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+const REPO = join(import.meta.dir, "..");
+const children: ChildProcess[] = [];
+const nonces: string[] = [];
+process.on("exit", () => {
+  for (const c of children) { try { c.kill(); } catch { /* gone */ } }
+  for (const n of nonces) { try { rmSync(n); } catch { /* ok */ } }
+});
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); }
+    catch { return cand; }
+  }
+  throw new Error("no free port");
+}
+
+async function spawnServer(env: Record<string, string | undefined>): Promise<{ port: number }> {
+  const port = await freePort();
+  const nonce = `vr-nonce-${crypto.randomUUID().slice(0, 8)}`;
+  const noncePath = join(REPO, "client", `${nonce}.txt`);
+  writeFileSync(noncePath, nonce); nonces.push(noncePath);
+  const child = spawn("bun", [join(REPO, "server", "server.ts")], {
+    env: { PORT: String(port), WORLDS_DIR: mkdtempSync(join(tmpdir(), "vr-")), ...env },
+    stdio: "ignore",
+  });
+  children.push(child);
+  for (let i = 0; i < 40; i++) {
+    try { await fetch(`http://127.0.0.1:${port}/`); break; }
+    catch { await new Promise((r) => setTimeout(r, 250)); }
+  }
+  const own = await fetch(`http://127.0.0.1:${port}/${nonce}.txt`).then((r) => r.ok && r.text()).catch(() => false);
+  if (own !== nonce) throw new Error(`listener on :${port} is not our child — refusing to test it`);
+  return { port };
+}
+
+const HOME = process.env.HOME; const BUNPATH = process.env.PATH;
+
+console.log("\n— A. env-driven build identity (deploy-image case) —");
+{
+  const { port } = await spawnServer({
+    HOME, PATH: BUNPATH,
+    BUILD_SHA: "cafe123", BUILD_TIME: "2026-08-11T00:00:00Z", BUILD_DIRTY: "false",
+  });
+  const res = await fetch(`http://127.0.0.1:${port}/version`);
+  const body = await res.json();
+  check("env sha echoed exactly", body.sha === "cafe123", JSON.stringify(body));
+  check("env commitTime echoed exactly", body.commitTime === "2026-08-11T00:00:00Z");
+  check("env dirty=false is boolean false", body.dirty === false, String(body.dirty));
+  check("cache-control is no-store", res.headers.get("cache-control") === "no-store",
+    String(res.headers.get("cache-control")));
+  check("startedAt is a valid timestamp", !Number.isNaN(Date.parse(body.startedAt)));
+  await new Promise((r) => setTimeout(r, 1100));
+  const again = await (await fetch(`http://127.0.0.1:${port}/version`)).json();
+  check("startedAt STABLE across requests (process identity, not request time)",
+    again.startedAt === body.startedAt, `${body.startedAt} vs ${again.startedAt}`);
+}
+
+console.log("\n— A2. env-driven dirty=true (a modified deploy must say so) —");
+{
+  const { port } = await spawnServer({
+    HOME, PATH: BUNPATH,
+    BUILD_SHA: "cafe123", BUILD_TIME: "2026-08-11T00:00:00Z", BUILD_DIRTY: "true",
+  });
+  const body = await (await fetch(`http://127.0.0.1:${port}/version`)).json();
+  check("env dirty=true is boolean true (visible, not laundered)", body.dirty === true, String(body.dirty));
+}
+
+console.log("\n— B. git-driven identity (dev checkout case) —");
+{
+  const { port } = await spawnServer({ HOME, PATH: BUNPATH });
+  const body = await (await fetch(`http://127.0.0.1:${port}/version`)).json();
+  check("sha resolved from git (not unknown)", body.sha !== "unknown" && body.sha.length >= 7, body.sha);
+  check("commitTime resolved from git", body.commitTime !== "unknown" && !Number.isNaN(Date.parse(body.commitTime)));
+  check("dirty is a real boolean when git can answer", body.dirty === true || body.dirty === false, String(body.dirty));
+}
+
+console.log("\n— C. no env, no git: honest unknowns, never fake-clean —");
+{
+  // PATH without git: gitLine's spawn fails → catch → "" → "unknown"s.
+  const bare = mkdtempSync(join(tmpdir(), "no-git-bin-"));
+  const bunReal = Bun.which("bun") ?? "/usr/local/bin/bun";
+  const { symlinkSync } = await import("node:fs");
+  symlinkSync(bunReal, join(bare, "bun"));
+  const { port } = await spawnServer({ HOME, PATH: bare });
+  const body = await (await fetch(`http://127.0.0.1:${port}/version`)).json();
+  check("sha falls back to 'unknown'", body.sha === "unknown", body.sha);
+  check("commitTime falls back to 'unknown'", body.commitTime === "unknown", body.commitTime);
+  check("dirty is 'unknown' — NOT false — when nothing can answer",
+    body.dirty === "unknown", String(body.dirty));
+  check("startedAt still present (process identity independent of code identity)",
+    !Number.isNaN(Date.parse(body.startedAt)));
+}
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/version-route-test.ts
+++ b/tools/version-route-test.ts
@@ -108,6 +108,24 @@ console.log("\n— B. git-driven identity (dev checkout case) —");
     body.dirty === true, String(body.dirty));
 }
 
+console.log("\n— B2. mixed provenance refused: sha/time are ONE pair (r3, review vectors) —");
+{
+  // BUILD_SHA without BUILD_TIME, git PRESENT: the tempting-but-wrong move is
+  // filling time from local HEAD — that pairs the image's sha with another
+  // identity's timestamp, the exact composite the dirty fix rejects.
+  const a = await spawnServer({ HOME, PATH: BUNPATH, BUILD_SHA: "cafe123" });
+  const bodyA = await (await fetch(`http://127.0.0.1:${a.port}/version`)).json();
+  check("BUILD_SHA alone, git present: commitTime is unknown, never local HEAD's",
+    bodyA.sha === "cafe123" && bodyA.commitTime === "unknown", `${bodyA.sha} @ ${bodyA.commitTime}`);
+  check("BUILD_SHA alone: dirty stays unknown too (no partner from another tree)",
+    bodyA.dirty === "unknown", String(bodyA.dirty));
+  // The mirror: BUILD_TIME without BUILD_SHA, git present.
+  const b = await spawnServer({ HOME, PATH: BUNPATH, BUILD_TIME: "2026-08-12T00:00:00Z" });
+  const bodyB = await (await fetch(`http://127.0.0.1:${b.port}/version`)).json();
+  check("BUILD_TIME alone, git present: sha is unknown, never local HEAD",
+    bodyB.commitTime === "2026-08-12T00:00:00Z" && bodyB.sha === "unknown", `${bodyB.sha} @ ${bodyB.commitTime}`);
+}
+
 console.log("\n— C. no env, no git: honest unknowns, never fake-clean —");
 {
   // PATH without git: gitLine's spawn fails → catch → "" → "unknown"s.

--- a/tools/version-route-test.ts
+++ b/tools/version-route-test.ts
@@ -124,6 +124,25 @@ console.log("\n— B2. mixed provenance refused: sha/time are ONE pair (r3, revi
   const bodyB = await (await fetch(`http://127.0.0.1:${b.port}/version`)).json();
   check("BUILD_TIME alone, git present: sha is unknown, never local HEAD",
     bodyB.commitTime === "2026-08-12T00:00:00Z" && bodyB.sha === "unknown", `${bodyB.sha} @ ${bodyB.commitTime}`);
+  // The THIRD direction (adversarial review): BUILD_DIRTY alone, git PRESENT.
+  // The image's dirty flag must NOT pair with a local git sha+time — the same
+  // composite class, the remaining member. sha and commitTime go unknown.
+  const c = await spawnServer({ HOME, PATH: BUNPATH, BUILD_DIRTY: "true" });
+  const bodyC = await (await fetch(`http://127.0.0.1:${c.port}/version`)).json();
+  check("BUILD_DIRTY alone, git present: sha AND commitTime are unknown (no local partner for an env dirty)",
+    bodyC.sha === "unknown" && bodyC.commitTime === "unknown", `${bodyC.sha} @ ${bodyC.commitTime} dirty=${bodyC.dirty}`);
+  check("BUILD_DIRTY alone: the env dirty value itself is still honored",
+    bodyC.dirty === true, String(bodyC.dirty));
+  // Garbage / empty BUILD_DIRTY clamps to "unknown", never a leaked raw string.
+  const d = await spawnServer({ HOME, PATH: BUNPATH, BUILD_DIRTY: "" });
+  const bodyD = await (await fetch(`http://127.0.0.1:${d.port}/version`)).json();
+  check("BUILD_DIRTY='' clamps dirty to unknown (no leaked empty string) and still marks env-identity",
+    bodyD.dirty === "unknown" && bodyD.sha === "unknown" && bodyD.commitTime === "unknown",
+    `dirty=${JSON.stringify(bodyD.dirty)} sha=${bodyD.sha}`);
+  const e = await spawnServer({ HOME, PATH: BUNPATH, BUILD_DIRTY: "garbage" });
+  const bodyE = await (await fetch(`http://127.0.0.1:${e.port}/version`)).json();
+  check("BUILD_DIRTY='garbage' clamps dirty to unknown (only true/false pass)",
+    bodyE.dirty === "unknown", JSON.stringify(bodyE.dirty));
 }
 
 console.log("\n— C. no env, no git: honest unknowns, never fake-clean —");


### PR DESCRIPTION
**The itch, from tonight in the commons:** Rabscuttle and deckard spent ten minutes failing to get voice working. The wedged-sender fixes (#36, #26, #47) had been merged for ~7 hours — but the running sequencer predated all of them, and nothing anywhere said so. I diagnosed it from merge timestamps and vibes; Rabscuttle's response was *"we really ought to get a build number displayed somewhere :D"*. He's right.

**Change:**
- `BUILD` resolved once at boot: `git rev-parse --short HEAD`, falling back to `BUILD_SHA` env (for deploy images without .git), then `"unknown"` — honestly.
- `GET /version` → `{sha, startedAt}`, public, `no-store` (the point is knowing what runs NOW).
- One client console line at boot: `[eidoverse] server build 2c16793, up since …` — visible to humans via F12 and to headless clients' logs alike.

**Verified:** scratch sequencer on PORT=8956 answers `{"sha":"2c16793","startedAt":"2026-08-07T05:59:43.804Z"}`; `/geom` untouched.

Deliberately tiny — no UI surface, no new verb (the closed-set doctrine untouched). If you'd rather the sha also ride the join hello or `look()`, happy to follow up, but the HTTP route alone already turns "is prod running the fix?" into `curl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)