### PR TITLE
voice: a live mic always has an attached track (three timing classes, #34)

### DIFF
--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -108,7 +108,7 @@ function peerFor(id) {
   const audio = new Audio();
   audio.autoplay = true;
   audio.playsInline = true;
-  p = { pc, audio };
+  p = { pc, audio, gen: ++_peerGen };
   peers.set(id, p);
   if (micStream) for (const t of micStream.getTracks()) pc.addTrack(t, micStream);
   pc.ontrack = (e) => {
@@ -181,9 +181,35 @@ async function offerOn(p, id, label) {
   } catch (e) { report(label, e); } finally { p._offering = false; }
 }
 
+/** Fire exactly one follow-up offer if our track set changed while this peer
+ *  was mid-negotiation. Generation-bound: pending work raised against an
+ *  earlier peer object is discarded rather than applied to its replacement.
+ *  Idempotent — the flag is cleared before the offer, so a repeated call
+ *  cannot stack duplicate offers. */
+function reconcilePending(p, id) {
+  if (!p || p.pendingReneg == null) return;
+  const owed = p.pendingReneg;
+  p.pendingReneg = null;                 // clear FIRST: no duplicate follow-ups
+  if (owed !== p.gen) return;            // raised against a peer that no longer exists
+  if (p.pc.signalingState !== 'stable') return;
+  renegotiate(id);
+}
+
 async function renegotiate(id) {
   const p = peers.get(id);
-  if (!p || p.pc.signalingState !== 'stable') return;
+  if (!p) return;
+  if (p.pc.signalingState !== 'stable') {
+    // FOURTH TIMING CLASS (Mica, #62). Our track set changed while a
+    // negotiation was already in flight, so we cannot offer now — but the
+    // old offer was built without this track, and no second event will
+    // bring us back here. Dropping the request is how a live mic ends up
+    // on a sendrecv transceiver carrying silence. Record the intent,
+    // STAMPED WITH THIS PEER'S GENERATION, and reconcile on return to
+    // stable; a peer that gets dropped and rebuilt takes its pending work
+    // with it rather than handing it to its successor.
+    p.pendingReneg = p.gen;
+    return;
+  }
   await offerOn(p, id, 'voice renegotiate');
 }
 
@@ -263,13 +289,23 @@ async function processSignal(p, from, payload) {
       const answer = await p.pc.createAnswer();
       await p.pc.setLocalDescription(answer);
       sendRtc(from, { sdp: p.pc.localDescription });
+      // NOT reconciled here. Answering lands us in stable, but applyDirection
+      // above already put the current track set into the answer we just sent —
+      // the far end has it. Firing a follow-up offer would re-destabilize a
+      // peer that is already correct, and it regressed the mid-negotiation
+      // test (peer ended have-local-offer instead of stable). The pending flag
+      // is owed only where WE were the offerer and our offer went out stale.
+      p.pendingReneg = null;
+
     } else if (payload.sdp?.type === 'answer') {
       if (p.pc.signalingState === 'have-local-offer') {
         await p.pc.setRemoteDescription(payload.sdp);
-      for (const c of p.pendingIce ?? []) {
-        await p.pc.addIceCandidate(c).catch((err) => (window.__iceLog ??= []).push(`flushIce-FAIL ${err.name}`));
-      }
-      p.pendingIce = [];
+        for (const c of p.pendingIce ?? []) {
+          await p.pc.addIceCandidate(c).catch((err) => (window.__iceLog ??= []).push(`flushIce-FAIL ${err.name}`));
+        }
+        p.pendingIce = [];
+        // Back to stable: pay any renegotiation we owed from mid-flight.
+        reconcilePending(p, from);
       }
     } else if (payload.ice) {
       if (p.pc.remoteDescription) {
@@ -342,6 +378,11 @@ export async function toggleMic(name) {
 // mute your presence. Level crossing the visible panel floor emits one
 // 'mic' typing-presence event; hysteresis (fall to 60% of floor) plus a
 // 1.5s refractory keep sustained speech from machine-gunning the channel.
+// Monotonic peer generation. A peer REPLACED by dropPeer+rebuild is a
+// different peer with the same id, and work scheduled against the old one
+// must not land on the new one — answers carry no negotiation identity of
+// their own, so we supply it (Mica, #62 review).
+let _peerGen = 0;
 let _onsetTimer = null, _above = false, _lastOnset = 0;
 function onsetTick() {
   const floor = micFloor();
@@ -496,6 +537,12 @@ export const voiceDebug = () => Object.fromEntries([...peers].map(([id, p]) => [
  *  audible while its mouth never moves, a half-repair visible only to everyone
  *  ELSE. Exported so that gap is assertable (and greppable in prod) rather
  *  than only observable by watching a face that should be talking. */
+/** Which peers owe a follow-up offer, and at which generation. The fourth
+ *  timing class is invisible from outside otherwise: a peer that owes a
+ *  renegotiation looks exactly like one that does not. */
+export const voicePendingReneg = () =>
+  Object.fromEntries([...peers].map(([id, p]) => [id, p.pendingReneg ?? null]));
+
 export const voiceMouthBound = () =>
   Object.fromEntries([...peers].map(([id, p]) => [id, !!p.stream]));
 export const voicePcs = () => [...peers.values()].map((p) => p.pc); // experiment branch: raw pcs for stats probes

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -325,7 +325,12 @@ export async function toggleMic(name) {
   // existing sender needs no renegotiation at all.
   for (const p of peers.values()) applyDirection(p);
   for (const id of [...peers.keys()]) renegotiate(id);
-  for (const id of humanIds()) offerTo(id);
+  // Only reach for peers we do NOT already hold. A peer mid-negotiation has
+  // an answer in flight that will carry the track we just attached — offering
+  // into it forces glare against ourselves and leaves the peer parked in
+  // have-local-offer (Mica, #34). renegotiate() above already covers the
+  // stable ones; this covers the strangers.
+  for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
   flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');
   bus.emit('voice', { on: true });
   startOnsetWatch();

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -78,6 +78,20 @@ function reenableInbound(p) {
 function applyDirection(p) {
   const dir = wantDirection();
   try {
+    // A live mic with nothing attached is the same class of mismatch as a
+    // wrong direction, so it is repaired in the same place. addTrack runs only
+    // in peerFor's construction path, which leaves two windows where a peer
+    // ends up permanently silent: a mic opened after the peer was built, and —
+    // the race that made this intermittent — a peer built DURING the await on
+    // getUserMedia, when micStream is still null and any one-shot back-fill
+    // has already run. Every offer and renegotiation passes through here, so
+    // attaching here makes it an invariant rather than a patch per path.
+    if (micStream) {
+      const track = micStream.getAudioTracks()[0];
+      const sender = p.pc.getSenders().find((s) => s.track?.kind === 'audio' || !s.track);
+      if (track && sender && sender.track !== track) sender.replaceTrack(track).catch((e) => report('voice track', e));
+      else if (track && !sender) p.pc.addTrack(track, micStream);
+    }
     for (const t of p.pc.getTransceivers?.() ?? []) {
       if (t.receiver?.track?.kind === 'audio' || t.sender?.track?.kind === 'audio' || !t.receiver) {
         if (t.direction !== dir) t.direction = dir;
@@ -303,6 +317,9 @@ export async function toggleMic(name) {
     flashHint('microphone unavailable — check browser permission');
     return false;
   }
+  // Existing peers are repaired by applyDirection, which every renegotiate
+  // and offer runs through — so re-offering is enough to attach the new track.
+  for (const id of [...peers.keys()]) renegotiate(id);
   for (const id of humanIds()) offerTo(id);
   flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');
   bus.emit('voice', { on: true });

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -317,8 +317,13 @@ export async function toggleMic(name) {
     flashHint('microphone unavailable — check browser permission');
     return false;
   }
-  // Existing peers are repaired by applyDirection, which every renegotiate
-  // and offer runs through — so re-offering is enough to attach the new track.
+  // Attach FIRST, renegotiate second. applyDirection is where the track is
+  // adopted, but renegotiate() bails on a peer that is not 'stable' — and a
+  // peer mid-negotiation when the mic opens is exactly one of the cases this
+  // is repairing, so routing the attachment only through renegotiate would
+  // skip it. Attaching is safe in any signaling state; replaceTrack on an
+  // existing sender needs no renegotiation at all.
+  for (const p of peers.values()) applyDirection(p);
   for (const id of [...peers.keys()]) renegotiate(id);
   for (const id of humanIds()) offerTo(id);
   flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -22,6 +22,10 @@ import { myState } from './controller.js';
 import { flashHint } from './ui.js';
 import { receivingVoice, volumeFor, isHushed } from './voiceconsent.js';
 
+// How long an unanswered local offer stays 'live' for glare purposes. Past
+// this, an incoming offer is treated as a rejoin rather than a rival — a real
+// glare rival answers within a round trip.
+const GLARE_GRACE_MS = 4000;
 const RTC_CFG = { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] };
 const FULL_M = 3, SILENT_M = 20;   // full volume inside 3m, gone by 20m
 
@@ -29,11 +33,7 @@ let micStream = null;
 let muted = false;
 const peers = new Map();           // id -> { pc, audio }
 let myId = null;
-// TRANSMITTING, not "a stream object exists". Going quiet now disables the
-// track instead of stopping it (see toggleMic), so micStream outlives mic-off
-// and `!!micStream` would leave the HUD stuck reading ON. Every caller of
-// micOn() is UI asking "am I being heard right now?" — this is that question.
-export const micOn = () => !!micStream && micStream.getAudioTracks().some((t) => t.enabled);
+export const micOn = () => !!micStream;
 export const isMuted = () => muted;
 
 function humanIds() {
@@ -181,6 +181,7 @@ async function offerOn(p, id, label) {
     applyDirection(p);
     const offer = await p.pc.createOffer();
     await p.pc.setLocalDescription(offer);
+    p._offeredAt = Date.now();     // for the rejoin-vs-glare distinction
     sendRtc(id, { sdp: p.pc.localDescription });
   } catch (e) { report(label, e); } finally { p._offering = false; }
 }
@@ -191,10 +192,26 @@ async function offerOn(p, id, label) {
  *  Idempotent — the flag is cleared before the offer, so a repeated call
  *  cannot stack duplicate offers. */
 function reconcilePending(p, id) {
+  // Bounded trace of every reconciliation decision. The cross-generation seam
+  // is invisible downstream — a leaked follow-up may still bail on signaling
+  // state, so an offer COUNT cannot see it — and this is what makes the
+  // refusal assertable. Capped so a long session cannot grow it without bound.
+  {
+    const L = (globalThis.__reconcileLog ??= []);
+    L.push(`id=${id} owed=${p?.pendingReneg} gen=${p?.gen} isCurrent=${peers.get(id) === p}`);
+    if (L.length > 200) L.splice(0, L.length - 200);
+  }
   if (!p || p.pendingReneg == null) return;
   const owed = p.pendingReneg;
   p.pendingReneg = null;                 // clear FIRST: no duplicate follow-ups
-  if (owed !== p.gen) return;            // raised against a peer that no longer exists
+  if (owed !== p.gen) return;            // debt belongs to this peer object
+  // ...and this peer object must still BE the peer for this id. The generation
+  // check above is self-referential: an old answer handler that was already
+  // mid-await when its peer was dropped and rebuilt compares the old object to
+  // its own gen, matches, and then renegotiate(id) resolves peers.get(id) —
+  // the REPLACEMENT. So the dead peer's debt gets paid by its successor, which
+  // is the exact leak the generation stamp was meant to prevent (Mica, #62).
+  if (peers.get(id) !== p) return;
   if (p.pc.signalingState !== 'stable') return;
   renegotiate(id);
 }
@@ -281,7 +298,27 @@ async function processSignal(p, from, payload) {
       // glare: both sides offered at once — the LOWER id's offer stands, the
       // higher id rolls back and answers (deterministic, no extra messages)
       if (p.pc.signalingState === 'have-local-offer') {
-        if ((myId ?? '') < from) return;               // mine stands; ignore theirs
+        // GLARE vs REJOIN. Glare's premise is that BOTH offers are live, so
+        // the loser's offer will be answered by the winner. A peer that
+        // RELOADED breaks that premise: their old session is gone, nobody is
+        // left to answer the offer we are protecting, and returning here
+        // discards the only live offer in the exchange — both sides strand,
+        // silently, forever. Field receipt 2026-08-08: "she could hear me
+        // until she hard reloaded."
+        //
+        // The tell is that our offer has been outstanding with no answer. A
+        // true glare rival answers within a round trip; a reloaded peer never
+        // will, because the session that owed us that answer no longer exists.
+        // So yield to an offer that arrives after our own has gone unanswered
+        // past a round trip, and keep the id rule only for the genuine
+        // simultaneous case.
+        // The tell is not TIME — a slow link can exceed any grace legitimately —
+        // it is whether this peer has ever answered anything of ours. A true
+        // glare rival is mid-exchange on a live connection; a reloaded peer is
+        // brand new to us and has never completed a negotiation. `_everStable`
+        // is set the first time we reach a settled state with them, so an
+        // offer from a peer we have never settled with is a JOIN, not a rival.
+        if (p._everStable && (myId ?? '') < from) return;   // real glare: mine stands
         await p.pc.setLocalDescription({ type: 'rollback' });
       }
       await p.pc.setRemoteDescription(payload.sdp);
@@ -292,6 +329,7 @@ async function processSignal(p, from, payload) {
       applyDirection(p);            // our answer states OUR consent, not theirs
       const answer = await p.pc.createAnswer();
       await p.pc.setLocalDescription(answer);
+      p._everStable = true;      // we answered them: a real exchange happened
       sendRtc(from, { sdp: p.pc.localDescription });
       // NOT reconciled here. Answering lands us in stable, but applyDirection
       // above already put the current track set into the answer we just sent —
@@ -303,6 +341,8 @@ async function processSignal(p, from, payload) {
 
     } else if (payload.sdp?.type === 'answer') {
       if (p.pc.signalingState === 'have-local-offer') {
+        p._offeredAt = null;       // answered: no longer an outstanding offer
+        p._everStable = true;      // we have completed a negotiation with them
         await p.pc.setRemoteDescription(payload.sdp);
         for (const c of p.pendingIce ?? []) {
           await p.pc.addIceCandidate(c).catch((err) => (window.__iceLog ??= []).push(`flushIce-FAIL ${err.name}`));
@@ -325,47 +365,37 @@ async function processSignal(p, from, payload) {
 
 export async function toggleMic(name) {
   myId = name ?? myId;
-  if (micOn()) {
-    // GOING QUIET IS A DATA CHANGE, NOT A CONNECTION CHANGE (R, 2026-08-08).
-    //
-    // This used to stop() the track, removeTrack() it from every peer, and
-    // renegotiate — three destructive operations to express "don't transmit".
-    // Four of the six voice bugs fixed this week were in the renegotiation
-    // that followed, and stop() manufactures precisely the `audio:ended`
-    // sender state that the live one-way-audio blocker shows in the field.
-    // The identical intent was already implemented correctly ten lines below
-    // in toggleMute (track.enabled = false, zero renegotiation, zero bugs) —
-    // it simply had no callers, while the HUD button called this.
-    //
-    // So: disable the track. It stays live, the sender stays bound, the
-    // transceiver stays sendonly, the SDP does not change, and coming back is
-    // one assignment rather than getUserMedia + renegotiate. Muting cannot
-    // deafen you because no peer is touched at all.
-    for (const t of micStream.getTracks()) t.enabled = false;
+  if (micStream) {
+    // SEND state only. Going quiet must not deafen you: listening is a
+    // separate permission (review catch — the old teardown dropped every
+    // peer, including inbound legs, which then had no trigger to re-offer
+    // until the next roster event, so muting yourself silently deafened you
+    // for an unbounded time). We remove OUR track from each peer and keep
+    // the connection alive; if we are not listening either, THEN the peer
+    // has no purpose and comes down.
+    for (const t of micStream.getTracks()) t.stop();
+    micStream = null;
     stopOnsetWatch();
     muted = false;
+    for (const [id, p] of [...peers]) {
+      try {
+        for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
+      } catch (e) { report('voice untrack', e); }
+      if (!receivingVoice()) dropPeer(id);
+      else renegotiate(id);          // tell them our track is gone; keep theirs
+    }
     flashHint('🎙 off');
     bus.emit('voice', { on: false });
     return false;
   }
-  // Coming back. If we still hold the stream (the normal case now — mic-off
-  // only disables it) re-enabling IS the whole acquisition step: no
-  // getUserMedia, so no permission re-prompt and no new track object. Then we
-  // fall THROUGH to the same attach/renegotiate/court-peers path a fresh mic
-  // takes; returning early here skipped peer creation entirely, which the
-  // lifecycle suite caught at once (mic ON with no peer courted).
-  if (micStream) {
-    for (const t of micStream.getTracks()) t.enabled = true;
-  } else {
-    try {
-      micStream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: true, noiseSuppression: true },
-      });
-    } catch (e) {
-      report('microphone', e);
-      flashHint('microphone unavailable — check browser permission');
-      return false;
-    }
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true },
+    });
+  } catch (e) {
+    report('microphone', e);
+    flashHint('microphone unavailable — check browser permission');
+    return false;
   }
   // Attach FIRST, renegotiate second. applyDirection is where the track is
   // adopted, but renegotiate() bails on a peer that is not 'stable' — and a
@@ -438,10 +468,6 @@ export function micAnalyserLevel() {
   return Math.sqrt(s / _anBuf.length);
 }
 
-// Kept as the explicit verb for "go quiet without touching the mic button's
-// meaning" — it is now the SAME mechanism toggleMic uses (track.enabled), so
-// the two can no longer disagree. Before 2026-08-08 this was the correct
-// implementation with zero callers while the HUD used the destructive path.
 export function toggleMute() {
   if (!micStream) return false;
   muted = !muted;
@@ -449,26 +475,6 @@ export function toggleMute() {
   flashHint(muted ? '🔇 muted' : '🎙 unmuted');
   bus.emit('voice', { on: true, muted });
   return muted;
-}
-
-/** Release the microphone device entirely — the OS/browser recording indicator
- *  goes away. This is the ONLY path that stops tracks, and it is deliberately
- *  not what the HUD mic button does: it costs a permission re-prompt and a
- *  renegotiation to undo, so it is a privacy action, not a "go quiet" action. */
-export function releaseMicrophone() {
-  if (!micStream) return;
-  for (const t of micStream.getTracks()) t.stop();
-  micStream = null;
-  muted = false;
-  stopOnsetWatch();
-  for (const [id, p] of [...peers]) {
-    try {
-      for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
-    } catch (e) { report('voice untrack', e); }
-    if (!receivingVoice()) dropPeer(id); else renegotiate(id);
-  }
-  flashHint('🎙 released');
-  bus.emit('voice', { on: false });
 }
 
 export function initVoice(name) {
@@ -501,11 +507,8 @@ export function initVoice(name) {
     if (micStream) for (const id of humanIds()) offerTo(id);
   });
   bus.on('roster', () => {
-    // Arrivals get an offer while we're LIVE; departures get torn down.
-    // micOn(), not micStream: since mic-off keeps the stream and only disables
-    // the track, `micStream` is truthy while muted and would court strangers we
-    // have nothing to say to. Transmitting is the condition that matters.
-    if (micOn()) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
+    // arrivals get an offer while we're live; departures get torn down
+    if (micStream) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
     for (const id of [...peers.keys()]) if (!remotes.has(id)) dropPeer(id);
   });
   // Two clocks on purpose. Distance is a slow fact — 300ms is plenty and
@@ -581,6 +584,10 @@ export const voiceDebug = () => Object.fromEntries([...peers].map(([id, p]) => [
 /** Which peers owe a follow-up offer, and at which generation. The fourth
  *  timing class is invisible from outside otherwise: a peer that owes a
  *  renegotiation looks exactly like one that does not. */
+/** TEST SEAM: clear a peer's pending debt so a regression can isolate work
+ *  that could only have come from a DIFFERENT peer generation. */
+export const voiceClearPending = (id) => { const p = peers.get(id); if (p) p.pendingReneg = null; };
+
 export const voicePendingReneg = () =>
   Object.fromEntries([...peers].map(([id, p]) => [id, p.pendingReneg ?? null]));
 

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -29,7 +29,11 @@ let micStream = null;
 let muted = false;
 const peers = new Map();           // id -> { pc, audio }
 let myId = null;
-export const micOn = () => !!micStream;
+// TRANSMITTING, not "a stream object exists". Going quiet now disables the
+// track instead of stopping it (see toggleMic), so micStream outlives mic-off
+// and `!!micStream` would leave the HUD stuck reading ON. Every caller of
+// micOn() is UI asking "am I being heard right now?" — this is that question.
+export const micOn = () => !!micStream && micStream.getAudioTracks().some((t) => t.enabled);
 export const isMuted = () => muted;
 
 function humanIds() {
@@ -321,37 +325,47 @@ async function processSignal(p, from, payload) {
 
 export async function toggleMic(name) {
   myId = name ?? myId;
-  if (micStream) {
-    // SEND state only. Going quiet must not deafen you: listening is a
-    // separate permission (review catch — the old teardown dropped every
-    // peer, including inbound legs, which then had no trigger to re-offer
-    // until the next roster event, so muting yourself silently deafened you
-    // for an unbounded time). We remove OUR track from each peer and keep
-    // the connection alive; if we are not listening either, THEN the peer
-    // has no purpose and comes down.
-    for (const t of micStream.getTracks()) t.stop();
-    micStream = null;
+  if (micOn()) {
+    // GOING QUIET IS A DATA CHANGE, NOT A CONNECTION CHANGE (R, 2026-08-08).
+    //
+    // This used to stop() the track, removeTrack() it from every peer, and
+    // renegotiate — three destructive operations to express "don't transmit".
+    // Four of the six voice bugs fixed this week were in the renegotiation
+    // that followed, and stop() manufactures precisely the `audio:ended`
+    // sender state that the live one-way-audio blocker shows in the field.
+    // The identical intent was already implemented correctly ten lines below
+    // in toggleMute (track.enabled = false, zero renegotiation, zero bugs) —
+    // it simply had no callers, while the HUD button called this.
+    //
+    // So: disable the track. It stays live, the sender stays bound, the
+    // transceiver stays sendonly, the SDP does not change, and coming back is
+    // one assignment rather than getUserMedia + renegotiate. Muting cannot
+    // deafen you because no peer is touched at all.
+    for (const t of micStream.getTracks()) t.enabled = false;
     stopOnsetWatch();
     muted = false;
-    for (const [id, p] of [...peers]) {
-      try {
-        for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
-      } catch (e) { report('voice untrack', e); }
-      if (!receivingVoice()) dropPeer(id);
-      else renegotiate(id);          // tell them our track is gone; keep theirs
-    }
     flashHint('🎙 off');
     bus.emit('voice', { on: false });
     return false;
   }
-  try {
-    micStream = await navigator.mediaDevices.getUserMedia({
-      audio: { echoCancellation: true, noiseSuppression: true },
-    });
-  } catch (e) {
-    report('microphone', e);
-    flashHint('microphone unavailable — check browser permission');
-    return false;
+  // Coming back. If we still hold the stream (the normal case now — mic-off
+  // only disables it) re-enabling IS the whole acquisition step: no
+  // getUserMedia, so no permission re-prompt and no new track object. Then we
+  // fall THROUGH to the same attach/renegotiate/court-peers path a fresh mic
+  // takes; returning early here skipped peer creation entirely, which the
+  // lifecycle suite caught at once (mic ON with no peer courted).
+  if (micStream) {
+    for (const t of micStream.getTracks()) t.enabled = true;
+  } else {
+    try {
+      micStream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true },
+      });
+    } catch (e) {
+      report('microphone', e);
+      flashHint('microphone unavailable — check browser permission');
+      return false;
+    }
   }
   // Attach FIRST, renegotiate second. applyDirection is where the track is
   // adopted, but renegotiate() bails on a peer that is not 'stable' — and a
@@ -424,6 +438,10 @@ export function micAnalyserLevel() {
   return Math.sqrt(s / _anBuf.length);
 }
 
+// Kept as the explicit verb for "go quiet without touching the mic button's
+// meaning" — it is now the SAME mechanism toggleMic uses (track.enabled), so
+// the two can no longer disagree. Before 2026-08-08 this was the correct
+// implementation with zero callers while the HUD used the destructive path.
 export function toggleMute() {
   if (!micStream) return false;
   muted = !muted;
@@ -431,6 +449,26 @@ export function toggleMute() {
   flashHint(muted ? '🔇 muted' : '🎙 unmuted');
   bus.emit('voice', { on: true, muted });
   return muted;
+}
+
+/** Release the microphone device entirely — the OS/browser recording indicator
+ *  goes away. This is the ONLY path that stops tracks, and it is deliberately
+ *  not what the HUD mic button does: it costs a permission re-prompt and a
+ *  renegotiation to undo, so it is a privacy action, not a "go quiet" action. */
+export function releaseMicrophone() {
+  if (!micStream) return;
+  for (const t of micStream.getTracks()) t.stop();
+  micStream = null;
+  muted = false;
+  stopOnsetWatch();
+  for (const [id, p] of [...peers]) {
+    try {
+      for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
+    } catch (e) { report('voice untrack', e); }
+    if (!receivingVoice()) dropPeer(id); else renegotiate(id);
+  }
+  flashHint('🎙 released');
+  bus.emit('voice', { on: false });
 }
 
 export function initVoice(name) {
@@ -463,8 +501,11 @@ export function initVoice(name) {
     if (micStream) for (const id of humanIds()) offerTo(id);
   });
   bus.on('roster', () => {
-    // arrivals get an offer while we're live; departures get torn down
-    if (micStream) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
+    // Arrivals get an offer while we're LIVE; departures get torn down.
+    // micOn(), not micStream: since mic-off keeps the stream and only disables
+    // the track, `micStream` is truthy while muted and would court strangers we
+    // have nothing to say to. Transmitting is the condition that matters.
+    if (micOn()) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
     for (const id of [...peers.keys()]) if (!remotes.has(id)) dropPeer(id);
   });
   // Two clocks on purpose. Distance is a slow fact — 300ms is plenty and

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -744,6 +744,27 @@ check("unhush rejoins the SAME peer at full volume",
     `${pcDuring.getSenders().length} senders total`);
 }
 
+{
+  // Digi/antra field case (commons, 2026-08-07): voice worked ONCE, then never
+  // again across mic toggles. removeTrack nulls the sender but leaves it in
+  // place, so a later mic-on — which only addTracks on NEW peers — never
+  // re-attaches. The first toggle-off is permanent, not unlucky.
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  consent.setReceiveVoice(true);
+  created.length = 0;
+  if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }   // mic ON first
+  stubs.remotes.set("digi", { agent: false });
+  bus.emit("roster"); await settle();
+  const pcT = created.at(-1)!;
+  check("toggle: first connection while mic live has a track (the 'hello' that worked)",
+    pcT.getSenders().filter((s) => s.track).length === 1);
+  await voice.toggleMic("me"); await settle();     // mic OFF
+  await voice.toggleMic("me"); await settle();     // mic ON again
+  check("toggle: mic off->on re-attaches to the SAME peer (was permanent silence)",
+    pcT.getSenders().filter((s) => s.track).length === 1,
+    `${pcT.getSenders().filter((s) => s.track).length} live of ${pcT.getSenders().length}`);
+}
+
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -682,6 +682,68 @@ check("unhush rejoins the SAME peer at full volume",
   consent.setReceiveVoice(false);
 }
 
+// ---- mic-after-peer: the track must reach peers built before it -----------
+// Two races, both leaving a peer with a sender carrying NO track on a
+// transceiver negotiated sendrecv: it renegotiates happily and transmits
+// silence, forever, while the UI reports "mic LIVE". Field receipt (phone on
+// cellular -> Burrow, 2026-08-07): in=1179 out=0.
+// Both FAIL on pre-fix main.
+{
+  // T6: peer exists BEFORE the mic opens.
+  // toggleMic is a TOGGLE — drive to the state, never assume a call reaches it.
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  consent.setReceiveVoice(true);
+  created.length = 0;
+  stubs.remotes.set("early", { agent: false });
+  bus.emit("roster");                                // peer built with no mic
+  await settle();
+  bus.emit("rtc", { from: "early", payload: { sdp: { type: "offer", sdp: "x" } } });
+  await settle();
+  const pcEarly = created.at(-1)!;
+  if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }   // mic ON now
+  await settle();
+  const live = pcEarly.getSenders().filter((s) => s.track);
+  check("mic-after-peer: an existing peer gets the track (was a sender with none)",
+    live.length === 1, `${live.length} live senders of ${pcEarly.getSenders().length}`);
+
+  // T7: a peer appears WHILE mic acquisition is still pending. This is the
+  // race that made it intermittent — getUserMedia takes hundreds of ms, and a
+  // peer built inside that await is constructed while micStream is still null,
+  // so addTrack skips it AND any one-shot back-fill has already run. Forced
+  // deterministically rather than hoped for: the stub holds the promise open
+  // until we have created the peer.
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }    // back to mic OFF
+  created.length = 0;
+  let release: (() => void) | null = null;
+  const held = new Promise<void>((r) => { release = r; });
+  const realGUM = navigator.mediaDevices.getUserMedia;
+  (navigator.mediaDevices as { getUserMedia: unknown }).getUserMedia = async (c: unknown) => {
+    await held;                                      // peer arrives during this
+    return realGUM.call(navigator.mediaDevices, c);
+  };
+  const micOpening = voice.micOn() ? Promise.resolve(false) : voice.toggleMic("me");
+  await settle();
+  stubs.remotes.set("during", { agent: false });
+  bus.emit("rtc", { from: "during", payload: { sdp: { type: "offer", sdp: "x" } } });
+  await settle();                                    // peer now exists, micStream still null
+  release!();
+  await micOpening;
+  await settle();
+  (navigator.mediaDevices as { getUserMedia: unknown }).getUserMedia = realGUM;
+  const pcDuring = created.at(-1)!;
+  const liveDuring = pcDuring.getSenders().filter((s) => s.track);
+  check("mic-during-acquisition: a peer born inside the getUserMedia await still gets the track",
+    liveDuring.length === 1, `${liveDuring.length} live senders of ${pcDuring.getSenders().length}`);
+
+  // Exactly one — a repair that attaches on every renegotiation must not
+  // accumulate duplicate senders on a peer that is offered to repeatedly.
+  bus.emit("roster"); await settle();
+  bus.emit("roster"); await settle();
+  check("mic-after-peer: repeated renegotiation does not stack duplicate senders",
+    pcDuring.getSenders().filter((s) => s.track).length === 1,
+    `${pcDuring.getSenders().length} senders total`);
+}
+
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -825,9 +825,14 @@ check("unhush rejoins the SAME peer at full volume",
   // something reconciles on return to stable, the far end is left holding a
   // description of a dead track.
   //
-  // (The mic-LESS local offer Mica describes may not be reachable — every
-  // offer-initiating path on this branch is gated on micStream. Asked rather
-  // than guessed; if it is reachable, that test comes separately.)
+  // (CORRECTED: the mic-LESS local offer IS reachable, and my "every offer
+  // path is mic-gated" reading was wrong — I grepped the offer-INITIATING
+  // sites and skipped renegotiate()'s callers. toggleMic's OFF branch calls
+  // renegotiate AFTER micStream = null, so it builds a genuinely mic-less
+  // offer and parks the peer in have-local-offer. Note it fires only when
+  // receive is ON — the same asymmetry as the toggle bug: it selects for
+  // listeners. The generation-bound pending-on-stable repair for that case is
+  // still outstanding; this test covers the mid-offer variant only.)
   if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
   consent.setReceiveVoice(true);
   if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }   // mic ON

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -247,10 +247,25 @@ const liveTrack = (await import("../client/lib/voice.js")).micOn();
 await voice.toggleMic("me");
 check("mic off stops the local track", liveTrack === true && voice.micOn() === false);
 check("mic off does NOT close a consented inbound peer (send ≠ receive)", !inbound.closed);
-check("mic off leaves no outbound track on the peer",
-  inbound.getSenders().every((s) => s.track === null));
+// THE CONTRACT CHANGED (2026-08-08). Mic-off used to stop() the track and
+// removeTrack() it from every peer, then renegotiate — three destructive acts
+// to express "don't transmit", and the source of four of the six voice bugs
+// fixed this week. It now disables the track instead, so the sender KEEPS it
+// and the SDP never changes. Asserting track === null here would be asserting
+// the bug. What matters is that nothing audible leaves:
+check("mic off keeps the sender bound but silences it (no renegotiation)",
+  inbound.getSenders().every((s) => !s.track || s.track.enabled === false));
+check("mic off does not stop() the track — an ended track cannot be revived",
+  inbound.getSenders().every((s) => !s.track || s.track.readyState !== "ended"));
 
 // ---- refusal must not loop ------------------------------------------------
+// Refusal is only reachable from a body that holds NO stream. Since mic-off
+// keeps the stream (and re-enabling needs no permission — correctly: a mic you
+// were already granted is not re-asked for), the honest way to reach the
+// permission path is to RELEASE the device first. That is what
+// releaseMicrophone() is for, and it is the only caller that stops tracks.
+voice.releaseMicrophone();
+await settle();
 denyMic = true;
 const before = micDenies;
 const r1 = await voice.toggleMic("me");
@@ -284,6 +299,13 @@ consent.setReceiveVoice(false);
 created.length = 0;
 stubs.remotes.set("peer1", { agent: false });
 denyMic = false;
+// Drive to the state, never assume a call reaches it (the discipline this file
+// states at the bottom). Mic-off now KEEPS the stream and only disables the
+// track, so a bare toggleMic() means "flip", not "on".
+// A real off->on cycle, so the courting path runs for THIS test's peer rather
+// than relying on one a previous test happened to leave behind.
+if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+created.length = 0;
 await voice.toggleMic("me");            // mic ON, receive OFF
 await settle();
 const outbound = created.at(-1)!;

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -765,6 +765,28 @@ check("unhush rejoins the SAME peer at full volume",
     `${pcT.getSenders().filter((s) => s.track).length} live of ${pcT.getSenders().length}`);
 }
 
+{
+  // The toggle bug bites LISTENERS, not speakers. mic-off drops the peer when
+  // we are not receiving (so mic-on rebuilds it with the track — recovers),
+  // but keeps it when we are (stripping the track and leaving an empty
+  // sender). Digi toggled freely in commons while mic-only; anyone wearing
+  // headphones would have been silenced by their own toggle with no signal.
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  consent.setReceiveVoice(false);                 // mic-only, like Digi
+  created.length = 0;
+  if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  stubs.remotes.set("deaf", { agent: false });
+  bus.emit("roster"); await settle();
+  await voice.toggleMic("me"); await settle();    // OFF -> dropPeer
+  await voice.toggleMic("me"); await settle();    // ON  -> fresh peer
+  bus.emit("roster"); await settle();
+  const pcFresh = created.at(-1)!;
+  check("toggle while NOT receiving: peer is rebuilt with a track (why Digi's toggles worked)",
+    pcFresh.getSenders().filter((s) => s.track).length === 1,
+    `${pcFresh.getSenders().filter((s) => s.track).length} live of ${pcFresh.getSenders().length}`);
+  consent.setReceiveVoice(true);
+}
+
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1,3 +1,4 @@
+const peersOf = (): any => undefined;
 // voice-lifecycle — the consent choices, executed.
 //
 //   bun tools/voice-lifecycle-test.ts
@@ -77,7 +78,12 @@ class FakePC {
   /** the direction actually offered to the far end */
   offeredDirection() { return this.transceivers[0]?.direction ?? "none"; }
   static gate: Promise<void> | null = null;   // slows createOffer for race tests
+  offers = 0;                 // how many offers this peer has actually produced —
+                              // the fourth-class tests assert on EXACTLY ONE
+                              // follow-up, which needs a real count rather than
+                              // a field that silently reads undefined.
   async createOffer(opts?: unknown) {
+    this.offers++;
     this.lastOfferOpts = opts ?? null;
     if (FakePC.gate) await FakePC.gate;
     return { type: "offer", sdp: "fake" };
@@ -847,6 +853,106 @@ check("unhush rejoins the SAME peer at full volume",
   const liveStale = pcStale.getSenders().filter((s) => s.track);
   check("stale-offer: the peer carries exactly one live track after a mid-offer toggle",
     liveStale.length === 1, `${liveStale.length} live of ${pcStale.getSenders().length}`);
+}
+
+// ---- FOURTH TIMING CLASS: mic change during an outstanding local offer ------
+// Mica's #62 review. The peer holds a local offer built WITHOUT the mic track;
+// toggling the mic attaches locally, but renegotiate() bails while unstable and
+// nothing schedules a follow-up — so the far end keeps a description of a
+// send-less peer forever and nobody hears you. Field receipt: Digi in commons,
+// 2026-08-08, "nobody on desktop or mobile heard her".
+//
+// HONEST NOTE ON THE FIXTURE: the peer is parked in have-local-offer
+// DELIBERATELY, not reached by a natural race. Several attempts at a natural
+// repro kept landing in stable because createOffer cannot be reliably held open
+// at the moment renegotiate runs. The state is real and reachable in
+// production (toggleMic's OFF branch renegotiates after micStream = null);
+// this test forces it rather than claiming a repro I do not have.
+{
+  consent.setReceiveVoice(true);
+  if (!voice.micOn()) await voice.toggleMic("me");
+  await settle();
+  created.length = 0;
+  stubs.remotes.set("fourth", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const pc4 = created.at(-1)!;
+  if (!pc4) throw new Error("no peer built for the fourth-class test");
+
+  // The peer is ALREADY in have-local-offer: it offered on roster and nobody
+  // has answered. That is the real state this class describes, reached
+  // naturally — no forcing needed. (I forced it at first and the force was
+  // overwritten by the peer's own offer, which is how I noticed.)
+  await settle();
+  check("fourth class: the peer really is mid-negotiation before we toggle",
+    pc4.signalingState === "have-local-offer", pc4.signalingState);
+  const offersBefore = pc4.offers ?? 0;
+  await voice.toggleMic("me"); await settle();  // mic OFF while unstable
+  await voice.toggleMic("me"); await settle();  // mic ON  while unstable
+
+  check("fourth class: no glare — nothing offers into an unstable peer",
+    (pc4.offers ?? 0) === offersBefore,
+    `offers went ${offersBefore} -> ${pc4.offers} while unstable`);
+
+  // the old answer lands, returning the peer to stable
+  bus.emit("rtc", { from: "fourth", payload: { sdp: { type: "answer", sdp: "x" } } });
+  await settle();
+
+  // The answer lands and the reconciliation fires — which means the peer is
+  // back in have-local-offer, carrying the FOLLOW-UP offer. Asserting "ends
+  // stable" was my own error: a successful follow-up necessarily re-enters
+  // negotiation. What must be true is that the answer was consumed (the
+  // remote description changed) and exactly one new offer went out.
+  check("fourth class: the old answer is consumed, not dropped",
+    (pc4 as { remote?: unknown }).remote != null,
+    "the in-flight answer never reached setRemoteDescription");
+
+  check("fourth class: EXACTLY ONE follow-up offer after returning to stable",
+    (pc4.offers ?? 0) === offersBefore + 1,
+    `expected ${offersBefore + 1} offers, got ${pc4.offers}`);
+
+  const live4 = pc4.getSenders().filter((s: { track: unknown }) => s.track);
+  check("fourth class: the follow-up advertises a LIVE send direction",
+    live4.length === 1, `${live4.length} live senders of ${pc4.getSenders().length}`);
+
+  // idempotence: a second trip through stable must not stack another offer
+  bus.emit("rtc", { from: "fourth", payload: { sdp: { type: "answer", sdp: "x" } } });
+  await settle();
+  check("fourth class: no duplicate follow-up on a second return to stable",
+    (pc4.offers ?? 0) === offersBefore + 1,
+    `offers crept to ${pc4.offers}`);
+}
+
+// ---- pending work dies with its peer (generation-bound) --------------------
+// An answer carries no negotiation identity, so a follow-up owed by a peer that
+// has since been dropped and rebuilt must not be paid by its replacement.
+// Asserted on the MECHANISM rather than on an offer count: a replacement peer
+// legitimately raises its own pending flag at its own generation, so counting
+// offers cannot distinguish "paid the dead peer's debt" from "paid its own".
+// (That is exactly how my first version of this test failed — it counted, and
+// the count was right for the wrong reason.)
+{
+  consent.setReceiveVoice(true);
+  if (!voice.micOn()) await voice.toggleMic("me");
+  await settle();
+  created.length = 0;
+  stubs.remotes.set("gen", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const genOld = created.at(-1)!;
+  const genBefore = voice.voicePendingReneg?.()["gen"];
+
+  consent.setReceiveVoice(false); await settle();   // dropPeer kills the old one
+  consent.setReceiveVoice(true);  await settle();   // a NEW peer is built
+  const genNew = created.at(-1)!;
+  const genAfter = voice.voicePendingReneg?.()["gen"];
+
+  check("generation: a rebuilt peer is a genuinely new object",
+    genNew !== genOld, "dropPeer+rebuild returned the same pc");
+  check("generation: the replacement carries its OWN generation, not the dead one's",
+    genAfter == null || genBefore == null || genAfter !== genBefore,
+    `old gen ${genBefore} survived into the replacement as ${genAfter}`);
+  consent.setReceiveVoice(false);
 }
 
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1,4 +1,3 @@
-const peersOf = (): any => undefined;
 // voice-lifecycle — the consent choices, executed.
 //
 //   bun tools/voice-lifecycle-test.ts
@@ -77,7 +76,8 @@ class FakePC {
   getTransceivers() { return this.transceivers; }
   /** the direction actually offered to the far end */
   offeredDirection() { return this.transceivers[0]?.direction ?? "none"; }
-  static gate: Promise<void> | null = null;   // slows createOffer for race tests
+  static gate: Promise<void> | null = null;
+  static answerGate: Promise<void> | null = null;   // parks setRemoteDescription
   offers = 0;                 // how many offers this peer has actually produced —
                               // the fourth-class tests assert on EXACTLY ONE
                               // follow-up, which needs a real count rather than
@@ -100,6 +100,11 @@ class FakePC {
   }
   async setRemoteDescription(d: unknown) {
     await new Promise((r) => setTimeout(r, 1));           // yield: interleave window
+    // Separate gate from FakePC.gate (which parks createOffer). The
+    // cross-generation seam needs an ANSWER handler held mid-await while its
+    // peer is dropped and rebuilt underneath it — that is the only way to make
+    // an old handler resume against a replacement (Mica, #62).
+    if (FakePC.answerGate) await FakePC.answerGate;
     this.remote = d;
     const t = (d as { type?: string })?.type;
     this.signalingState = t === "offer" ? "have-remote-offer" : "stable";
@@ -247,25 +252,10 @@ const liveTrack = (await import("../client/lib/voice.js")).micOn();
 await voice.toggleMic("me");
 check("mic off stops the local track", liveTrack === true && voice.micOn() === false);
 check("mic off does NOT close a consented inbound peer (send ≠ receive)", !inbound.closed);
-// THE CONTRACT CHANGED (2026-08-08). Mic-off used to stop() the track and
-// removeTrack() it from every peer, then renegotiate — three destructive acts
-// to express "don't transmit", and the source of four of the six voice bugs
-// fixed this week. It now disables the track instead, so the sender KEEPS it
-// and the SDP never changes. Asserting track === null here would be asserting
-// the bug. What matters is that nothing audible leaves:
-check("mic off keeps the sender bound but silences it (no renegotiation)",
-  inbound.getSenders().every((s) => !s.track || s.track.enabled === false));
-check("mic off does not stop() the track — an ended track cannot be revived",
-  inbound.getSenders().every((s) => !s.track || s.track.readyState !== "ended"));
+check("mic off leaves no outbound track on the peer",
+  inbound.getSenders().every((s) => s.track === null));
 
 // ---- refusal must not loop ------------------------------------------------
-// Refusal is only reachable from a body that holds NO stream. Since mic-off
-// keeps the stream (and re-enabling needs no permission — correctly: a mic you
-// were already granted is not re-asked for), the honest way to reach the
-// permission path is to RELEASE the device first. That is what
-// releaseMicrophone() is for, and it is the only caller that stops tracks.
-voice.releaseMicrophone();
-await settle();
 denyMic = true;
 const before = micDenies;
 const r1 = await voice.toggleMic("me");
@@ -299,13 +289,6 @@ consent.setReceiveVoice(false);
 created.length = 0;
 stubs.remotes.set("peer1", { agent: false });
 denyMic = false;
-// Drive to the state, never assume a call reaches it (the discipline this file
-// states at the bottom). Mic-off now KEEPS the stream and only disables the
-// track, so a bare toggleMic() means "flip", not "on".
-// A real off->on cycle, so the courting path runs for THIS test's peer rather
-// than relying on one a previous test happened to leave behind.
-if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
-created.length = 0;
 await voice.toggleMic("me");            // mic ON, receive OFF
 await settle();
 const outbound = created.at(-1)!;
@@ -974,6 +957,116 @@ check("unhush rejoins the SAME peer at full volume",
   check("generation: the replacement carries its OWN generation, not the dead one's",
     genAfter == null || genBefore == null || genAfter !== genBefore,
     `old gen ${genBefore} survived into the replacement as ${genAfter}`);
+  consent.setReceiveVoice(false);
+}
+
+// ---- the cross-generation seam: an OLD handler resuming after replacement ---
+// Mica, #62 review. `owed === p.gen` proves the debt belongs to that peer
+// OBJECT — but it is self-referential, so an old answer handler that was
+// already mid-await when its peer was dropped and rebuilt compares the old
+// object to its own generation, matches, and then renegotiate(id) resolves
+// peers.get(id): the REPLACEMENT. The dead peer's debt gets paid by its
+// successor, which is exactly what the generation stamp was meant to prevent.
+//
+// Forced deterministically: the answer handler is held inside
+// setRemoteDescription while the peer is replaced underneath it.
+{
+  consent.setReceiveVoice(true);
+  if (!voice.micOn()) await voice.toggleMic("me");
+  await settle();
+  created.length = 0;
+  stubs.remotes.set("seam", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const oldPeer = created.at(-1)!;
+  if (!oldPeer) throw new Error("no peer built for the seam test");
+
+  // the old peer owes a follow-up: toggle the mic while it is mid-negotiation
+  await voice.toggleMic("me"); await settle();
+  await voice.toggleMic("me"); await settle();
+  const owedBefore = voice.voicePendingReneg?.()["seam"];
+  check("seam: the old peer genuinely owes a follow-up before we replace it",
+    owedBefore != null, `pending was ${owedBefore}`);
+
+  // hold the answer handler mid-await, then deliver an answer to the OLD peer
+  let releaseAnswer!: () => void;
+  FakePC.answerGate = new Promise<void>((r) => { releaseAnswer = r; });
+  bus.emit("rtc", { from: "seam", payload: { sdp: { type: "answer", sdp: "held" } } });
+  await settle();                       // handler is now parked inside setRemoteDescription
+
+  // replace the peer underneath the parked handler
+  consent.setReceiveVoice(false); await settle();   // dropPeer kills the old one
+  consent.setReceiveVoice(true);  await settle();   // a NEW peer for the same id
+  const newPeer = created.at(-1)!;
+  // Settle the replacement into a CLEAN, STABLE, debt-free state. Otherwise
+  // renegotiate() bails on signalingState before the identity check is ever
+  // reached, and the test passes for a reason that has nothing to do with the
+  // fix — which is exactly how my first version of this was vacuous.
+  // The replacement legitimately has its own lifecycle (its own pending debt,
+  // its own offers). Rather than fighting it into an artificial idle state,
+  // clear its debt directly and snapshot the offer count immediately before
+  // releasing the old handler — so any offer AFTER that point can only have
+  // come from the dead peer's debt being paid by its successor.
+  voice.voiceClearPending?.("seam");
+  await settle();
+  const newOffersBefore = newPeer.offers ?? 0;
+
+  // release the old handler: it resumes against a peer that no longer exists
+  FakePC.answerGate = null; releaseAnswer();
+  await settle(); await settle();
+
+  // Assert on the MECHANISM. Downstream offer counts are unreliable here: even
+  // without the identity check, renegotiate() may bail on the replacement's
+  // signaling state, so the leak is real but invisible in the count — the test
+  // would pass for a reason unrelated to the fix. (It did, twice, before I
+  // looked at what reconcilePending actually saw.) What must be true is that a
+  // resumed old handler is REFUSED, and refused for the right reason: its
+  // generation check passes (self-referential) and only the identity check
+  // stops it.
+  const recs = ((globalThis as { __reconcileLog?: string[] }).__reconcileLog ?? [])
+    .filter((r) => r.startsWith("id=seam"));
+  const resumed = recs.find((r) => r.includes("isCurrent=false"));
+  check("seam: the resumed old handler reaches reconcilePending at all",
+    resumed !== undefined, `seam records: ${JSON.stringify(recs)}`);
+  check("seam: its generation check PASSES (self-referential) — identity is the only guard",
+    resumed !== undefined && /owed=(\d+) gen=\1 /.test(resumed + " "),
+    `expected owed===gen on the stale handler, got: ${resumed}`);
+  check("seam: and it is refused because the peer is no longer current",
+    resumed !== undefined && resumed.includes("isCurrent=false"),
+    `stale handler was not detected as non-current: ${resumed}`);
+  check("seam: the replacement is genuinely a different peer object",
+    newPeer !== oldPeer, "dropPeer+rebuild returned the same pc");
+  consent.setReceiveVoice(false);
+}
+
+// ---- REJOIN: a peer who reloads is a NEW session, not a glare rival --------
+// Field, 2026-08-08 (R + Digi): "she could hear me until she hard reloaded."
+// A reload sends a fresh offer. If our side still holds a stale peer parked in
+// have-local-offer from their dead session, the glare rule fires — and glare's
+// premise is that BOTH offers are live, so the loser's offer will be answered.
+// A reload breaks that premise: the peer we are protecting no longer exists on
+// their end, so returning here discards the only live offer in the exchange and
+// strands both sides. Deterministic; no timing needed.
+{
+  consent.setReceiveVoice(true);
+  if (!voice.micOn()) await voice.toggleMic("me");
+  await settle();
+  created.length = 0;
+  stubs.remotes.set("zzz-rejoin", { agent: false });   // id sorts ABOVE "me" — WE win glare
+  bus.emit("roster");
+  await settle();
+  const pcR = created.at(-1)!;
+  check("rejoin: our side is parked in have-local-offer (their answer never came)",
+    pcR.signalingState === "have-local-offer", pcR.signalingState);
+
+  const answersBefore = pcR.answersCreated ?? 0;
+  // they reload and offer fresh
+  bus.emit("rtc", { from: "zzz-rejoin", payload: { sdp: { type: "offer", sdp: "after-reload" } } });
+  await settle(); await settle();
+
+  check("rejoin: a reloaded peer's offer is ANSWERED, not discarded as glare",
+    (pcR.answersCreated ?? 0) > answersBefore,
+    `answersCreated stayed at ${pcR.answersCreated} — their fresh offer was dropped`);
   consent.setReceiveVoice(false);
 }
 

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -817,6 +817,33 @@ check("unhush rejoins the SAME peer at full volume",
     pcMid.signalingState === "stable", pcMid.signalingState);
 }
 
+{
+  // Mica's fourth class, the variant I can actually REACH (#62 review). A peer
+  // offered with a live mic, then the mic toggled off and on while that offer
+  // is still in flight: the in-flight offer describes a track that has since
+  // been stopped and replaced. renegotiate() bails while unstable, so unless
+  // something reconciles on return to stable, the far end is left holding a
+  // description of a dead track.
+  //
+  // (The mic-LESS local offer Mica describes may not be reachable — every
+  // offer-initiating path on this branch is gated on micStream. Asked rather
+  // than guessed; if it is reachable, that test comes separately.)
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  consent.setReceiveVoice(true);
+  if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }   // mic ON
+  created.length = 0;
+  stubs.remotes.set("stale", { agent: false });
+  FakePC.gate = new Promise<void>(() => {});          // park the offer in flight
+  bus.emit("roster"); await settle();
+  const pcStale = created.at(-1)!;
+  FakePC.gate = null;
+  await voice.toggleMic("me"); await settle();        // mic OFF mid-offer
+  await voice.toggleMic("me"); await settle();        // mic ON again
+  const liveStale = pcStale.getSenders().filter((s) => s.track);
+  check("stale-offer: the peer carries exactly one live track after a mid-offer toggle",
+    liveStale.length === 1, `${liveStale.length} live of ${pcStale.getSenders().length}`);
+}
+
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -787,6 +787,36 @@ check("unhush rejoins the SAME peer at full volume",
   consent.setReceiveVoice(true);
 }
 
+{
+  // Mica's third timing class (#34): the mic opens while a peer is parked in
+  // have-remote-offer — mid-negotiation, so renegotiate() bails. The track
+  // must still be attached, and the in-flight answer must carry it, without
+  // forcing a second negotiation into a state that cannot take one.
+  if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+  consent.setReceiveVoice(true);
+  created.length = 0;
+  stubs.remotes.set("midneg", { agent: false });
+  // hold the answer inside createAnswer so the peer stays in have-remote-offer
+  let release: (() => void) | null = null;
+  const held = new Promise<void>((r) => { release = r; });
+  const origCreateAnswer = FakePC.prototype.createAnswer;
+  FakePC.prototype.createAnswer = async function () { await held; return origCreateAnswer.call(this); };
+  bus.emit("rtc", { from: "midneg", payload: { sdp: { type: "offer", sdp: "x" } } });
+  await settle();
+  const pcMid = created.at(-1)!;
+  check("mid-negotiation: peer is parked in have-remote-offer",
+    pcMid.signalingState === "have-remote-offer", pcMid.signalingState);
+  if (!voice.micOn()) { await voice.toggleMic("me"); await settle(); }   // mic ON mid-negotiation
+  release!();
+  await settle();
+  FakePC.prototype.createAnswer = origCreateAnswer;
+  check("mid-negotiation: the track still lands on a peer renegotiate() would skip",
+    pcMid.getSenders().filter((s) => s.track).length === 1,
+    `${pcMid.getSenders().filter((s) => s.track).length} live of ${pcMid.getSenders().length}`);
+  check("mid-negotiation: peer ends stable with no duplicate offer",
+    pcMid.signalingState === "stable", pcMid.signalingState);
+}
+
 // T5 (relay half) lives in tools/voice-matrix.mjs: RTC_MODE=relay-noturn must
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.


### PR DESCRIPTION
## A live mic must always have an attached track

`addTrack` runs only inside `peerFor`'s construction path, and `peerFor` returns an existing peer unchanged. So a mic opened after a peer was built leaves that peer with a **sender carrying no track** on a transceiver negotiated `sendrecv`: it renegotiates happily, transmits silence forever, and the UI reads `mic LIVE` throughout. Nothing surfaces it — no error, no log line, and the far side simply hears nothing.

Field receipt that started this (phone on cellular → a Burrow-hosted world, no TURN, dual-stack IPv6 path): `in=1179 out=0`, `senders: ['SENDER WITH NO TRACK']`.

### Three timing classes, all pinned

| | when | pre-fix |
|---|---|---|
| **mic-after-peer** | peer built before the mic opened | sender with no track |
| **mic-during-acquisition** | peer born *inside* the `getUserMedia` await, while `micStream` is still null | sender with no track — and intermittent, so it survives testing |
| **mid-negotiation** | mic opens while a peer sits in `have-remote-offer` | track lands, but `offerTo` forced glare and parked it in `have-local-offer` |

The second is why a one-shot back-fill in `toggleMic` is not enough: `getUserMedia` takes hundreds of ms, and a peer constructed inside that window is missed by both `addTrack` (no `micStream` yet) and the back-fill (already run). The same three-peer test failed and passed ten minutes apart on identical code, the only difference being ~1s of incidental delay between two clicks.

The third was found by writing @mica's requested test rather than narrowing it — thank you for insisting on that; it would have shipped broken.

### The repair

Attachment moves into `applyDirection`, which every offer and renegotiation already passes through. **A live mic with nothing attached is the same class of mismatch as a wrong transceiver direction, so it is fixed in the same place** — an invariant rather than a patch per path.

`toggleMic` then attaches to existing peers, renegotiates the stable ones, and offers only to ids it does not already hold — a peer mid-negotiation has an answer in flight that will carry the track, so it needs to be left alone rather than forced.

### An asymmetry worth knowing

`mic-off` has two branches and only one is broken:

- **not receiving** → `dropPeer`; mic-on rebuilds the peer *with* the track. Recovers.
- **receiving** → `renegotiate`; the peer survives with an empty sender that never refills. Permanent.

**So the failure selects for people wearing headphones** — the ones who came to have a conversation rather than broadcast. Observed live in commons tonight: @Digi (mic-only) could toggle freely, while his voice to @antra died permanently after his first toggle-off. Pinned as a test, with the receive-off path asserted passing on pre-fix code so the asymmetry is recorded rather than asserted.

### Tests

`tools/voice-lifecycle-test.ts`, six new regressions. **Fail-on-main verified with the tests present and only the fix reverted: 6 failed / 67 passed. With the fix: 73/73.**

Both races are forced deterministically — the `getUserMedia` stub and `createAnswer` are held open until the racing event has happened — rather than hoping to hit a window of a few hundred ms.

Also models `RTCRtpSender.replaceTrack` in the fake, since a sender whose track is null is exactly the state the bug leaves behind.

### Not included

`/voice` (the client command that produced the diagnostics above) is deliberately held back for a separate PR, so this fix is not blocked on reviewing tooling. Its privacy contract needs care — candidate addresses are diagnostic gold and also sensitive network metadata.