### PR TITLE
client: resident-controlled local grass cap — full/medium/low/off (#60)

### DIFF
--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -15,7 +15,8 @@ import { loadGLB, libLabels, listLibrary } from './assets.js';
 import { makeLightGizmo } from './lights.js';
 import { entities, entityMeta, comps, findPart } from './world.js';
 import { surfaceUnder, reindexCollider } from './colliders.js';
-import { heightAt } from './terrain.js';
+import { heightAt, GRASS_QUALITY, getGrassQuality, setGrassQuality,
+  getGrassDensity, getGrassShed } from './terrain.js';
 import { sendVerb, sendDrag } from './net.js';
 import { myState, mouse, setPointerClaim, setEditingProbe } from './controller.js';
 import { makeSection, toast, flashHint, collapseAll, panelFrame } from './ui.js';
@@ -1086,6 +1087,28 @@ function paintSky(body) {
   cqRow.title = 'local performance setting — not shared with the world';
   body.appendChild(cqRow);
 
+  // The meadow budget is likewise YOURS (#60) — a persisted cap on how much
+  // of the field this machine draws. Species/seed/extent stay world state;
+  // the auto governor may thin below the cap under load, never above it.
+  const gq = document.createElement('select');
+  gq.style.cssText = wx.style.cssText;
+  for (const q of GRASS_QUALITY) gq.appendChild(new Option(q, q));
+  const gqRow = mkRow('grass⚙', gq);
+  const syncGrassRow = () => {
+    gq.value = getGrassQuality();
+    const eff = getGrassDensity();
+    gqRow.title = getGrassShed() < 1 && gq.value !== 'off'
+      ? `local performance setting — auto governor thinned this session to ×${eff}`
+      : 'local performance setting — not shared with the world';
+  };
+  gq.onchange = () => {
+    setGrassQuality(gq.value);
+    syncGrassRow();
+    flashHint(`grass: ${gq.value} (yours only)`);
+  };
+  syncGrassRow();
+  body.appendChild(gqRow);
+
   for (const [key, label, min, max, step, dflt] of SLIDERS) {
     const input = document.createElement('input');
     input.type = 'range';
@@ -1147,6 +1170,7 @@ function paintSky(body) {
     if (a.world) wl.value = a.world;
     ck.value = a.clock === 'real' ? 'real' : '';
     syncClockUi();
+    syncGrassRow();
   };
   body._sync();
 }

--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -1100,14 +1100,25 @@ function paintSky(body) {
   // two dials stay attributed to their owners: the select is the RESIDENT's
   // cap, ⚙× is the GOVERNOR's own session dial, ×draws is what min() yields.
   const gqState = document.createElement('span');
-  gqState.className = 'v';
+  // NOT `.v` — that's the sliders' fixed 34px readout column; this text
+  // would wrap inside it, reflowing the whole row. The visible half is
+  // compact enough to fit the default 232px panel on one line (measured:
+  // ≤62px available beside the select); the aria-live announcement reads a
+  // whole sentence instead, via a visually-hidden twin.
+  gqState.style.cssText = 'margin-left:auto; white-space:nowrap; color:var(--accent); font-size:10px;';
   gqState.setAttribute('aria-live', 'polite');
+  const gqStateEye = document.createElement('span');
+  gqStateEye.setAttribute('aria-hidden', 'true');
+  const gqStateEar = document.createElement('span');
+  gqStateEar.style.cssText = 'position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0 0 0 0);';
+  gqState.append(gqStateEye, gqStateEar);
   gqRow.appendChild(gqState);
   const syncGrassRow = () => {
     gq.value = getGrassQuality();
-    const shed = getGrassShed();
+    const shed = getGrassShed(), eff = getGrassDensity();
     const active = shed < 1 && gq.value !== 'off';
-    gqState.textContent = active ? `⚙×${shed} draws ×${getGrassDensity()}` : '';
+    gqStateEye.textContent = active ? `⚙${shed}→${eff}` : '';
+    gqStateEar.textContent = active ? `auto governor dial ${shed}, drawing ${eff}` : '';
     gqRow.title = active
       ? `your cap: ${gq.value} — the auto governor's session dial is ×${shed}; the field draws the lower of the two`
       : 'local performance setting — not shared with the world';

--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -1092,13 +1092,24 @@ function paintSky(body) {
   // the auto governor may thin below the cap under load, never above it.
   const gq = document.createElement('select');
   gq.style.cssText = wx.style.cssText;
+  gq.setAttribute('aria-label', 'grass quality — local only, never shared with the world');
   for (const q of GRASS_QUALITY) gq.appendChild(new Option(q, q));
   const gqRow = mkRow('grass⚙', gq);
+  // Live dial state as visible text, not a tooltip — the governor's shed is
+  // state a keyboard or screen-reader user must be able to learn too. The
+  // two dials stay attributed to their owners: the select is the RESIDENT's
+  // cap, ⚙× is the GOVERNOR's own session dial, ×draws is what min() yields.
+  const gqState = document.createElement('span');
+  gqState.className = 'v';
+  gqState.setAttribute('aria-live', 'polite');
+  gqRow.appendChild(gqState);
   const syncGrassRow = () => {
     gq.value = getGrassQuality();
-    const eff = getGrassDensity();
-    gqRow.title = getGrassShed() < 1 && gq.value !== 'off'
-      ? `local performance setting — auto governor thinned this session to ×${eff}`
+    const shed = getGrassShed();
+    const active = shed < 1 && gq.value !== 'off';
+    gqState.textContent = active ? `⚙×${shed} draws ×${getGrassDensity()}` : '';
+    gqRow.title = active
+      ? `your cap: ${gq.value} — the auto governor's session dial is ×${shed}; the field draws the lower of the two`
       : 'local performance setting — not shared with the world';
   };
   gq.onchange = () => {
@@ -1107,6 +1118,7 @@ function paintSky(body) {
     flashHint(`grass: ${gq.value} (yours only)`);
   };
   syncGrassRow();
+  bus.on('grass-budget', syncGrassRow);   // governor sheds repaint immediately
   body.appendChild(gqRow);
 
   for (const [key, label, min, max, step, dflt] of SLIDERS) {

--- a/client/lib/flora.js
+++ b/client/lib/flora.js
@@ -16,6 +16,7 @@ import { myState } from './controller.js';
 import { remotes } from './remotes.js';
 import { mapGrassArgs, presetStrokes } from './flora_args.js';
 import { composeField } from './flora_field.js';
+import { densityCount } from './grass_quality.js';
 import { pushHostHook } from './autohooks.js';
 
 export { mapGrassArgs, presetStrokes } from './flora_args.js';
@@ -155,7 +156,8 @@ function wireDensityDial(field) {
   // the stem mesh (shrub wood) rides the same attribute OBJECTS, so the
   // shuffle above already covers it — only the count needs mirroring
   field.setDensity = (f) => {
-    const keep = Math.max(1, Math.round(n * Math.min(1, Math.max(0.05, f))));
+    // densityCount owns the clamp — including genuine zero for `off` (#60)
+    const keep = densityCount(n, f);
     field.mesh.count = keep;
     if (field.stemMesh) field.stemMesh.count = keep;
   };

--- a/client/lib/grass_quality.js
+++ b/client/lib/grass_quality.js
@@ -1,0 +1,61 @@
+// grass_quality — the resident's local meadow budget, DOM-free (unit-tested
+// in tools/grass-quality-test.ts).
+//
+// Two dials own the meadow's draw cost, and they are different people's:
+//
+//   the CAP is the resident's chosen ceiling (full/medium/low/off) — "my poor
+//   gpu" (#60). Persisted per browser, so it survives re-grows, reconnects
+//   and restarts.
+//
+//   the SHED is the frame governor's dial — session-only, lowered under load.
+//
+// What the field actually draws is min(cap, shed): the governor may thin
+// below the resident's ceiling, but can never silently raise above it, and
+// the resident raising their cap never un-sheds a machine that measured a
+// slow frame. Neither dial is ever a verb — the shared field (species, seed,
+// extent, provenance) is world state; how many blades THIS machine fills
+// pixels with is not.
+
+export const GRASS_QUALITY = ['full', 'medium', 'low', 'off'];
+export const QUALITY_DENSITY = { full: 1, medium: 0.6, low: 0.35, off: 0 };
+
+const KEY = 'ew-grass-quality';
+
+/** The dial state. `store` is localStorage in the browser, anything with
+ *  getItem/setItem in tests, or absent (state then lives for the session). */
+export function makeGrassQuality(store) {
+  const saved = store?.getItem?.(KEY);
+  let quality = GRASS_QUALITY.includes(saved) ? saved : 'full';
+  let shed = 1;
+  return {
+    /** the resident's chosen level ('full' | 'medium' | 'low' | 'off') */
+    get quality() { return quality; },
+    /** the governor's session dial, before the cap is applied */
+    get shed() { return shed; },
+    /** the resident's cap as a density factor */
+    get cap() { return QUALITY_DENSITY[quality]; },
+    /** what the field should actually draw */
+    effective() { return Math.min(QUALITY_DENSITY[quality], shed); },
+    /** choose a level; unknown names are refused, the current level stands */
+    setQuality(q) {
+      if (!GRASS_QUALITY.includes(q)) return quality;
+      quality = q;
+      store?.setItem?.(KEY, q);
+      return quality;
+    },
+    /** the governor's handle — clamped to [0, 1] */
+    shedTo(f) {
+      shed = Math.min(1, Math.max(0, Number.isFinite(f) ? f : 1));
+      return shed;
+    },
+  };
+}
+
+/** How many of a stroke's `n` instances a density factor keeps. Off (≤0) is
+ *  genuinely zero — an InstancedMesh with count 0 draws nothing — while any
+ *  positive factor keeps at least one plant so a thinned field never reads
+ *  as mowed. */
+export function densityCount(n, f) {
+  if (f <= 0) return 0;
+  return Math.max(1, Math.round(n * Math.min(1, Math.max(0.05, f))));
+}

--- a/client/lib/terrain.js
+++ b/client/lib/terrain.js
@@ -6,6 +6,7 @@
 
 import { scene, ground, grid } from './core.js';
 import { retireField } from './flora_field.js';
+import { makeGrassQuality, GRASS_QUALITY } from './grass_quality.js';
 
 let current = null;
 
@@ -43,17 +44,46 @@ let currentGrass = null;
 export function setGrass(field) {
   retireField(currentGrass, globalThis._autoParticleSystems, scene);
   currentGrass = field ?? null;
-  // sticky density: a machine that had to thin its meadow keeps it thin
-  // across re-grows, instead of re-discovering the same slow frame rate
-  if (field?.setDensity && grassDensity < 1) field.setDensity(grassDensity);
+  // sticky budget: a machine that had to thin its meadow keeps it thin
+  // across re-grows, instead of re-discovering the same slow frame rate —
+  // and a resident's chosen cap (persisted) survives them the same way
+  if (field && budget.effective() < 1) applyGrassBudget();
 }
 export const clearGrass = () => setGrass(null);
 export const hasGrass = () => currentGrass !== null;
 
-// Perf governor's handle on the meadow.
-let grassDensity = 1;
-export function setGrassDensity(f) {
-  grassDensity = f;
-  currentGrass?.setDensity?.(f);
+// The meadow budget: the resident's persisted cap × the governor's session
+// shed (grass_quality.js owns the semantics — effective is their min).
+const budget = makeGrassQuality(globalThis.localStorage);
+
+function applyGrassBudget() {
+  if (!currentGrass) return;
+  const eff = budget.effective();
+  // `off` retires the draw entirely: count 0 stops the fill, and hiding the
+  // group spares raycasts/shadows too. The field object stays whole — shared
+  // state untouched, and any cap raise restores it in place.
+  if (currentGrass.mesh) currentGrass.mesh.visible = eff > 0;
+  currentGrass.setDensity?.(eff);
 }
-export const getGrassDensity = () => grassDensity;
+
+// Perf governor's handle on the meadow — may thin below the resident's cap,
+// never raises above it (the cap wins in effective()).
+export function setGrassDensity(f) {
+  budget.shedTo(f);
+  applyGrassBudget();
+}
+/** effective density — what this machine actually draws */
+export const getGrassDensity = () => budget.effective();
+
+// The resident's own dial (#60): full | medium | low | off, persisted per
+// browser. Never a verb — the shared field is world state, the draw cost is
+// not.
+export function setGrassQuality(q) {
+  const applied = budget.setQuality(q);
+  applyGrassBudget();
+  return applied;
+}
+export const getGrassQuality = () => budget.quality;
+/** the governor's uncapped session dial, for inspection */
+export const getGrassShed = () => budget.shed;
+export { GRASS_QUALITY };

--- a/client/lib/terrain.js
+++ b/client/lib/terrain.js
@@ -4,7 +4,7 @@
 // the controller needs ground height every frame, and world.js needs the
 // controller's position to place things. Both depend on this instead.
 
-import { scene, ground, grid } from './core.js';
+import { scene, ground, grid, bus } from './core.js';
 import { retireField } from './flora_field.js';
 import { makeGrassQuality, GRASS_QUALITY } from './grass_quality.js';
 
@@ -57,13 +57,18 @@ export const hasGrass = () => currentGrass !== null;
 const budget = makeGrassQuality(globalThis.localStorage);
 
 function applyGrassBudget() {
-  if (!currentGrass) return;
   const eff = budget.effective();
-  // `off` retires the draw entirely: count 0 stops the fill, and hiding the
-  // group spares raycasts/shadows too. The field object stays whole — shared
-  // state untouched, and any cap raise restores it in place.
-  if (currentGrass.mesh) currentGrass.mesh.visible = eff > 0;
-  currentGrass.setDensity?.(eff);
+  if (currentGrass) {
+    // `off` retires the draw entirely: count 0 stops the fill, and hiding the
+    // group spares raycasts/shadows too. The field object stays whole — shared
+    // state untouched, and any cap raise restores it in place.
+    if (currentGrass.mesh) currentGrass.mesh.visible = eff > 0;
+    currentGrass.setDensity?.(eff);
+  }
+  // whoever renders the dials (the grass⚙ row) hears every budget change —
+  // including the governor's, which otherwise went stale until the next
+  // panel open
+  bus.emit('grass-budget');
 }
 
 // Perf governor's handle on the meadow — may thin below the resident's cap,

--- a/client/lib/ui.js
+++ b/client/lib/ui.js
@@ -292,8 +292,10 @@ export function buildHelp() {
       sky changes, nearly free per frame. <b>high</b> raymarches them live
       every frame (they drift and breathe, and cost most of your GPU). Open
       <b>sky</b> and set <b>clouds⚙</b> — that setting is yours alone and is
-      never shared with the world. The client will also turn it down by
-      itself if the frame rate drops.</p>
+      never shared with the world. <b>grass⚙</b> in the same panel caps how
+      much of the meadow your machine draws (<b>off</b> hides it entirely,
+      for you only) — the shared field itself is untouched. The client will
+      also turn both down by itself if the frame rate drops.</p>
     <h2>Your layout</h2>
     <p class="sub">Every panel moves and resizes, and where you put it is
       remembered. <kbd>Alt</kbd>+drag moves a panel from anywhere on it. The

--- a/client/main.js
+++ b/client/main.js
@@ -13,7 +13,7 @@ import { contributeThumbnail, makeAvatar, EMOTE_ORDER, EMOTES } from './lib/avat
 import { updateSky, updateAutoSystems, skyArgs, skyImpl,
   CLOUD_QUALITY, getCloudQuality, setCloudQuality } from './lib/sky.js';
 import { setSkyArgsSource, entities, liveEntities, buildsPending, roleOf, worldHasOwner, comps, avatarMounts, mountTransform, socketWorldPos } from './lib/world.js';
-import { hasGrass, setGrassDensity } from './lib/terrain.js';
+import { hasGrass, setGrassDensity, getGrassDensity } from './lib/terrain.js';
 // side-effecting: the `particles` component's host wires itself to the comp
 // and entity buses on import (it has no boot step of its own)
 import { emitterCount, emitterQuality, setEmitterQuality } from './lib/emitters.js';
@@ -1109,11 +1109,13 @@ function shedClouds(now) {
 // frame budget on some browsers (Safari, measured 08-02 — "grass really
 // kills visual smoothness"), and a 60% field at full resolution reads far
 // better than a full field at 70% resolution. Sticky across re-grows.
-let grassShed = 1;
+// Steps from the EFFECTIVE density (the resident's grass⚙ cap already
+// applies), so a capped meadow isn't "shed" to a value the cap was already
+// below — that would toast without changing a single blade.
 function shedGrass() {
-  if (!hasGrass() || grassShed <= 0.35) return false;
-  grassShed = grassShed > 0.65 ? 0.6 : 0.35;
-  setGrassDensity(grassShed);
+  const eff = getGrassDensity();
+  if (!hasGrass() || eff <= 0.35) return false;
+  setGrassDensity(eff > 0.65 ? 0.6 : 0.35);
   toast(`grass thinned to keep the frame rate`, 'warn', 8000);
   return true;
 }

--- a/tools/grass-quality-test.ts
+++ b/tools/grass-quality-test.ts
@@ -1,0 +1,155 @@
+// The resident's local grass cap (#60), run headless.
+//
+//   bun tools/grass-quality-test.ts
+//
+// The contract under test: the resident's chosen level (full/medium/low/off,
+// persisted per browser) and the frame governor's session shed are separate
+// dials, and the field draws their MIN — the governor may thin below the cap
+// but can never silently raise above it, `off` genuinely draws zero without
+// touching the shared field object, and the cap survives field replacement
+// (re-grow) and arrives before the first field loads. None of it is ever a
+// world verb.
+//
+// Negative control: this suite FAILS on current main — grass_quality.js does
+// not exist there, terrain.js exports no quality surface, and main's inline
+// density dial keeps ≥1 instance per stroke at factor 0 (the densityCount
+// zero assertion is the behavioral delta, not just a missing module).
+
+import { plugin } from "bun";
+const here = (f: string) => new URL(f, import.meta.url).pathname;
+plugin({
+  name: "grass-stubs",
+  setup(b) {
+    b.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here("./grass-terrain-stub.mjs") }));
+  },
+});
+
+// terrain reads localStorage at module init — install the fake FIRST, with a
+// value already present: the "setting exists before any field loads" case.
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+};
+store.set("ew-grass-quality", "low");
+(globalThis as any)._autoParticleSystems = [];
+
+const { makeGrassQuality, densityCount, GRASS_QUALITY, QUALITY_DENSITY } =
+  await import("../client/lib/grass_quality.js");
+const terrain = await import("../client/lib/terrain.js");
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+const near = (a: number, b: number, eps = 1e-9) => Math.abs(a - b) < eps;
+
+// A field shaped to terrain's setGrass contract, recording what it was told.
+const mkField = () => {
+  const f: any = {
+    mesh: { visible: true },
+    calls: [] as number[],
+    disposed: false,
+    autoHooks: [],
+  };
+  f.setDensity = (k: number) => f.calls.push(k);
+  f.dispose = () => { f.disposed = true; };
+  return f;
+};
+const last = (f: any) => f.calls[f.calls.length - 1];
+
+console.log("\nthe dial itself (makeGrassQuality)");
+{
+  const q = makeGrassQuality(undefined);
+  check("no store → full, effective 1", q.quality === "full" && near(q.effective(), 1));
+  const s = new Map([["ew-grass-quality", "medium"]]);
+  const fake = { getItem: (k: string) => s.get(k) ?? null, setItem: (k: string, v: string) => s.set(k, v) };
+  const q2 = makeGrassQuality(fake);
+  check("persisted level loads", q2.quality === "medium" && near(q2.cap, 0.6));
+  q2.setQuality("low");
+  check("setQuality persists", s.get("ew-grass-quality") === "low");
+  check("reload sees the change", makeGrassQuality(fake).quality === "low");
+  check("unknown level refused, current stands",
+    q2.setQuality("turbo") === "low" && q2.quality === "low");
+  s.set("ew-grass-quality", "9000");
+  check("garbage in the store → full", makeGrassQuality(fake).quality === "full");
+
+  const g = makeGrassQuality(undefined);
+  g.setQuality("medium");
+  check("governor may lower below the cap", near((g.shedTo(0.35), g.effective()), 0.35));
+  check("governor cannot raise above the cap", near((g.shedTo(1), g.effective()), 0.6));
+  g.setQuality("full");
+  g.shedTo(0.6);
+  check("raising the cap does not un-shed the session", near(g.effective(), 0.6));
+  g.setQuality("off");
+  check("off is zero regardless of shed", near(g.effective(), 0));
+  check("shed clamps to [0,1]", near(g.shedTo(2), 1) && near(g.shedTo(-1), 0) && near(g.shedTo(NaN), 1));
+  check("levels and factors agree",
+    GRASS_QUALITY.every((k: string) => QUALITY_DENSITY[k] !== undefined));
+}
+
+console.log("\nthe instance-count dial (densityCount)");
+{
+  check("full keeps the field", densityCount(1000, 1) === 1000);
+  check("0.6 keeps 600", densityCount(1000, 0.6) === 600);
+  check("tiny factors floor at 5%", densityCount(1000, 0.001) === 50);
+  check("a thinned field never reads as mowed", densityCount(3, 0.01) === 1);
+  check("off draws ZERO (main keeps ≥1 per stroke)", densityCount(1000, 0) === 0);
+  check("negative is zero too", densityCount(1000, -0.5) === 0);
+}
+
+console.log("\nterrain lifecycle (the real setGrass/setGrassDensity path)");
+{
+  check("cap set BEFORE any field load is live", terrain.getGrassQuality() === "low");
+
+  const a = mkField();
+  terrain.setGrass(a);
+  check("field arriving finds the cap waiting", near(last(a), 0.35), String(a.calls));
+
+  check("chosen and effective are separately inspectable",
+    terrain.getGrassQuality() === "low" && near(terrain.getGrassDensity(), 0.35)
+    && near(terrain.getGrassShed(), 1));
+
+  terrain.setGrassQuality("medium");
+  check("cap change applies to the loaded field", near(last(a), 0.6), String(a.calls));
+
+  const b = mkField();
+  terrain.setGrass(b);
+  check("replacement field inherits the cap (sticky re-grow)", near(last(b), 0.6), String(b.calls));
+  check("replaced field was retired, not mutated", a.disposed === true);
+
+  terrain.setGrassQuality("off");
+  check("off tells the field to draw zero", near(last(b), 0));
+  check("off hides the group locally", b.mesh.visible === false);
+  check("off leaves the field object whole (shared state untouched)",
+    b.disposed === false && typeof b.setDensity === "function");
+
+  terrain.setGrassQuality("full");
+  check("raising the cap restores in place", b.mesh.visible === true && near(last(b), 1));
+
+  terrain.setGrassDensity(0.6);
+  check("governor thins the live field", near(last(b), 0.6));
+  terrain.setGrassQuality("low");
+  terrain.setGrassDensity(1);
+  check("governor recovery still honors the cap", near(last(b), 0.35), String(last(b)));
+
+  check("the chosen level persisted for the next session",
+    store.get("ew-grass-quality") === "low");
+
+  check("unknown level via terrain refused",
+    terrain.setGrassQuality("mega") === "low" && terrain.getGrassQuality() === "low");
+}
+
+console.log("\nnever a verb (source-level)");
+{
+  const src = await Bun.file(here("../client/lib/terrain.js")).text();
+  const gq = await Bun.file(here("../client/lib/grass_quality.js")).text();
+  check("terrain.js does not import net.js or send verbs",
+    !src.includes("net.js") && !src.includes("sendVerb"));
+  check("grass_quality.js is dependency-free",
+    !gq.includes("import "));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/tools/grass-quality-test.ts
+++ b/tools/grass-quality-test.ts
@@ -10,10 +10,12 @@
 // (re-grow) and arrives before the first field loads. None of it is ever a
 // world verb.
 //
-// Negative control: this suite FAILS on current main — grass_quality.js does
-// not exist there, terrain.js exports no quality surface, and main's inline
-// density dial keeps ≥1 instance per stroke at factor 0 (the densityCount
-// zero assertion is the behavioral delta, not just a missing module).
+// Negative control: this suite FAILS on current main, and the FIRST section
+// fails there for the right reason — it evaluates flora.js's shipped dial
+// expression (source-extracted, runnable on both trees) and demonstrates the
+// behavioral delta directly: factor 0 keeps 50 instances on main, 0 here.
+// The later sections need grass_quality.js and are skipped on main with an
+// explicit novelty-not-behavior note.
 
 import { plugin } from "bun";
 const here = (f: string) => new URL(f, import.meta.url).pathname;
@@ -34,16 +36,40 @@ const store = new Map<string, string>();
 store.set("ew-grass-quality", "low");
 (globalThis as any)._autoParticleSystems = [];
 
-const { makeGrassQuality, densityCount, GRASS_QUALITY, QUALITY_DENSITY } =
-  await import("../client/lib/grass_quality.js");
-const terrain = await import("../client/lib/terrain.js");
-
 let pass = 0, fail = 0;
 const check = (name: string, ok: boolean, detail = "") => {
   if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
   else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
 };
 const near = (a: number, b: number, eps = 1e-9) => Math.abs(a - b) < eps;
+
+// ---- behavioral delta — runs on BOTH trees -------------------------------
+// Evaluate the dial exactly as flora.js ships it, extracted from the tree's
+// own source (not retyped), so this one assertion is a live A/B: main's
+// inline expression floors at >=1 instance per stroke and keeps 50 of 1000
+// at factor 0; the branch delegates to densityCount and keeps 0.
+const gqMod = await import("../client/lib/grass_quality.js").then((m) => m, () => null);
+console.log("\nflora's shipped density dial (source-extracted, both trees)");
+{
+  const src = await Bun.file(here("../client/lib/flora.js")).text();
+  const dial = src.match(/const keep = ([^;\n]+);/);
+  let keep: unknown = "dial expression not found in flora.js";
+  if (dial) {
+    try {
+      keep = new Function("n", "f", "densityCount", `return (${dial[1]});`)(
+        1000, 0, gqMod?.densityCount);
+    } catch (e) { keep = `threw: ${e}`; }
+  }
+  check("factor 0 keeps ZERO of 1000 instances (main keeps 50)", keep === 0, `keep=${keep}`);
+}
+
+if (!gqMod) {
+  console.log(`\n${pass} passed, ${fail} failed — client/lib/grass_quality.js absent` +
+    ` (expected on main; that absence is novelty, the dial assertion above is the behavior)`);
+  process.exit(1);
+}
+const { makeGrassQuality, densityCount, GRASS_QUALITY, QUALITY_DENSITY } = gqMod;
+const terrain = await import("../client/lib/terrain.js");
 
 // A field shaped to terrain's setGrass contract, recording what it was told.
 const mkField = () => {

--- a/tools/grass-terrain-stub.mjs
+++ b/tools/grass-terrain-stub.mjs
@@ -4,3 +4,4 @@
 export const scene = { add() {}, remove() {} };
 export const ground = { visible: true };
 export const grid = { visible: true };
+export const bus = { on() {}, emit() {} };

--- a/tools/grass-terrain-stub.mjs
+++ b/tools/grass-terrain-stub.mjs
@@ -1,0 +1,6 @@
+// Test stand-in for client/lib/core.js, scoped to terrain.js's cone — see
+// tools/grass-quality-test.ts. terrain touches only the scene handle and the
+// stage floor/grid visibility, so no renderer (and no three) is needed.
+export const scene = { add() {}, remove() {} };
+export const ground = { visible: true };
+export const grid = { visible: true };


### PR DESCRIPTION
Closes #60. Design-and-review pipeline: authored by worker `eido-grass-local`; do not merge — Mica assigns independent reviewers per the worktree-wave agreement.

## What

A resident-controlled, local-only grass density cap (`full | medium | low | off`) in the sky section of the world panel, beside `clouds⚙` — the same "yours alone, never a verb" contract.

Two dials own the meadow's draw cost:
- the **resident's cap** — persisted per browser (`ew-grass-quality`), survives re-grow, replacement, reconnect and reload;
- the **frame governor's shed** — session-only, unchanged in spirit (`shedGrass` now steps from the *effective* density so a capped meadow is never "shed" to a value the cap was already below, which would toast without changing a blade).

The field draws **min(cap, shed)**: the governor may thin below the cap, never silently raise above it; raising the cap doesn't un-shed a session that measured a slow frame.

`off` genuinely draws zero — `densityCount` returns 0 instances (main's inline dial floored at ≥1 per stroke) and the group is hidden — while the field object, its hooks, and all shared world facts (species/seed/extent/provenance in the log) stay whole; raising the cap restores in place with no re-grow.

## Requirements → evidence (issue #60)

1. **never writes a world verb** — source-level test asserts terrain.js has no `net.js`/`sendVerb`; server-probe before/after dialing shows identical world `grass` state.
2. **applies through `setGrassDensity` to every stroke/stem** — dial delegates to `densityCount`; stem meshes mirror the count as before.
3. **persists & survives re-grow/reconnect** — localStorage + sticky application in `setGrass`; browser receipt: `off` held across full page reload.
4. **governor lowers, never raises above cap** — `effective() = min(cap, shed)`; unit-tested both directions.
5. **chosen and effective inspectable** — `getGrassQuality()` / `getGrassDensity()` / `getGrassShed()`; the `grass⚙` row title surfaces governor thinning.
6. **off retires/draws zero without destroying shared state** — count 0 + hidden group; field object untouched; probe confirms world state unchanged.
7. **two browsers at different caps agree on authored facts** — no verb is ever written; world `grass` args identical throughout the receipt session.
8. **receipts before load / after load / across replacement** — `tools/grass-quality-test.ts` (34 checks) covers cap-set-before-field-arrival, live-field cap change, replacement inheritance, off→restore; browser receipts below.

## Receipts

- `bun tools/grass-quality-test.ts` — **34/34 on this branch; fails on `main`** (module absent there, and the `densityCount(n, 0) === 0` assertion is a real behavioral delta, not just a missing file).
- `bun tools/flora.test.ts` — 42/42 (unchanged suite).
- `bun build client/main.js` — 0 errors, same 3 pre-existing warnings as main (verified against main).
- Browser (worktree server, scratch world): full → medium → low → off screenshots; fps rose 45 → 61 at low/off on the test machine; `off` persisted across reload; `off → low` restored the already-built field in place; server-side world `grass` state identical before/after all dialing.

## Notes for reviewers

- With cap `off` at join, the client still *builds* the field once, then zeroes/hides it. Skipping the build entirely at `off` would also skip its wind/pusher hooks and complicate cap-raise restore; left as a possible follow-up optimization.
- `getGrassDensity()` semantics changed from "last value set" to "effective density"; its only caller (`shedGrass`) is updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)