### PR TITLE
Ops: allow Eidoverse whispers to fail closed

### DIFF
--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -89,6 +89,8 @@ function persistState() {
 
 // ---- tools (shared schema with the stdio server, minus retina by default) --
 
+const WHISPERS_ENABLED = process.env.EIDO_WHISPERS_ENABLED !== "0";
+
 const TOOLS = [
   { name: "look", description: "Text-tier perception: where you are, who's present and what they're doing, every placed thing with distance/bearing, and chat since you last looked.", inputSchema: { type: "object", properties: {} } },
   { name: "snapshot", description: "A rendered image from the world (spectator browser on a GPU host). Slower than look — use when spatial/visual detail matters. view: 'first' (default) is your avatar's eyes — you are not in frame; 'third' is an over-the-shoulder chase view — your body and what's ahead of it; 'selfie' faces you from in front — your avatar, framed.", inputSchema: { type: "object", properties: { view: { type: "string", enum: ["first", "third", "selfie"] } } } },
@@ -554,7 +556,7 @@ class Session {
         try {
           switch (req.method) {
             case "tools/list":
-              this.conn.sendResponse(req.id, { tools: TOOLS });
+              this.conn.sendResponse(req.id, { tools: WHISPERS_ENABLED ? TOOLS : TOOLS.filter((t) => t.name !== "whisper") });
               break;
             case "tools/call":
               this.conn.sendResponse(req.id, await this.handleTool(String(params.name), (params.arguments ?? {}) as Record<string, any>));
@@ -815,6 +817,7 @@ class Session {
       }
       case "say": ag.say(String(a.text).slice(0, 4000)); return text("said");
       case "whisper": {
+        if (!WHISPERS_ENABLED) return text("whispers are disabled in this world");
         ag.whisper(String(a.to), String(a.text).slice(0, 4000));
         return text(`whispered to ${a.to}`);
       }

--- a/server/server.ts
+++ b/server/server.ts
@@ -1239,6 +1239,7 @@ function requestSnap(world: World, follow: string, view = "first"): Promise<{ ok
  *  private message that simply never arrives. */
 const pendingWhispers = new Map<string, unknown[]>();
 const whisperKey = (world: string, recipient: string) => `${world}\u0000${recipient}`;
+const WHISPERS_ENABLED = process.env.EIDO_WHISPERS_ENABLED !== "0";
 
 let clientVersionCache: { at: number; v: string } | null = null;
 let nextClientNum = 1;
@@ -2404,6 +2405,10 @@ const server = Bun.serve({
           break;
         }
         case "whisper": {
+          if (!WHISPERS_ENABLED) {
+            ws.send(JSON.stringify({ type: "error", error: "whispers are disabled in this world" }));
+            break;
+          }
           // A private message between two bodies.
           //
           // It must NEVER reach the world log. The log is append-only, public,

--- a/tools/whisper-disable-test.ts
+++ b/tools/whisper-disable-test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { strict as A } from "node:assert";
+const server = readFileSync(new URL("../server/server.ts", import.meta.url), "utf8");
+const mcpl = readFileSync(new URL("../mcpl/net-server.ts", import.meta.url), "utf8");
+A.match(server, /const WHISPERS_ENABLED = process\.env\.EIDO_WHISPERS_ENABLED !== "0"/);
+A.match(server, /case "whisper": \{\s*if \(!WHISPERS_ENABLED\)/);
+A.match(server, /whispers are disabled in this world/);
+A.match(mcpl, /TOOLS\.filter\(\(t\) => t\.name !== "whisper"\)/);
+A.match(mcpl, /case "whisper": \{\s*if \(!WHISPERS_ENABLED\)/);
+console.log("whisper disable gates: 5/5");


### PR DESCRIPTION
Adds an `EIDO_WHISPERS_ENABLED=0` fail-closed gate at both the sequencer delivery/holding path and the MCPL tool surface. Disabled MCPL servers omit the whisper tool and reject stale direct calls; the sequencer refuses browser/raw whisper packets before delivery or pending-memory hold. Default behavior remains enabled until production opts out. Requested by Antra during the Evander output-path incident.