### PR TITLE
voice: consent must silence inbound audio, not destroy it (one-way audio)

### DIFF
--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -51,6 +51,25 @@ function wantDirection() {
 
 /** Force every audio transceiver on this peer to the currently-consented
  *  direction. Called before any offer/answer, and again when consent moves. */
+/** Un-silence inbound audio that the consent gate disabled on arrival.
+ *  The tracks are still live — the gate sets `enabled = false` rather than
+ *  stop() precisely so this is possible — so consenting later is a local flip
+ *  with no renegotiation. Attaches the element too, for the case where the
+ *  peer was built before any track arrived. */
+function reenableInbound(p) {
+  const tracks = (p.pc.getReceivers?.() ?? [])
+    .map((r) => r.track)
+    .filter((t) => t && t.kind === 'audio' && t.readyState === 'live');
+  if (!tracks.length) return;
+  for (const t of tracks) t.enabled = true;
+  if (!p.audio.srcObject) {
+    const stream = new MediaStream(tracks);
+    p.audio.srcObject = stream;
+    p.stream = stream;
+  }
+  p.audio.play().catch(() => addEventListener('click', () => p.audio.play().catch(() => {}), { once: true }));
+}
+
 function applyDirection(p) {
   const dir = wantDirection();
   try {
@@ -75,10 +94,25 @@ function peerFor(id) {
   if (micStream) for (const t of micStream.getTracks()) pc.addTrack(t, micStream);
   pc.ontrack = (e) => {
     // FAIL CLOSED: consent can be revoked mid-negotiation, and a track that
-    // was in flight when it happened must not land. Nothing is attached and
-    // nothing plays unless receive is on at the moment audio actually arrives.
-    if (!receivingVoice()) { try { for (const t of e.streams[0]?.getTracks() ?? []) t.stop(); } catch { /* best effort */ } return; }
+    // was in flight when it happened must not land. Nothing is AUDIBLE unless
+    // receive is on at the moment audio actually arrives.
+    // FAIL CLOSED, but REVERSIBLY. This previously called t.stop() on their
+    // track, which is a ONE-WAY DOOR: per mediacapture-streams stop() ends a
+    // track permanently, and per WebRTC-PC §5.3.1 `receiver.track` is never
+    // reassigned — so that transceiver's remote track was gone for its whole
+    // lifetime. No renegotiation, no direction change, and no second ontrack
+    // could bring it back. Consenting AFTER someone's track arrived left you
+    // permanently deaf to that person while still audible to them: the
+    // one-way report of 2026-08-08, order-dependent, which is why it read as
+    // a who-joined-first problem.
+    //
+    // stop() also never stopped the RTP on the wire, so it bought no
+    // bandwidth — it only removed the way back. `enabled` is the mechanism
+    // the spec provides for a reversible refusal: synchronous, local,
+    // mandated to render silence, and reversible with no negotiation.
+    for (const t of e.streams[0]?.getTracks() ?? []) t.enabled = receivingVoice();
     audio.srcObject = e.streams[0];
+    if (!receivingVoice()) return;   // attached but SILENT until consent
     p.stream = e.streams[0];        // kept so their mouth can move with their voice
     // autoplay policy: if the browser balks (receiver never clicked anything),
     // retry on the next user gesture rather than failing silently
@@ -329,6 +363,12 @@ export function initVoice(name) {
   bus.on('audio:receive', (on) => {
     if (on) {
       // permit inbound on peers we already hold, then reach the rest
+      // Re-enable anything the gate silenced on arrival. Without this, a
+      // track that landed while receive was off stays enabled=false forever:
+      // the direction below is repaired but no audio is ever heard, which is
+      // the one-way bug this pairs with. Idempotent, so it is safe on every
+      // flip; a track that was never silenced is simply set true again.
+      for (const p of peers.values()) reenableInbound(p);
       for (const p of peers.values()) applyDirection(p);
       for (const id of [...peers.keys()]) renegotiate(id);
       if (micStream) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -62,10 +62,15 @@ function reenableInbound(p) {
     .filter((t) => t && t.kind === 'audio' && t.readyState === 'live');
   if (!tracks.length) return;
   for (const t of tracks) t.enabled = true;
+  // Restore the element only if it lost its stream, but ALWAYS ensure p.stream
+  // names something: the gate's early return can leave a peer attached with no
+  // stream recorded, and that is the exact path this function repairs.
   if (!p.audio.srcObject) {
     const stream = new MediaStream(tracks);
     p.audio.srcObject = stream;
     p.stream = stream;
+  } else if (!p.stream) {
+    p.stream = p.audio.srcObject;      // same object the element already holds
   }
   p.audio.play().catch(() => addEventListener('click', () => p.audio.play().catch(() => {}), { once: true }));
 }
@@ -112,8 +117,14 @@ function peerFor(id) {
     // mandated to render silence, and reversible with no negotiation.
     for (const t of e.streams[0]?.getTracks() ?? []) t.enabled = receivingVoice();
     audio.srcObject = e.streams[0];
-    if (!receivingVoice()) return;   // attached but SILENT until consent
-    p.stream = e.streams[0];        // kept so their mouth can move with their voice
+    // p.stream is set BEFORE the consent bail, not after. It is what
+    // peerLevels()/mouth animation read, and a refused-then-consented track
+    // recovers its AUDIO via reenableInbound() but would never come back
+    // through here — so leaving it unset behind the bail made the repaired
+    // path permanently mouth-blind. Attaching and naming the stream are one
+    // act; only PLAYING is gated. (Mica, #63 review.)
+    p.stream = e.streams[0];
+    if (!receivingVoice()) return;   // attached and named, but SILENT until consent
     // autoplay policy: if the browser balks (receiver never clicked anything),
     // retry on the next user gesture rather than failing silently
     audio.play().catch(() => addEventListener('click', () => audio.play().catch(() => {}), { once: true }));
@@ -453,6 +464,13 @@ export async function voiceStats() {
 export const peerVolume = (id) => peers.get(id)?.audio.volume ?? null;
 // test/debug probe — connection states by peer id
 export const voiceDebug = () => Object.fromEntries([...peers].map(([id, p]) => [id, p.pc.connectionState]));
+/** Which peers have a stream bound for mouth animation. `peerLevels()` skips
+ *  any peer without one, and it does so silently — so a peer can be perfectly
+ *  audible while its mouth never moves, a half-repair visible only to everyone
+ *  ELSE. Exported so that gap is assertable (and greppable in prod) rather
+ *  than only observable by watching a face that should be talking. */
+export const voiceMouthBound = () =>
+  Object.fromEntries([...peers].map(([id, p]) => [id, !!p.stream]));
 export const voicePcs = () => [...peers.values()].map((p) => p.pc); // experiment branch: raw pcs for stats probes
 
 // ---- per-speaker levels (R, 23:30: mouths move in sync with the sound)

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -18,7 +18,13 @@ const check = (name: string, ok: boolean, detail = "") => {
 
 // ---- fakes ----------------------------------------------------------------
 const created: FakePC[] = [];
-class FakeTrack { stopped = false; kind = "audio"; stop() { this.stopped = true; } }
+class FakeTrack {
+  stopped = false;
+  enabled = true;              // the consent gate silences via enabled, never stop()
+  readyState = "live";
+  kind = "audio";
+  stop() { this.stopped = true; this.readyState = "ended"; }
+}
 class FakeStream {
   tracks = [new FakeTrack()];
   attached = false;
@@ -34,6 +40,16 @@ Object.defineProperty(globalThis.HTMLMediaElement.prototype, "srcObject", {
   set(v) { this._srcObject = v; if (v && typeof v === "object") (v as { attached?: boolean }).attached = true; },
 });
 (globalThis.HTMLMediaElement.prototype as { play?: () => Promise<void> }).play = () => Promise.resolve();
+// A real RTCRtpSender can be re-pointed at a different track without
+// renegotiating. Modelled because the repair for the mic-after-peer races uses
+// it: an existing sender whose track is null is exactly the state a peer is
+// left in when it was built before the mic opened.
+type FakeSender = { track: FakeTrack | null; replaceTrack(t: FakeTrack | null): Promise<void> };
+const mkSender = (t: FakeTrack | null): FakeSender => ({
+  track: t,
+  replaceTrack(next) { this.track = next; return Promise.resolve(); },
+});
+
 class FakePC {
   signalingState = "stable";
   connectionState = "new";
@@ -48,7 +64,7 @@ class FakePC {
   onconnectionstatechange: unknown = null;
   constructor() { created.push(this); }
   addTrack(t: FakeTrack) {
-    const sender = { track: t };
+    const sender = mkSender(t);
     this.senders.push(sender);
     // a real addTrack creates (or reuses) a sendrecv transceiver — modelled
     // faithfully, because that default is exactly what the bug rode in on
@@ -98,7 +114,16 @@ class FakePC {
     if (!this.remote) { const e = new Error("The remote description was null"); e.name = "InvalidStateError"; throw e; }
     this.addedCandidates.push(c);
   }
-  close() { this.closed = true; this.connectionState = "closed"; }
+  close() {
+    this.closed = true;
+    this.connectionState = "closed";
+    // A real pc.close() ends every receiver's track and detaches the element.
+    // The fake used to only set a flag, so a test could observe audio still
+    // "playing" from a closed connection — which is how a revoke-path privacy
+    // assertion could fail for a reason that did not exist in the browser.
+    for (const r of this._receivers) r.track.readyState = "ended";
+    if (this._lastStream) this._lastStream.attached = false;
+  }
   playedAudio = false;
   /** Simulate the far end delivering audio. Acceptance is observed the way
    *  the code expresses it: an accepted track gets attached to an <audio>
@@ -107,9 +132,24 @@ class FakePC {
   deliverAudio() {
     const stream = new FakeStream();
     stream.attached = false;
+    // The receiver and the stream expose the SAME track object, as a real
+    // browser does. An earlier version of this fake built two, so code that
+    // disabled the stream's track left the receiver's looking untouched — a
+    // consent test could pass while consent did nothing. (Mica, #34.)
+    this._receivers = [{ track: stream.tracks[0] }];
+    this._lastStream = stream;
     this.ontrack?.({ streams: [stream] });
     if (stream.attached) this.playedAudio = true;
   }
+  _receivers: { track: FakeTrack }[] = [];
+  _lastStream: FakeStream | null = null;
+  getReceivers() { return this._receivers; }
+  /** Audible = attached to an element AND not silenced AND not destroyed. */
+  inboundAudible() {
+    const t = this._receivers[0]?.track;
+    return !!(t && t.enabled && t.readyState === "live" && this._lastStream?.attached);
+  }
+  inboundStopped() { return this._receivers[0]?.track.readyState === "ended"; }
 }
 (globalThis as Record<string, unknown>).RTCPeerConnection = FakePC;
 
@@ -248,8 +288,14 @@ check("mic-ON + receive-OFF: no blanket offerToReceiveAudio",
   !JSON.stringify(outbound.lastOfferOpts ?? {}).includes("offerToReceiveAudio"));
 outbound.deliverAudio();                 // far end tries to send anyway
 await settle();
-check("mic-ON + receive-OFF: an inbound track is refused, not played",
-  !outbound.playedAudio, "audio was attached/played");
+// What must be true is that nothing is AUDIBLE — not that nothing is attached.
+// Those two come apart exactly where the one-way bug lived: stop() made the
+// track unattached AND unrecoverable, and the old assertion could not tell the
+// difference between a refusal and a destruction.
+check("mic-ON + receive-OFF: an inbound track is silenced, not audible",
+  outbound.inboundAudible() === false, "audio was audible with receive off");
+check("mic-ON + receive-OFF: ...and NOT destroyed (revocable, not fatal)",
+  outbound.inboundStopped() === false, "the gate stopped a remote track — one-way door");
 
 // now consent to hear: direction opens and tracks are accepted
 consent.setReceiveVoice(true);
@@ -564,6 +610,59 @@ check("unhush rejoins the SAME peer at full volume",
   check("forced double-offer interleave: BOTH answers actually SENT (main loses the second at setLocal)",
     answersSent === 2 && pc9.signalingState === "stable",
     `answersSent=${answersSent} state=${pc9.signalingState}`);
+  consent.setReceiveVoice(false);
+}
+
+
+// ---- the one-way bug: consent AFTER a track has already arrived -----------
+// Field report 2026-08-08: "they can hear me, I can't hear them." ontrack
+// fires ONCE per transceiver. A track arriving while receive is off was
+// stop()ed — permanent, since receiver.track is never reassigned (WebRTC-PC
+// §5.3.1) — so consenting later repaired the DIRECTION while nothing was ever
+// wired. Outbound was unaffected, hence exactly one-way, and dependent on who
+// arrived first. All three FAIL on pre-fix main.
+{
+  consent.setReceiveVoice(false);
+  if (!voice.micOn()) await voice.toggleMic("me");   // mic ON, receive OFF
+  await settle();
+  created.length = 0;
+  stubs.remotes.set("oneway", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const pcX = created.at(-1)!;
+  if (!pcX) throw new Error("no peer was built for the one-way test");
+
+  pcX.deliverAudio();                       // arrives BEFORE consent
+  await settle();
+  check("one-way: nothing audible before consent",
+    pcX.inboundAudible() === false, "audio played before consent was given");
+  check("one-way: the refused track survives for later (not stop()ed)",
+    pcX.inboundStopped() === false, "remote track destroyed — unrecoverable");
+
+  consent.setReceiveVoice(true);             // consent arrives AFTER
+  await settle();
+  check("one-way: consenting AFTER arrival makes the SAME track audible",
+    pcX.inboundAudible() === true,
+    "direction repaired but the earlier track never became audible — one-way audio");
+
+  // Repeated revoke/enable must not degrade. NOTE: revoke calls dropPeer, so
+  // each cycle builds a NEW RTCPeerConnection — the assertion has to follow
+  // the current peer rather than the original handle. (My first version held
+  // the stale one and "failed" on a connection the code had correctly closed.)
+  let ratchet = "";
+  for (let i = 0; i < 5 && !ratchet; i++) {
+    consent.setReceiveVoice(false); await settle();
+    const closed = created.at(-1)!;
+    if (closed.inboundAudible()) ratchet = `cycle ${i}: audible after revoke`;
+
+    consent.setReceiveVoice(true); await settle();
+    const fresh = created.at(-1)!;
+    fresh.deliverAudio();                    // the far end re-sends on the new leg
+    await settle();
+    if (!fresh.inboundAudible()) ratchet = `cycle ${i}: silent after re-consent`;
+  }
+  check("one-way: five revoke/enable cycles stay reversible (no ratchet)",
+    ratchet === "", ratchet);
   consent.setReceiveVoice(false);
 }
 

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -644,6 +644,22 @@ check("unhush rejoins the SAME peer at full volume",
   check("one-way: consenting AFTER arrival makes the SAME track audible",
     pcX.inboundAudible() === true,
     "direction repaired but the earlier track never became audible — one-way audio");
+  // AUDIBLE is not the whole repair. peerLevels() skips any peer with no
+  // `p.stream`, so a peer could recover its sound while staying permanently
+  // mouth-blind — a half-repair visible only from OUTSIDE the session, which
+  // is the same shape as the bug itself. (Mica, #63 review.)
+  // Asserted through the real consumer rather than a test-only accessor:
+  // peerLevels() does `if (!p.stream) continue`, so a mouth-blind peer is
+  // simply absent from its map. AudioContext is unavailable under happy-dom,
+  // so the analyser path throws and `continue`s — presence in the map is the
+  // signal we can read here, and absence is exactly the bug.
+  check("one-way: the repaired peer is also VISIBLE (p.stream pinned for the mouth)",
+    // Optional-call so the negative control FAILS rather than crashing: on
+    // pre-fix main the export does not exist, and a TypeError would prove only
+    // that, not that the mouth is blind. Absent export reads as unbound, which
+    // is the same user-visible outcome.
+    voice.voiceMouthBound?.()["oneway"] === true,
+    "audio recovered but p.stream is unset — peerLevels() skips them, mouth never moves");
 
   // Repeated revoke/enable must not degrade. NOTE: revoke calls dropPeer, so
   // each cycle builds a NEW RTCPeerConnection — the assertion has to follow

--- a/tools/voice-wiring-test.ts
+++ b/tools/voice-wiring-test.ts
@@ -52,20 +52,46 @@ check("receive-voice defaults OFF", /recvVoice:\s*false/.test(consent));
 check("STT is gated on its own consent, not on the mic", /ensureSttConsent|sttConsented/.test(mictoggle));
 check("STT consent names the third party in plain words",
   /vendor|third party/i.test(consent) && /transcrib/i.test(consent));
-check("revoking receive tears existing peers down",
-  /on\(\s*['"]audio:receive['"][\s\S]{0,1200}dropPeer/.test(voice));
+// Comment-stripped source: prose must never satisfy or break a code assertion.
+const voiceCode = voice.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+// Asserted on the HANDLER BODY rather than a character window: the old regex
+// measured distance, so it broke when a comment grew between the two lines and
+// would have passed if dropPeer moved into an unrelated branch. Slice the
+// handler, then test the revoke arm for what it must actually do.
+const receiveHandler = (() => {
+  const i = voice.search(/on\(\s*['"]audio:receive['"]/);
+  return i < 0 ? "" : voice.slice(i, i + 3000);
+})();
+check("the audio:receive handler exists", receiveHandler.length > 0);
+check("revoking receive tears existing peers down (hard revoke, not just a gain)",
+  /dropPeer/.test(receiveHandler));
 
 // --- consent is STRUCTURAL: the direction, not a gate to remember
 check("consent is expressed as a transceiver direction", /sendonly|recvonly|sendrecv/.test(voice));
 // strip comments before this one: the word legitimately appears in the
 // rationale explaining why we no longer USE it, and a test that cannot tell
 // prose from code would forbid documenting the bug we fixed
-const voiceCode = voice.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
 check("no blanket offerToReceiveAudio in code", !/offerToReceiveAudio/.test(voiceCode));
 check("every offer path states the direction first",
   (voice.match(/createOffer\(/g) ?? []).length <= (voice.match(/applyDirection\(/g) ?? []).length);
-check("ontrack fails closed on revoked consent",
-  /ontrack[\s\S]{0,300}receivingVoice\(\)/.test(voice));
+// The contract changed with the one-way fix (#63): refusal must be REVERSIBLE.
+// stop() on a remote track is permanent — receiver.track is never reassigned —
+// so the gate silences via `enabled` and consent-on re-enables. Assert the
+// contract, not the old shape.
+// Read from the COMMENT-STRIPPED source: the fix's own rationale mentions
+// t.stop() by name to explain why we no longer call it, and a test that cannot
+// tell prose from code would forbid documenting the bug we fixed. (The file
+// already learned this once — see voiceCode above.)
+const ontrackBody = (() => {
+  const i = voiceCode.indexOf("ontrack");
+  return i < 0 ? "" : voiceCode.slice(i, i + 2000);
+})();
+check("ontrack fails closed on revoked consent", /receivingVoice\(\)/.test(ontrackBody));
+check("ontrack silences via enabled, never stop() — refusal must be reversible",
+  /\.enabled\s*=\s*receivingVoice\(\)/.test(ontrackBody) && !/\bt\.stop\(\)/.test(ontrackBody));
+check("consent-on re-enables what the gate silenced (no permanent deafness)",
+  /reenableInbound/.test(receiveHandler));
 
 // --- categories stay separate: the headphone must not touch world sound
 check("voice volume runs through the 'voices' category", /volumeFor\(['"]voices['"]\)/.test(voice));


### PR DESCRIPTION
Split out of #62 as requested, against current `origin/main` (`0402e34`). Independent of the mic-attachment work.

## The bug

Field report this morning: *"they can hear me, I can't hear them."*

`ontrack` fires **once per transceiver**. A track arriving while receive was off was `stop()`ed — and `stop()` on a **remote** track is a one-way door:

- [mediacapture-streams](https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-stop): `stop()` ends the track permanently.
- [WebRTC-PC §5.3.1](https://www.w3.org/TR/webrtc/#dom-rtcrtpreceiver-track): `receiver.track` is **never reassigned**.

So no renegotiation, no direction change, and no second `ontrack` could revive it. Consenting afterwards repaired only the **direction** — the transceiver read `sendrecv` while nothing was ever wired, and `voiceStats()` looked healthy.

The outbound leg was never affected → **exactly one-way**, and dependent on whether their track arrived before or after consent, which is why it presented as a who-joined-first problem.

`stop()` also never stopped the RTP, so it bought no bandwidth. It only removed the way back.

## The fix

`track.enabled = false/true` — synchronous, local, spec-mandated to render silence, reversible without renegotiation, consistent across Chrome and Firefox. The gate attaches and disables; consent-on re-enables via `reenableInbound()`.

| | stops RTP? | silences? | reversible? |
|---|---|---|---|
| `track.stop()` | **no** | yes | **no — permanent** |
| `direction = 'inactive'` | yes (after O/A) | yes | yes, but needs a round trip |
| `track.enabled = false` | no | **yes, spec-mandated** | **yes, trivially** |

If you also want the bytes off the wire, that's the `direction` renegotiation — a separate decision, since it costs a round trip per toggle.

## Receipts

**Fail-on-main verified** with tests present and only `voice.js` reverted to `0402e34`: **66 passed / 3 failed without, 69/0 with.**

The three requested regressions are all present: receive-OFF arrival → later consent ON; no playback before consent; five revoke/enable cycles with no ratchet.

## Two fixture bugs, same family

Both are cases of a fake that *could not express the failure it was supposed to catch* — worth naming since this suite has now produced three of these:

1. **`deliverAudio()` built a separate track object** for `getReceivers()` than the one inside the stream. Code disabling one left the other looking untouched — a consent test could pass while consent did nothing.
2. **`close()` only set a flag,** leaving receiver tracks `live`, so a closed connection could still look like it was playing audio.

Also corrected: the old assertions checked *"nothing is ATTACHED"* when the property that matters is *"nothing is AUDIBLE."* Those come apart exactly where this bug lived — `stop()` made the track unattached **and** unrecoverable, and the assertion couldn't tell a refusal from a destruction.

The revoke/enable test caught my own error too: my first version held a stale `pc` handle across cycles and "failed" on a connection the code had correctly closed. Revoke calls `dropPeer`, so each cycle builds a new peer; the test follows the current one and says so in a comment.

## Correction owed

**You were right about the lineage and I was wrong.** I claimed `origin/main` was behind production; it isn't. `1d63679` is an ancestor of `0402e34` (behind_by=0). My diff was against a **local** `worlds-native` checkout that I had aliased as `origin` — I compared upstream to my own stale copy and reported the gap as upstream's. Retracting that from #34 as well.
