### PR TITLE
sky: one clock governs, and the folded state says which (#65)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,27 @@ the next scheduled segment boundary, then the forecast resumes. Re-author
 sky is a griefing vector, not weather). Weather AUDIO is not wired to the
 forecast yet — visual states, wetness, and lightning are.
 
+**One clock governs, and the folded state says which** (issue #65). The day
+clock has three modes: `fixed` (an authored `hours`, no motion), `rated`
+(`hours` + `rate` — world-time multiplier), and `real` (`clock: "real"` +
+`tz` — the world's hour IS that timezone's wall hour). Because `sky` folds
+wholesale, authors legitimately re-issue the full standing bag when flipping
+modes — so the FOLD normalizes: under an effective real clock, top-level
+`hours`/`rate` never survive; they are parked in `dormantRated` (explicitly
+inactive; the tuner restores them to its sliders when you switch back).
+The fold also stamps top-level `seq`/`by` — which sky entry authored the
+current bag. Machine consumers should not divine precedence from raw fields:
+`effectiveClock(sky, now)` in `client/lib/forecast.js` (also serialized in
+`look()`'s `World.sky.effectiveClock`) answers
+`{mode: "real"|"rated"|"fixed", hour, tz?, rate?, seq, by}` — reporting what
+is ACTUALLY in effect, including the fallback when a `clock: "real"` names a
+timezone Intl can't resolve (then the rated/fixed fields stay active and
+`requestedTz` flags the typo). Migration for older consumers: `sky.rate` can
+no longer be stale-but-present under a real clock — it is simply absent, so
+`sky.rate` remains a truthful read in rated mode and `undefined` otherwise.
+Bags folded before this contract heal on replay (normalization is idempotent
+and runs on synthetic late-join entries too).
+
 **Things can EMIT — fire, embers, smoke, motes.** `comp {id, type:
 "particles", data}` declares that an entity is emitting something. It is an
 ordinary component: builder rights, folded blindly, ≤8KB, and it never writes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,21 +206,30 @@ clock has three modes: `fixed` (an authored `hours`, no motion), `rated`
 (`hours` + `rate` — world-time multiplier), and `real` (`clock: "real"` +
 `tz` — the world's hour IS that timezone's wall hour). Because `sky` folds
 wholesale, authors legitimately re-issue the full standing bag when flipping
-modes — so the FOLD normalizes: under an effective real clock, top-level
-`hours`/`rate` never survive; they are parked in `dormantRated` (explicitly
-inactive; the tuner restores them to its sliders when you switch back).
-The fold also stamps top-level `seq`/`by` — which sky entry authored the
-current bag. Machine consumers should not divine precedence from raw fields:
+modes — so the FOLD normalizes: whenever `clock: "real"` is authored,
+top-level `hours`/`rate` never survive; they park in `dormantRated`
+(`{hours, rate, ts}` — explicitly inactive, anchored at its own parking
+moment; the tuner restores it to its sliders when you switch back). Parking
+is unconditional on real mode, so the folded state is a pure function of the
+log on every runtime — the fold never consults the timezone database. If the
+tz turns out not to resolve, the PARKED clock genuinely governs: `hoursAt`
+falls back to it, the sun keeps moving (a typo dims nothing), and the parked
+`ts` anchor means later weather merges never snap the fallback day. The fold
+also stamps top-level `seq`/`by` — which sky entry authored the current bag.
+Machine consumers should not divine precedence from raw fields:
 `effectiveClock(sky, now)` in `client/lib/forecast.js` (also serialized in
 `look()`'s `World.sky.effectiveClock`) answers
 `{mode: "real"|"rated"|"fixed", hour, tz?, rate?, seq, by}` — reporting what
-is ACTUALLY in effect, including the fallback when a `clock: "real"` names a
-timezone Intl can't resolve (then the rated/fixed fields stay active and
-`requestedTz` flags the typo). Migration for older consumers: `sky.rate` can
-no longer be stale-but-present under a real clock — it is simply absent, so
-`sky.rate` remains a truthful read in rated mode and `undefined` otherwise.
-Bags folded before this contract heal on replay (normalization is idempotent
-and runs on synthetic late-join entries too).
+is ACTUALLY in effect; an unresolvable real-clock tz reports the fallback
+mode with `requestedTz` flagging the typo. A `sky` verb re-issuing the
+standing bag carries `dormantRated` forward as authored config (same verb,
+same owner rank as authoring `rate` itself; shape-sanitized to finite
+`{hours, rate, ts}`); `weather` verbs can never touch it. Migration for
+older consumers: `sky.rate` can no longer be stale-but-present under a real
+clock — it is simply absent, so `sky.rate` remains a truthful read in rated
+mode and `undefined` otherwise. Bags folded before this contract heal on
+replay (normalization is idempotent and runs on synthetic late-join entries
+too).
 
 **Things can EMIT — fire, embers, smoke, motes.** `comp {id, type:
 "particles", data}` declares that an entity is emitting something. It is an

--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -1116,7 +1116,17 @@ function paintSky(body) {
   ck.value = skyArgs().clock === 'real' ? 'real' : '';
   ck.onchange = () => {
     if (ck.value === 'real') { local.clock = 'real'; local.tz = 'America/Los_Angeles'; }
-    else { local.clock = undefined; local.tz = undefined; }
+    else {
+      local.clock = undefined; local.tz = undefined;
+      // returning to the authored clock: the fold parked the prior rated
+      // fields under dormantRated (#65) — hand them back to the sliders so
+      // commit restores the old day/rate instead of noon-at-rate-0
+      const d = skyArgs().dormantRated;
+      if (d) for (const k of ['hours', 'rate']) if (d[k] != null && inputs[k]) {
+        inputs[k].value = d[k];
+        inputs[k].parentNode.querySelector('.v').textContent = inputs[k].value;
+      }
+    }
     syncClockUi();
     previewSky(gather()).catch((e) => report('sky preview', e));
     commit.classList.add('dirty');
@@ -1139,7 +1149,9 @@ function paintSky(body) {
   body._sync = () => {
     const a = skyArgs();
     for (const [key, , , , , dflt] of SLIDERS) {
-      inputs[key].value = a[key] ?? dflt;
+      // under a real clock hours/rate live in dormantRated (#65); show them
+      // (disabled) as what the world would return to
+      inputs[key].value = a[key] ?? a.dormantRated?.[key] ?? dflt;
       inputs[key].parentNode.querySelector('.v').textContent = inputs[key].value;
     }
     if (a.weather) wx.value = a.weather;

--- a/client/lib/forecast.js
+++ b/client/lib/forecast.js
@@ -316,7 +316,12 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
     if (base.seq != null) out.seq = base.seq; else delete out.seq;
     if (base.by != null) out.by = base.by; else delete out.by;
   }
-  // a weather verb can never author the parked clock — base's only
+  // a weather verb can never author the parked clock — base's only. That
+  // includes the indirect route: while the standing clock is real, stray
+  // authored hours/rate on a weather verb must not reach the park (base
+  // carries no top-level rated fields under real mode, so anything here came
+  // from args). Same rank as sky either way — verb semantics, not rights.
+  if (base.clock === 'real') { delete out.hours; delete out.rate; }
   return normalizeClock(out, sanitizeDormant(base.dormantRated));
 }
 

--- a/client/lib/forecast.js
+++ b/client/lib/forecast.js
@@ -53,6 +53,15 @@ export function hoursAt(sky, tMs) {
       const get = Object.fromEntries(f.formatToParts(new Date(tMs)).map((p) => [p.type, p.value]));
       return (Number(get.hour) % 24) + Number(get.minute) / 60 + Number(get.second) / 3600;
     }
+    // tz didn't resolve: the PARKED rated clock governs (#65). A normalized
+    // bag carries no top-level hours/rate — without this arm a typo'd tz on a
+    // normalized world would freeze the sun at the `?? 12` default forever.
+    // dormantRated anchors on its own ts (the parking moment), so later
+    // weather merges restamping sky.ts never snap the fallback day.
+    const d = sky.dormantRated;
+    if (d && typeof d === 'object') {
+      return ((((d.hours ?? 12) + (d.rate ?? 0) * (tMs - (d.ts ?? sky.ts ?? tMs)) / 3600e3) % 24) + 24) % 24;
+    }
   }
   return ((sky.hours ?? 12) + (sky.rate ?? 0) * (tMs - (sky.ts ?? tMs)) / 3600e3 + 24000) % 24;
 }
@@ -201,28 +210,49 @@ export function effectiveSky(sky, nowMs, cursor = null) {
 
 // ---------------------------------------------------------------- fold
 
-/** One clock may govern (issue #65). Under an EFFECTIVE real clock —
- *  `clock:'real'` with a tz Intl can resolve — the rated fields `hours`/`rate`
- *  must not remain as active-looking top-level state: they demote into
- *  `dormantRated`, an explicitly-inactive namespace a later return to rated
- *  mode can restore from (the tuner prefills its sliders with it). Outside
- *  real mode `dormantRated` is dropped: the top-level fields are the active
- *  clock again and history lives in the log.
+/** dormantRated is a CLOCK, not a grab-bag: {hours, rate, ts} — the rated
+ *  clock parked when real mode took over, anchored at its own parking-moment
+ *  ts. Shape-sanitize anything arriving from args or prior state: finite
+ *  numbers only, no junk keys. Null when nothing usable remains. */
+function sanitizeDormant(d) {
+  if (!d || typeof d !== 'object') return null;
+  const s = {};
+  if (Number.isFinite(d.hours)) s.hours = d.hours;
+  if (Number.isFinite(d.rate)) s.rate = d.rate;
+  if (Number.isFinite(d.ts)) s.ts = d.ts;
+  return (s.hours != null || s.rate != null) ? s : null;
+}
+
+/** One clock may govern (issue #65). Whenever `clock:'real'` is authored,
+ *  the rated fields `hours`/`rate` never remain as active-looking top-level
+ *  state: they park under `dormantRated` — an explicitly-inactive clock a
+ *  later return to rated mode restores from (the tuner prefills its sliders
+ *  with it), and the one fallback source hoursAt/effectiveClock consult when
+ *  the tz turns out not to resolve. Parking is UNCONDITIONAL on real mode —
+ *  the fold never asks ICU anything, so the folded STATE is a pure function
+ *  of the log on every runtime; only derived hours depend on the tz database
+ *  (exactly as on the pre-contract fold). Outside real mode `dormantRated`
+ *  is dropped: the top-level fields are the active clock again.
  *
- *  Runs on EVERY fold, synthetic replay included — this is config
- *  normalization, not provenance stamping: deterministic, idempotent, and it
- *  heals bags folded before the contract existed the next time a late join
- *  replays them. When the tz does NOT resolve, hours/rate stay active: they
- *  genuinely govern via hoursAt's fallback, and demoting them would recreate
- *  the lie in the other direction (effectiveClock reports the fallback). */
-function normalizeClock(out) {
-  const dormant = (out.dormantRated && typeof out.dormantRated === 'object') ? { ...out.dormantRated } : {};
+ *  Newly-authored top-level fields win over the carried-forward park (and
+ *  re-anchor its ts); a standing-bag re-issue with neither inherits `prior`
+ *  untouched — that is how the wholesale sky fold carries the parked clock
+ *  across mode flips without the fold holding any state of its own.
+ *
+ *  Runs on EVERY fold, synthetic replay included — config normalization, not
+ *  provenance stamping: deterministic, idempotent, and it heals bags folded
+ *  before the contract existed the next time a late join replays them. */
+function normalizeClock(out, prior) {
   delete out.dormantRated;
-  if (out.clock === 'real' && tzFormatter(out.tz ?? 'America/Los_Angeles')) {
-    if (out.hours != null) dormant.hours = out.hours;
-    if (out.rate != null) dormant.rate = out.rate;
+  if (out.clock === 'real') {
+    const parked = {};
+    if (Number.isFinite(out.hours)) parked.hours = out.hours;
+    if (Number.isFinite(out.rate)) parked.rate = out.rate;
+    const d = (parked.hours != null || parked.rate != null)
+      ? { ...(prior ?? {}), ...parked, ts: out.ts }
+      : prior;
     delete out.hours; delete out.rate;
-    if (Object.keys(dormant).length) out.dormantRated = dormant;
+    if (d) out.dormantRated = d;
   }
   return out;
 }
@@ -257,7 +287,11 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
       }
       out.seq = seq; out.by = actor;
     }
-    return normalizeClock(out);
+    // args.dormantRated is the standing-bag re-issue carrier (the wholesale
+    // fold has no prev to inherit from) — authored CONFIG at the same trust
+    // level as authoring hours/rate directly (same verb, same rank), but
+    // shape-sanitized so junk can never land in the fold
+    return normalizeClock(out, sanitizeDormant(args.dormantRated));
   }
   // weather — merges onto the standing sky (DESIGN.md: a thing that HAPPENS,
   // not a property you set). `keepSky: false` discards the standing sky and
@@ -282,7 +316,8 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
     if (base.seq != null) out.seq = base.seq; else delete out.seq;
     if (base.by != null) out.by = base.by; else delete out.by;
   }
-  return normalizeClock(out);
+  // a weather verb can never author the parked clock — base's only
+  return normalizeClock(out, sanitizeDormant(base.dormantRated));
 }
 
 /** The canonical answer to "what clock governs this sky?" (issue #65) — no
@@ -305,7 +340,10 @@ export function effectiveClock(sky, nowMs) {
   if (sky.clock === 'real') {
     const tz = sky.tz ?? 'America/Los_Angeles';
     if (tzFormatter(tz)) return { mode: 'real', tz, hour, ...prov };
-    const rate = sky.rate ?? 0;
+    // fallback mirrors hoursAt exactly: the parked clock on a normalized
+    // bag, the top-level fields on a bag that never folded (preview args)
+    const rate = (sky.dormantRated && typeof sky.dormantRated === 'object')
+      ? (sky.dormantRated.rate ?? 0) : (sky.rate ?? 0);
     return rate !== 0
       ? { mode: 'rated', rate, hour, requestedTz: tz, ...prov }
       : { mode: 'fixed', hour, requestedTz: tz, ...prov };
@@ -334,7 +372,7 @@ export function describeSky(sky, nowMs) {
   bits.push(`hour ${ck.hour.toFixed(1)}${ck.mode === 'real'
     ? ` (real time, ${ck.tz})`
     : ck.mode === 'rated' ? ` (advancing ×${ck.rate})` : ''}${ck.requestedTz
-    ? ` (requested real-time tz "${ck.requestedTz}" is unknown — authored clock in effect)` : ''}`);
+    ? ` (requested real-time tz "${ck.requestedTz}" is unknown — fallback clock in effect)` : ''}`);
   const eff = effectiveSky(sky, nowMs);
   const mins = (t) => Math.max(0, Math.round((t - nowMs) / 60000));
   if (eff.source === 'forecast') {

--- a/client/lib/forecast.js
+++ b/client/lib/forecast.js
@@ -201,16 +201,44 @@ export function effectiveSky(sky, nowMs, cursor = null) {
 
 // ---------------------------------------------------------------- fold
 
+/** One clock may govern (issue #65). Under an EFFECTIVE real clock —
+ *  `clock:'real'` with a tz Intl can resolve — the rated fields `hours`/`rate`
+ *  must not remain as active-looking top-level state: they demote into
+ *  `dormantRated`, an explicitly-inactive namespace a later return to rated
+ *  mode can restore from (the tuner prefills its sliders with it). Outside
+ *  real mode `dormantRated` is dropped: the top-level fields are the active
+ *  clock again and history lives in the log.
+ *
+ *  Runs on EVERY fold, synthetic replay included — this is config
+ *  normalization, not provenance stamping: deterministic, idempotent, and it
+ *  heals bags folded before the contract existed the next time a late join
+ *  replays them. When the tz does NOT resolve, hours/rate stay active: they
+ *  genuinely govern via hoursAt's fallback, and demoting them would recreate
+ *  the lie in the other direction (effectiveClock reports the fallback). */
+function normalizeClock(out) {
+  const dormant = (out.dormantRated && typeof out.dormantRated === 'object') ? { ...out.dormantRated } : {};
+  delete out.dormantRated;
+  if (out.clock === 'real' && tzFormatter(out.tz ?? 'America/Los_Angeles')) {
+    if (out.hours != null) dormant.hours = out.hours;
+    if (out.rate != null) dormant.rate = out.rate;
+    delete out.hours; delete out.rate;
+    if (Object.keys(dormant).length) out.dormantRated = dormant;
+  }
+  return out;
+}
+
 /** Fold a `sky` or `weather` log entry onto the standing sky state. The
  *  sequencer, the live browser client, and the embodied agent all fold
  *  through here — one code path, three planes, no drift.
  *
- *  Server-owned stamps: `forecast.{epoch,seq,by}` and the whole `override`
- *  bag come from the ENTRY, never from the authored args — a policy bag
- *  cannot spoof its own provenance. The one exception is synthetic
- *  pre-history replay (stateToEntries' negative seqs): those args ARE the
- *  already-stamped fold, so they pass through untouched — restamping them
- *  with the synthetic entry would re-epoch the forecast on every late join.
+ *  Server-owned stamps: `forecast.{epoch,seq,by}`, the whole `override` bag,
+ *  and the top-level `seq`/`by` (which sky entry authored this bag — the
+ *  effective clock's provenance, issue #65) come from the ENTRY, never from
+ *  the authored args — a policy bag cannot spoof its own provenance. The one
+ *  exception is synthetic pre-history replay (stateToEntries' negative seqs):
+ *  those args ARE the already-stamped fold, so stamps pass through untouched —
+ *  restamping them with the synthetic entry would re-epoch the forecast on
+ *  every late join.
  *
  *  A weather verb under a rated sky also REBASES `hours` to the hour the old
  *  epoch implies at the entry's ts. Without this the merge re-epochs t0 while
@@ -227,8 +255,9 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
       } else {
         delete out.forecast;      // absent or null: forecast off, authored-only
       }
+      out.seq = seq; out.by = actor;
     }
-    return out;
+    return normalizeClock(out);
   }
   // weather — merges onto the standing sky (DESIGN.md: a thing that HAPPENS,
   // not a property you set). `keepSky: false` discards the standing sky and
@@ -249,8 +278,40 @@ export function foldSkyEntry(prev, { verb, args = {}, ts, seq, actor }) {
       };
     } else if (base.override) out.override = base.override;
     else delete out.override;
+    // nor can it claim authorship of the bag — seq/by stay the sky entry's
+    if (base.seq != null) out.seq = base.seq; else delete out.seq;
+    if (base.by != null) out.by = base.by; else delete out.by;
   }
-  return out;
+  return normalizeClock(out);
+}
+
+/** The canonical answer to "what clock governs this sky?" (issue #65) — no
+ *  precedence folklore. Mirrors hoursAt's ACTUAL behavior, including the
+ *  unknown-tz fallback: `mode` is what is effective right now, never what was
+ *  merely requested. Shapes:
+ *    { mode:'real',  tz, hour, seq?, by? }
+ *    { mode:'rated', rate, hour, seq?, by?, requestedTz? }
+ *    { mode:'fixed', hour, seq?, by?, requestedTz? }
+ *  `requestedTz` appears only when `clock:'real'` was authored with a tz Intl
+ *  cannot resolve — the fallback governs and says so. `seq`/`by` are the
+ *  fold-stamped provenance of the sky entry that authored this bag. */
+export function effectiveClock(sky, nowMs) {
+  if (!sky) return { mode: 'fixed', hour: 12 };
+  const hour = hoursAt(sky, nowMs);
+  const prov = {
+    ...(sky.seq != null ? { seq: sky.seq } : {}),
+    ...(sky.by != null ? { by: sky.by } : {}),
+  };
+  if (sky.clock === 'real') {
+    const tz = sky.tz ?? 'America/Los_Angeles';
+    if (tzFormatter(tz)) return { mode: 'real', tz, hour, ...prov };
+    const rate = sky.rate ?? 0;
+    return rate !== 0
+      ? { mode: 'rated', rate, hour, requestedTz: tz, ...prov }
+      : { mode: 'fixed', hour, requestedTz: tz, ...prov };
+  }
+  const rate = sky.rate ?? 0;
+  return rate !== 0 ? { mode: 'rated', rate, hour, ...prov } : { mode: 'fixed', hour, ...prov };
 }
 
 /** Coarse day phase — the granularity ambient perception actually wants.
@@ -269,11 +330,11 @@ export function dayPhase(hours) {
 export function describeSky(sky, nowMs) {
   if (!sky) return null;
   const bits = [];
-  const rated = (sky.rate ?? 0) !== 0;
-  const real = sky.clock === 'real';
-  bits.push(`hour ${hoursAt(sky, nowMs).toFixed(1)}${real
-    ? ` (real time, ${sky.tz ?? 'America/Los_Angeles'})`
-    : rated ? ` (advancing ×${sky.rate})` : ''}`);
+  const ck = effectiveClock(sky, nowMs);
+  bits.push(`hour ${ck.hour.toFixed(1)}${ck.mode === 'real'
+    ? ` (real time, ${ck.tz})`
+    : ck.mode === 'rated' ? ` (advancing ×${ck.rate})` : ''}${ck.requestedTz
+    ? ` (requested real-time tz "${ck.requestedTz}" is unknown — authored clock in effect)` : ''}`);
   const eff = effectiveSky(sky, nowMs);
   const mins = (t) => Math.max(0, Math.round((t - nowMs) / 60000));
   if (eff.source === 'forecast') {

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -12,7 +12,7 @@ import { HeadlessBody } from "./physics.ts";
 // The same pure sky fold + weather derivation the browser client and the
 // sequencer run — text-tier perception must land on the SAME hour and
 // weather every renderer shows (issue #29's shared-fact boundary).
-import { foldSkyEntry, describeSky, effectiveSky, dayPhase, hoursAt } from "../client/lib/forecast.js";
+import { foldSkyEntry, describeSky, effectiveSky, effectiveClock, dayPhase, hoursAt } from "../client/lib/forecast.js";
 // The `particles` component's meaning, shared verbatim with the browser host:
 // a renderer client and a resident who perceives by reading must agree about
 // what is burning (#25's shared-facts boundary).
@@ -801,7 +801,9 @@ export class WorldAgent {
     const eff = effectiveSky(this.skyState, nowMs, this.skyCursor);
     this.skyCursor = eff.cursor;
     const key = `${eff.source}:${eff.seg?.idx ?? "-"}:${eff.weather ?? "-"}`;
-    const advancing = (this.skyState.rate ?? 0) !== 0 || this.skyState.clock === "real";
+    // the canonical clock decides whether day phases can move (#65) — under a
+    // real clock the folded bag no longer carries rate at all
+    const advancing = effectiveClock(this.skyState, nowMs).mode !== "fixed";
     const phase = advancing ? dayPhase(hoursAt(this.skyState, nowMs)) : null;
     if (this.lastSkyKey === null) {
       this.lastSkyKey = key;
@@ -1234,11 +1236,16 @@ export class WorldAgent {
     if (this.skyState) {
       const now = Date.now();
       const eff = effectiveSky(this.skyState, now);
+      const ck = effectiveClock(this.skyState, now);
       this.worldInfo.sky = {
         ...this.skyState,
         currentHour: Number(hoursAt(this.skyState, now).toFixed(2)),
         ...(eff.weather ? { currentWeather: eff.weather } : {}),
         source: eff.source,
+        // the one canonical clock object (#65): machine consumers read THIS,
+        // not rate/hours precedence folklore — the folded fields alongside are
+        // active state only (a real-clock fold carries no top-level rate)
+        effectiveClock: { ...ck, hour: Number(ck.hour.toFixed(2)) },
         description: describeSky(this.skyState, now),
       };
     }

--- a/tools/forecast-test.ts
+++ b/tools/forecast-test.ts
@@ -15,7 +15,7 @@
 //
 // Run: bun tools/forecast-test.ts
 
-import { WEATHERS, normalizePolicy, segmentAt, effectiveSky, foldSkyEntry, hoursAt, describeSky }
+import { WEATHERS, normalizePolicy, segmentAt, effectiveSky, effectiveClock, foldSkyEntry, hoursAt, describeSky }
   from "../client/lib/forecast.js";
 
 let pass = 0, fail = 0;
@@ -306,6 +306,114 @@ const policyArgs = {
     JSON.stringify({ clock: wet.clock, tz: wet.tz }));
   check("describeSky names the real clock", (describeSky(sky, jan) ?? "").includes("real time, America/Los_Angeles"),
     describeSky(sky, jan) ?? "null");
+}
+
+// ---------------------------------------------------------------- clock contract (#65)
+// One clock governs, and the folded state says which. Accelerated → real →
+// accelerated is the acceptance path from the issue: no stale active-looking
+// hours/rate beside clock:'real', history parked under dormantRated, bag
+// provenance (top-level seq/by) stamped by the fold, and effectiveClock as the
+// canonical machine answer on every plane.
+
+{
+  const synth = (bag: any) => foldSkyEntry(null, { verb: "sky", args: bag, ts: T0 + 9 * HOUR, seq: -1, actor: "world" });
+
+  // 1 — author accelerated policy (the commons shape: seq 2561)
+  const rated = foldSkyEntry(null,
+    { verb: "sky", args: { hours: 6.8, rate: 24, clouds: "cumulus", forecast: policyArgs }, ts: T0, seq: 2561, actor: "mica" });
+  check("#65 rated: hours/rate are top-level active state", rated.hours === 6.8 && rated.rate === 24);
+  check("#65 rated: fold stamps bag provenance", rated.seq === 2561 && rated.by === "mica");
+  const ckRated = effectiveClock(rated, T0 + HOUR);
+  check("#65 rated: effectiveClock mode/rate/provenance",
+    ckRated.mode === "rated" && ckRated.rate === 24 && ckRated.seq === 2561 && ckRated.by === "mica",
+    JSON.stringify(ckRated));
+  check("#65 rated: late join re-fold is identical",
+    JSON.stringify(synth(rated)) === JSON.stringify(rated));
+
+  // 2 — flip to real time, re-issuing the FULL standing bag (the tuner's
+  // gather() spreads skyArgs(), so the stale hours/rate ride along — the
+  // exact authoring shape that produced the issue's receipt at seq 4777)
+  const real = foldSkyEntry(null,
+    { verb: "sky", args: { ...rated, clock: "real", tz: "America/Los_Angeles" }, ts: T0 + 2 * HOUR, seq: 4777, actor: "antra" });
+  check("#65 real: no effective field still says ×24", real.rate === undefined && real.hours === undefined,
+    JSON.stringify({ hours: real.hours, rate: real.rate }));
+  check("#65 real: prior rated clock parked as dormantRated",
+    real.dormantRated?.hours === 6.8 && real.dormantRated?.rate === 24, JSON.stringify(real.dormantRated));
+  check("#65 real: clock/tz + new provenance", real.clock === "real" && real.seq === 4777 && real.by === "antra");
+  check("#65 real: forecast survives the flip (bag re-issue keeps policy)", !!real.forecast);
+  const ckReal = effectiveClock(real, Date.UTC(2026, 0, 15, 20, 30, 0));
+  check("#65 real: effectiveClock is canonical, no rate anywhere",
+    ckReal.mode === "real" && ckReal.tz === "America/Los_Angeles" && !("rate" in ckReal)
+      && ckReal.seq === 4777 && ckReal.by === "antra" && Math.abs(ckReal.hour - 12.5) < 1e-9,
+    JSON.stringify(ckReal));
+  const realDesc = describeSky(real, Date.UTC(2026, 0, 15, 20, 30, 0)) ?? "";
+  check("#65 real: narration names real time, never ×24",
+    realDesc.includes("real time, America/Los_Angeles") && !realDesc.includes("advancing"), realDesc);
+  check("#65 real: late join re-fold is identical",
+    JSON.stringify(synth(real)) === JSON.stringify(real));
+
+  // a bag folded BEFORE the contract (stale top-level hours/rate beside
+  // clock:'real' — the live commons state) heals on synthetic replay, with
+  // every provenance stamp passing through untouched
+  const legacy = { hours: 6.8, rate: 24, clouds: "cumulus", clock: "real", tz: "America/Los_Angeles",
+    forecast: { ...policyArgs, epoch: T0, seq: 4777, by: "antra" }, ts: T0 + 2 * HOUR };
+  const healed = synth(legacy);
+  check("#65 legacy bag heals on late-join replay",
+    healed.hours === undefined && healed.rate === undefined
+      && healed.dormantRated?.hours === 6.8 && healed.dormantRated?.rate === 24, JSON.stringify(healed));
+  check("#65 healing never restamps provenance",
+    healed.forecast.epoch === T0 && healed.forecast.seq === 4777 && healed.forecast.by === "antra"
+      && healed.ts === T0 + 2 * HOUR);
+
+  // 3 — weather under a real clock: merge stays clean, authorship stays put
+  const wet = foldSkyEntry(real,
+    { verb: "weather", args: { weather: "rain", seq: 9999, by: "evil" } as any, ts: T0 + 3 * HOUR, seq: 5000, actor: "digi" });
+  check("#65 weather merge resurrects no rated fields",
+    wet.rate === undefined && wet.hours === undefined && wet.dormantRated?.rate === 24, JSON.stringify(
+      { hours: wet.hours, rate: wet.rate, dormant: wet.dormantRated }));
+  check("#65 weather verb cannot claim bag authorship", wet.seq === 4777 && wet.by === "antra",
+    JSON.stringify({ seq: wet.seq, by: wet.by }));
+  check("#65 weather under real clock needs no hours rebase", !("hours" in wet));
+
+  // 4 — return to accelerated: what the tuner commits after restoring its
+  // sliders from dormantRated (clock cleared, full bag re-issued)
+  const back = foldSkyEntry(null,
+    { verb: "sky", args: { ...wet, clock: undefined, tz: undefined, hours: 6.8, rate: 24 }, ts: T0 + 4 * HOUR, seq: 5100, actor: "antra" });
+  check("#65 back to rated: hours/rate active again, dormant dropped",
+    back.hours === 6.8 && back.rate === 24 && back.dormantRated === undefined, JSON.stringify(
+      { hours: back.hours, rate: back.rate, dormant: back.dormantRated }));
+  const ckBack = effectiveClock(back, T0 + 4 * HOUR);
+  check("#65 back to rated: effective source changed once, new seq/by",
+    ckBack.mode === "rated" && ckBack.rate === 24 && ckBack.seq === 5100,
+    JSON.stringify(ckBack));
+  check("#65 back to rated: late join re-fold is identical",
+    JSON.stringify(synth(back)) === JSON.stringify(back));
+
+  // spoofing: authored seq/by/dormantRated are fold-owned and recomputed
+  const spoof = foldSkyEntry(null,
+    { verb: "sky", args: { hours: 3, rate: 1, seq: 1, by: "evil", dormantRated: { rate: 999 } } as any, ts: T0, seq: 6000, actor: "antra" });
+  check("#65 sky verb cannot spoof provenance or park fake history",
+    spoof.seq === 6000 && spoof.by === "antra" && spoof.dormantRated === undefined, JSON.stringify(spoof));
+
+  // unknown tz: the rated fallback GENUINELY governs, so it must stay active
+  // and the canonical clock must say so instead of hiding it
+  const typoFold = foldSkyEntry(null,
+    { verb: "sky", args: { clock: "real", tz: "America/Nowhere", hours: 6, rate: 1 }, ts: T0, seq: 7000, actor: "antra" });
+  check("#65 unknown tz keeps the rated fallback active",
+    typoFold.hours === 6 && typoFold.rate === 1 && typoFold.dormantRated === undefined);
+  const ckTypo = effectiveClock(typoFold, T0 + 2 * HOUR);
+  check("#65 unknown tz: effectiveClock reports the fallback honestly",
+    ckTypo.mode === "rated" && ckTypo.rate === 1 && ckTypo.requestedTz === "America/Nowhere"
+      && Math.abs(ckTypo.hour - 8) < 1e-9, JSON.stringify(ckTypo));
+  check("#65 unknown tz: narration flags the typo",
+    (describeSky(typoFold, T0) ?? "").includes('"America/Nowhere" is unknown'), describeSky(typoFold, T0) ?? "null");
+
+  // degenerate shapes
+  check("#65 effectiveClock: null sky is fixed noon",
+    JSON.stringify(effectiveClock(null, T0)) === JSON.stringify({ mode: "fixed", hour: 12 }));
+  const still = foldSkyEntry(null, { verb: "sky", args: { hours: 9 }, ts: T0, seq: 8000, actor: "antra" });
+  check("#65 effectiveClock: rate-less sky is fixed at its hour",
+    effectiveClock(still, T0 + HOUR).mode === "fixed" && effectiveClock(still, T0 + HOUR).hour === 9);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/forecast-test.ts
+++ b/tools/forecast-test.ts
@@ -401,6 +401,14 @@ const policyArgs = {
     { verb: "weather", args: { weather: "rain", dormantRated: { rate: 666 } } as any, ts: T3, seq: 5200, actor: "digi" });
   check("#65 guard: weather verb cannot author the parked clock",
     wSpoof.dormantRated?.rate === 24 && wSpoof.dormantRated?.hours === 6.8, JSON.stringify(wSpoof.dormantRated));
+  // the indirect route (review N1'): top-level hours/rate on a weather verb
+  // while the standing clock is real must not reach the park either
+  const wIndirect = foldSkyEntry(real,
+    { verb: "weather", args: { weather: "rain", hours: 1, rate: 666 }, ts: T3, seq: 5250, actor: "digi" });
+  check("#65 guard: weather-verb hours/rate cannot reach the park under a real clock",
+    wIndirect.dormantRated?.hours === 6.8 && wIndirect.dormantRated?.rate === 24 && wIndirect.dormantRated?.ts === T1
+      && wIndirect.hours === undefined && wIndirect.rate === undefined,
+    JSON.stringify({ park: wIndirect.dormantRated, hours: wIndirect.hours, rate: wIndirect.rate }));
   const junk = foldSkyEntry(null,
     { verb: "sky", args: { clock: "real", tz: "America/Los_Angeles", dormantRated: { rate: 999, hours: "noon", junk: 7, ts: "yes" } } as any, ts: T0, seq: 5300, actor: "antra" });
   check("#65 guard: sky-verb dormantRated is shape-sanitized (finite numbers only)",

--- a/tools/forecast-test.ts
+++ b/tools/forecast-test.ts
@@ -15,8 +15,14 @@
 //
 // Run: bun tools/forecast-test.ts
 
-import { WEATHERS, normalizePolicy, segmentAt, effectiveSky, effectiveClock, foldSkyEntry, hoursAt, describeSky }
-  from "../client/lib/forecast.js";
+// Namespace import ON PURPOSE (#65 N2): a named import of an export main
+// doesn't have dies at LINK time, so not one assertion runs there and the
+// suite can't serve as a negative control. This way the shared checks and the
+// both-tree behavioral controls run on any tree; only the canonical-clock
+// checks gate on the export existing (labeled as novelty when absent).
+import * as F from "../client/lib/forecast.js";
+const { WEATHERS, normalizePolicy, segmentAt, effectiveSky, foldSkyEntry, hoursAt, describeSky } = F as any;
+const effectiveClock = (F as any).effectiveClock;
 
 let pass = 0, fail = 0;
 function check(name: string, ok: boolean, detail = "") {
@@ -308,12 +314,16 @@ const policyArgs = {
     describeSky(sky, jan) ?? "null");
 }
 
+
 // ---------------------------------------------------------------- clock contract (#65)
 // One clock governs, and the folded state says which. Accelerated → real →
-// accelerated is the acceptance path from the issue: no stale active-looking
-// hours/rate beside clock:'real', history parked under dormantRated, bag
-// provenance (top-level seq/by) stamped by the fold, and effectiveClock as the
-// canonical machine answer on every plane.
+// accelerated is the acceptance path from the issue; the review's B1 path —
+// normalized real → unresolvable tz — is the regression guard: the parked
+// clock must survive the re-issue and genuinely govern (a typo dims nothing).
+//
+// The CONTROL checks below use only surfaces that exist on BOTH trees
+// (foldSkyEntry + hoursAt), so on main they fail with the actual stale
+// numbers — behavioral evidence, never a link-time missing-export.
 
 {
   const synth = (bag: any) => foldSkyEntry(null, { verb: "sky", args: bag, ts: T0 + 9 * HOUR, seq: -1, actor: "world" });
@@ -322,98 +332,132 @@ const policyArgs = {
   const rated = foldSkyEntry(null,
     { verb: "sky", args: { hours: 6.8, rate: 24, clouds: "cumulus", forecast: policyArgs }, ts: T0, seq: 2561, actor: "mica" });
   check("#65 rated: hours/rate are top-level active state", rated.hours === 6.8 && rated.rate === 24);
-  check("#65 rated: fold stamps bag provenance", rated.seq === 2561 && rated.by === "mica");
-  const ckRated = effectiveClock(rated, T0 + HOUR);
-  check("#65 rated: effectiveClock mode/rate/provenance",
-    ckRated.mode === "rated" && ckRated.rate === 24 && ckRated.seq === 2561 && ckRated.by === "mica",
-    JSON.stringify(ckRated));
   check("#65 rated: late join re-fold is identical",
     JSON.stringify(synth(rated)) === JSON.stringify(rated));
 
   // 2 — flip to real time, re-issuing the FULL standing bag (the tuner's
   // gather() spreads skyArgs(), so the stale hours/rate ride along — the
   // exact authoring shape that produced the issue's receipt at seq 4777)
+  const T1 = T0 + 2 * HOUR;
   const real = foldSkyEntry(null,
-    { verb: "sky", args: { ...rated, clock: "real", tz: "America/Los_Angeles" }, ts: T0 + 2 * HOUR, seq: 4777, actor: "antra" });
-  check("#65 real: no effective field still says ×24", real.rate === undefined && real.hours === undefined,
-    JSON.stringify({ hours: real.hours, rate: real.rate }));
-  check("#65 real: prior rated clock parked as dormantRated",
-    real.dormantRated?.hours === 6.8 && real.dormantRated?.rate === 24, JSON.stringify(real.dormantRated));
-  check("#65 real: clock/tz + new provenance", real.clock === "real" && real.seq === 4777 && real.by === "antra");
-  check("#65 real: forecast survives the flip (bag re-issue keeps policy)", !!real.forecast);
-  const ckReal = effectiveClock(real, Date.UTC(2026, 0, 15, 20, 30, 0));
-  check("#65 real: effectiveClock is canonical, no rate anywhere",
-    ckReal.mode === "real" && ckReal.tz === "America/Los_Angeles" && !("rate" in ckReal)
-      && ckReal.seq === 4777 && ckReal.by === "antra" && Math.abs(ckReal.hour - 12.5) < 1e-9,
-    JSON.stringify(ckReal));
-  const realDesc = describeSky(real, Date.UTC(2026, 0, 15, 20, 30, 0)) ?? "";
-  check("#65 real: narration names real time, never ×24",
-    realDesc.includes("real time, America/Los_Angeles") && !realDesc.includes("advancing"), realDesc);
+    { verb: "sky", args: { ...rated, clock: "real", tz: "America/Los_Angeles" }, ts: T1, seq: 4777, actor: "antra" });
+  check("#65 CONTROL (both-tree): no effective field still says ×24 after the flip",
+    real.rate === undefined && real.hours === undefined,
+    `stale hours=${real.hours} rate=${real.rate}`);
+  check("#65 real: prior rated clock parked as dormantRated {hours, rate, ts}",
+    real.dormantRated?.hours === 6.8 && real.dormantRated?.rate === 24 && real.dormantRated?.ts === T1,
+    JSON.stringify(real.dormantRated));
+  check("#65 real: clock/tz + forecast survive the flip", real.clock === "real" && !!real.forecast);
+  check("#65 real: fold stamps bag provenance", real.seq === 4777 && real.by === "antra");
   check("#65 real: late join re-fold is identical",
     JSON.stringify(synth(real)) === JSON.stringify(real));
 
-  // a bag folded BEFORE the contract (stale top-level hours/rate beside
-  // clock:'real' — the live commons state) heals on synthetic replay, with
-  // every provenance stamp passing through untouched
+  // 3 — B1: re-issue the NORMALIZED standing bag with an unresolvable tz.
+  // The parked clock must survive and govern — rev-1 of this contract
+  // destroyed it here and froze the world at the `?? 12` default noon.
+  const T2 = T0 + 3 * HOUR;
+  const typo = foldSkyEntry(null,
+    { verb: "sky", args: { ...real, tz: "America/Nowhere" }, ts: T2, seq: 4800, actor: "antra" });
+  check("#65 B1: parked clock survives a bad-tz re-issue of a normalized bag",
+    typo.dormantRated?.hours === 6.8 && typo.dormantRated?.rate === 24 && typo.dormantRated?.ts === T1,
+    JSON.stringify(typo.dormantRated));
+  const h1 = hoursAt(typo, T1 + 30 * MIN), h2 = hoursAt(typo, T1 + 45 * MIN);
+  check("#65 CONTROL B1 (both-tree): the sun still MOVES under a typo'd tz",
+    Math.abs(h1 - 18.8) < 1e-9 && Math.abs(h2 - 0.8) < 1e-9,
+    `hour(+30m)=${h1} hour(+45m)=${h2} (frozen would be 12/12)`);
+  check("#65 B1: fallback anchors on the PARKING moment, not the re-issue ts",
+    Math.abs(hoursAt(typo, T1) - 6.8) < 1e-9, String(hoursAt(typo, T1)));
+  check("#65 B1: late join re-fold of the typo bag is identical",
+    JSON.stringify(synth(typo)) === JSON.stringify(typo));
+
+  // 4 — weather lands during the bad-tz fallback: merge restamps sky.ts but
+  // the parked clock's own ts anchor keeps the fallback day continuous
+  const T3 = T0 + 4 * HOUR;
+  const wetTypo = foldSkyEntry(typo, { verb: "weather", args: { weather: "rain" }, ts: T3, seq: 4900, actor: "digi" });
+  check("#65 B1: weather merge does not snap the fallback day",
+    Math.abs(hoursAt(wetTypo, T3 + MIN) - hoursAt(typo, T3 + MIN)) < 1e-9
+      && wetTypo.dormantRated?.ts === T1 && wetTypo.ts === T3,
+    `wet=${hoursAt(wetTypo, T3 + MIN)} dry=${hoursAt(typo, T3 + MIN)}`);
+  check("#65 weather merge resurrects no rated fields",
+    wetTypo.rate === undefined && wetTypo.hours === undefined);
+  check("#65 weather verb cannot claim bag authorship", wetTypo.seq === 4800 && wetTypo.by === "antra",
+    JSON.stringify({ seq: wetTypo.seq, by: wetTypo.by }));
+
+  // 5 — bad tz → back to accelerated: full bag re-issue with the clock
+  // cleared restores the rated fields as active state, dormant drops
+  const back = foldSkyEntry(null,
+    { verb: "sky", args: { ...wetTypo, clock: undefined, tz: undefined, hours: 6.8, rate: 24 }, ts: T0 + 5 * HOUR, seq: 5100, actor: "antra" });
+  check("#65 back to rated: hours/rate active again, dormant dropped",
+    back.hours === 6.8 && back.rate === 24 && back.dormantRated === undefined,
+    JSON.stringify({ hours: back.hours, rate: back.rate, dormant: back.dormantRated }));
+  check("#65 back to rated: new provenance", back.seq === 5100 && back.by === "antra");
+  check("#65 back to rated: late join re-fold is identical",
+    JSON.stringify(synth(back)) === JSON.stringify(back));
+
+  // 6 — dormantRated guards: weather verbs are locked out entirely; sky-verb
+  // values are authored config (same rank as authoring rate itself) but
+  // shape-sanitized — junk keys and non-finite values can never land
+  const wSpoof = foldSkyEntry(real,
+    { verb: "weather", args: { weather: "rain", dormantRated: { rate: 666 } } as any, ts: T3, seq: 5200, actor: "digi" });
+  check("#65 guard: weather verb cannot author the parked clock",
+    wSpoof.dormantRated?.rate === 24 && wSpoof.dormantRated?.hours === 6.8, JSON.stringify(wSpoof.dormantRated));
+  const junk = foldSkyEntry(null,
+    { verb: "sky", args: { clock: "real", tz: "America/Los_Angeles", dormantRated: { rate: 999, hours: "noon", junk: 7, ts: "yes" } } as any, ts: T0, seq: 5300, actor: "antra" });
+  check("#65 guard: sky-verb dormantRated is shape-sanitized (finite numbers only)",
+    junk.dormantRated?.rate === 999 && junk.dormantRated?.hours === undefined
+      && (junk.dormantRated as any)?.junk === undefined && junk.dormantRated?.ts === undefined,
+    JSON.stringify(junk.dormantRated));
+  const spoof = foldSkyEntry(null,
+    { verb: "sky", args: { hours: 3, rate: 1, seq: 1, by: "evil", dormantRated: { rate: 999 } } as any, ts: T0, seq: 6000, actor: "antra" });
+  check("#65 guard: rated mode drops dormantRated and fold owns seq/by",
+    spoof.seq === 6000 && spoof.by === "antra" && spoof.dormantRated === undefined, JSON.stringify(spoof));
+
+  // 7 — a legacy bag (folded before the contract: stale top-level fields
+  // beside clock:'real' — the live commons shape) heals on synthetic replay,
+  // provenance untouched
   const legacy = { hours: 6.8, rate: 24, clouds: "cumulus", clock: "real", tz: "America/Los_Angeles",
-    forecast: { ...policyArgs, epoch: T0, seq: 4777, by: "antra" }, ts: T0 + 2 * HOUR };
+    forecast: { ...policyArgs, epoch: T0, seq: 4777, by: "antra" }, ts: T1 };
   const healed = synth(legacy);
   check("#65 legacy bag heals on late-join replay",
     healed.hours === undefined && healed.rate === undefined
       && healed.dormantRated?.hours === 6.8 && healed.dormantRated?.rate === 24, JSON.stringify(healed));
   check("#65 healing never restamps provenance",
     healed.forecast.epoch === T0 && healed.forecast.seq === 4777 && healed.forecast.by === "antra"
-      && healed.ts === T0 + 2 * HOUR);
+      && healed.ts === T1);
 
-  // 3 — weather under a real clock: merge stays clean, authorship stays put
-  const wet = foldSkyEntry(real,
-    { verb: "weather", args: { weather: "rain", seq: 9999, by: "evil" } as any, ts: T0 + 3 * HOUR, seq: 5000, actor: "digi" });
-  check("#65 weather merge resurrects no rated fields",
-    wet.rate === undefined && wet.hours === undefined && wet.dormantRated?.rate === 24, JSON.stringify(
-      { hours: wet.hours, rate: wet.rate, dormant: wet.dormantRated }));
-  check("#65 weather verb cannot claim bag authorship", wet.seq === 4777 && wet.by === "antra",
-    JSON.stringify({ seq: wet.seq, by: wet.by }));
-  check("#65 weather under real clock needs no hours rebase", !("hours" in wet));
-
-  // 4 — return to accelerated: what the tuner commits after restoring its
-  // sliders from dormantRated (clock cleared, full bag re-issued)
-  const back = foldSkyEntry(null,
-    { verb: "sky", args: { ...wet, clock: undefined, tz: undefined, hours: 6.8, rate: 24 }, ts: T0 + 4 * HOUR, seq: 5100, actor: "antra" });
-  check("#65 back to rated: hours/rate active again, dormant dropped",
-    back.hours === 6.8 && back.rate === 24 && back.dormantRated === undefined, JSON.stringify(
-      { hours: back.hours, rate: back.rate, dormant: back.dormantRated }));
-  const ckBack = effectiveClock(back, T0 + 4 * HOUR);
-  check("#65 back to rated: effective source changed once, new seq/by",
-    ckBack.mode === "rated" && ckBack.rate === 24 && ckBack.seq === 5100,
-    JSON.stringify(ckBack));
-  check("#65 back to rated: late join re-fold is identical",
-    JSON.stringify(synth(back)) === JSON.stringify(back));
-
-  // spoofing: authored seq/by/dormantRated are fold-owned and recomputed
-  const spoof = foldSkyEntry(null,
-    { verb: "sky", args: { hours: 3, rate: 1, seq: 1, by: "evil", dormantRated: { rate: 999 } } as any, ts: T0, seq: 6000, actor: "antra" });
-  check("#65 sky verb cannot spoof provenance or park fake history",
-    spoof.seq === 6000 && spoof.by === "antra" && spoof.dormantRated === undefined, JSON.stringify(spoof));
-
-  // unknown tz: the rated fallback GENUINELY governs, so it must stay active
-  // and the canonical clock must say so instead of hiding it
-  const typoFold = foldSkyEntry(null,
-    { verb: "sky", args: { clock: "real", tz: "America/Nowhere", hours: 6, rate: 1 }, ts: T0, seq: 7000, actor: "antra" });
-  check("#65 unknown tz keeps the rated fallback active",
-    typoFold.hours === 6 && typoFold.rate === 1 && typoFold.dormantRated === undefined);
-  const ckTypo = effectiveClock(typoFold, T0 + 2 * HOUR);
-  check("#65 unknown tz: effectiveClock reports the fallback honestly",
-    ckTypo.mode === "rated" && ckTypo.rate === 1 && ckTypo.requestedTz === "America/Nowhere"
-      && Math.abs(ckTypo.hour - 8) < 1e-9, JSON.stringify(ckTypo));
-  check("#65 unknown tz: narration flags the typo",
-    (describeSky(typoFold, T0) ?? "").includes('"America/Nowhere" is unknown'), describeSky(typoFold, T0) ?? "null");
-
-  // degenerate shapes
-  check("#65 effectiveClock: null sky is fixed noon",
-    JSON.stringify(effectiveClock(null, T0)) === JSON.stringify({ mode: "fixed", hour: 12 }));
-  const still = foldSkyEntry(null, { verb: "sky", args: { hours: 9 }, ts: T0, seq: 8000, actor: "antra" });
-  check("#65 effectiveClock: rate-less sky is fixed at its hour",
-    effectiveClock(still, T0 + HOUR).mode === "fixed" && effectiveClock(still, T0 + HOUR).hour === 9);
+  // ---- canonical clock (branch-only export; absence is NOVELTY, the
+  //      CONTROL failures above are the behavioral evidence on main)
+  if (!effectiveClock) {
+    console.log("  (novelty) effectiveClock export absent on this tree — canonical-clock checks skipped;"
+      + " the #65 CONTROL failures above are the behavioral evidence");
+  } else {
+    const ckRated = effectiveClock(rated, T0 + HOUR);
+    check("#65 effectiveClock: rated mode with provenance",
+      ckRated.mode === "rated" && ckRated.rate === 24 && ckRated.seq === 2561 && ckRated.by === "mica",
+      JSON.stringify(ckRated));
+    const ckReal = effectiveClock(real, Date.UTC(2026, 0, 15, 20, 30, 0));
+    check("#65 effectiveClock: real mode is canonical, no rate anywhere",
+      ckReal.mode === "real" && ckReal.tz === "America/Los_Angeles" && !("rate" in ckReal)
+        && ckReal.seq === 4777 && Math.abs(ckReal.hour - 12.5) < 1e-9,
+      JSON.stringify(ckReal));
+    const ckTypo = effectiveClock(typo, T1 + 30 * MIN);
+    check("#65 effectiveClock: bad-tz fallback reads the PARKED clock honestly",
+      ckTypo.mode === "rated" && ckTypo.rate === 24 && ckTypo.requestedTz === "America/Nowhere"
+        && Math.abs(ckTypo.hour - 18.8) < 1e-9 && ckTypo.seq === 4800,
+      JSON.stringify(ckTypo));
+    const realDesc = describeSky(real, Date.UTC(2026, 0, 15, 20, 30, 0)) ?? "";
+    check("#65 narration: real time named, never ×24",
+      realDesc.includes("real time, America/Los_Angeles") && !realDesc.includes("advancing"), realDesc);
+    const typoDesc = describeSky(typo, T1 + 30 * MIN) ?? "";
+    check("#65 narration: bad tz flags the typo AND shows the moving fallback",
+      typoDesc.includes('"America/Nowhere" is unknown') && typoDesc.includes("advancing ×24")
+        && typoDesc.includes("hour 18.8"), typoDesc);
+    check("#65 effectiveClock: null sky is fixed noon",
+      JSON.stringify(effectiveClock(null, T0)) === JSON.stringify({ mode: "fixed", hour: 12 }));
+    const still = foldSkyEntry(null, { verb: "sky", args: { hours: 9 }, ts: T0, seq: 8000, actor: "antra" });
+    check("#65 effectiveClock: rate-less sky is fixed at its hour",
+      effectiveClock(still, T0 + HOUR).mode === "fixed" && effectiveClock(still, T0 + HOUR).hour === 9);
+  }
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/skywatch-test.ts
+++ b/tools/skywatch-test.ts
@@ -175,5 +175,53 @@ function rig(skyEntry: any) {
     JSON.stringify(ps));
 }
 
+// ---------------------------------------------------------------- F: clock contract in look() (#65)
+// The issue's receipt was look() itself: one sky object carrying stale
+// hours/rate beside clock:'real'. The agent plane must serialize the
+// normalized bag plus the canonical effectiveClock, and ambient day-phase
+// perception must keep working with no top-level rate at all.
+
+{
+  // accelerated commons shape, then the owner flips to real time re-issuing
+  // the standing bag (the tuner's gather() spread — the seq 4777 shape)
+  const { ag, events } = rig({ verb: "sky", args: { hours: 6.8, rate: 24, clouds: "cumulus", forecast: policyArgs }, ts: T0, seq: 2561, actor: "mica" });
+  ag.applyEntry({ verb: "sky", args: { ...ag.skyState, clock: "real", tz: "America/Los_Angeles" }, ts: T0 + HOUR, seq: 4777, actor: "antra" }, false);
+  ag.look();
+  const sky = ag.worldInfo.sky;
+  check("#65 look(): no stale active-looking hours/rate under a real clock",
+    sky.rate === undefined && sky.hours === undefined && sky.clock === "real",
+    JSON.stringify({ hours: sky.hours, rate: sky.rate, clock: sky.clock }));
+  check("#65 look(): prior rated clock is explicit inactive provenance",
+    sky.dormantRated?.hours === 6.8 && sky.dormantRated?.rate === 24, JSON.stringify(sky.dormantRated));
+  check("#65 look(): canonical effectiveClock rides alongside",
+    sky.effectiveClock?.mode === "real" && sky.effectiveClock?.tz === "America/Los_Angeles"
+      && typeof sky.effectiveClock?.hour === "number"
+      && sky.effectiveClock?.seq === 4777 && sky.effectiveClock?.by === "antra",
+    JSON.stringify(sky.effectiveClock));
+  check("#65 look(): narration says real time, never ×24",
+    sky.description.includes("real time, America/Los_Angeles") && !sky.description.includes("advancing"),
+    sky.description);
+
+  // day phases still move with no rate field: LA 4:50 (night) → 5:10 (dawn)
+  const night = Date.UTC(2026, 0, 15, 12, 50, 0), dawn = Date.UTC(2026, 0, 15, 13, 10, 0);
+  ag.checkSky(night);
+  const before = events.length;
+  ag.checkSky(dawn);
+  // (a forecast segment boundary may also land in the 20min window — only
+  // the phase crossing itself is under test here)
+  check("#65 ambient day-phase crossing still fires under a real clock",
+    events.slice(before).some((e: any) => /dawn/.test(e?.text ?? "")),
+    JSON.stringify(events.slice(before)));
+
+  // return to accelerated: effective source changes once, with new provenance
+  ag.applyEntry({ verb: "sky", args: { hours: 6.8, rate: 24, clouds: "cumulus" }, ts: T0 + 2 * HOUR, seq: 5100, actor: "antra" }, false);
+  ag.look();
+  const back = ag.worldInfo.sky;
+  check("#65 look(): back to rated — active fields return, dormant drops",
+    back.rate === 24 && back.hours === 6.8 && back.dormantRated === undefined
+      && back.effectiveClock?.mode === "rated" && back.effectiveClock?.seq === 5100,
+    JSON.stringify({ rate: back.rate, dormant: back.dormantRated, ck: back.effectiveClock }));
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/tools/skywatch-test.ts
+++ b/tools/skywatch-test.ts
@@ -7,6 +7,12 @@
 // uses, never a synthetic log verb, never a continuous clock.
 //
 // Run: bun tools/skywatch-test.ts
+//
+// Worktree reproduction note (#65 review N4): importing mcpl/agent.ts pulls
+// three/webgpu, so a bare worktree needs the NESTED node_modules symlinks —
+// client/node_modules and mcpl/node_modules — from the main checkout, not
+// just the top-level one, or this suite dies at import and looks broken
+// when it isn't.
 
 import { WorldAgent } from "../mcpl/agent.ts";
 import { normalizePolicy, segmentAt, foldSkyEntry } from "../client/lib/forecast.js";


### PR DESCRIPTION
Closes #65.

## The contract (issue options 1+3, blended)

**Fold-level normalization** — under an *effective* real clock (`clock:"real"` with a tz Intl can resolve), top-level `hours`/`rate` never survive the fold: they park in `dormantRated`, an explicitly-inactive namespace. Outside real mode `dormantRated` is dropped (the top-level fields are the active clock again). When the tz does **not** resolve, `hours`/`rate` stay active — `hoursAt`'s fallback genuinely governs, and demoting them would recreate the lie in the other direction.

**Canonical answer** — new pure `effectiveClock(sky, now)` in `client/lib/forecast.js`: `{mode: "real"|"rated"|"fixed", hour, tz?, rate?, seq, by, requestedTz?}` — reports what is *actually* in effect (`requestedTz` flags an unresolvable real-clock tz). `look()` serializes it as `World.sky.effectiveClock`; `describeSky` and the day-phase advancing gate derive from it.

**Provenance** — the fold stamps top-level `seq`/`by` (which sky entry authored the bag; same in-bag pattern as `forecast.{epoch,seq,by}`), spoof-guarded: sky args can't forge them, weather verbs can't claim them, `dormantRated` can't be authored into a rated bag.

**Healing** — normalization runs on synthetic replay too (config, not provenance — idempotent, deterministic, stamps pass through untouched). The live commons bag (the seq 4777 receipt) heals on the next late join with no log write. Note: the *server's own* in-memory `state.sky` keeps the legacy shape until its next sky/weather fold or restart — everything consumers see (late-join replay, live folds, `look()`) is already clean.

**Tuner** — flipping back to "authored (slider)" prefills the hours/rate sliders from `dormantRated`, so commit restores the prior day/rate instead of noon-at-rate-0; in real mode the disabled slider shows what the world would return to.

**Migration** (documented in AGENTS.md): `sky.rate` can no longer be stale-but-present — it is a truthful read in rated mode and `undefined` otherwise. Machine consumers should prefer `effectiveClock`.

## Acceptance receipts

1. Accelerated `{hours, rate}` policy → late join sees it effective (fold round-trip test + browser).
2. `{clock:"real", tz}` re-issuing the full standing bag (the tuner's exact `gather()` shape) → **no effective field says ×24**; bug byte-for-byte reproduced on main first.
3. Old rate retained only as `dormantRated` — explicitly inactive.
4. Return to accelerated → effective source changes once, new `seq`/`by`.
5. Planes agree: `forecast-test` 47→**72**, `skywatch-test` 27→**33** (look() shape, narration, day-phase under real clock), `look-test` 4/4, `comptest` 33/33 through a real sequencer, and a **live browser** late-join receipt through a scratch sequencer: folded bag `{clock:"real", tz, dormantRated:{hours:6.8, rate:24}, seq, by}` with no top-level `hours`/`rate`, browser hour == LA wall clock (14.796 vs 14:47), then back-to-rated reload shows `{hours:6.8, rate:24}` active and dormant gone.

No deploy, no merge — for independent review per Mica's fences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)