### PR TITLE
grass: report whether the resident cap actually APPLIED, not just requested (#74)

### DIFF
--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -16,7 +16,7 @@ import { makeLightGizmo } from './lights.js';
 import { entities, entityMeta, comps, findPart } from './world.js';
 import { surfaceUnder, reindexCollider } from './colliders.js';
 import { heightAt, GRASS_QUALITY, getGrassQuality, setGrassQuality,
-  getGrassDensity, getGrassShed } from './terrain.js';
+  getGrassDensity, getGrassShed, getGrassApplied } from './terrain.js';
 import { sendVerb, sendDrag } from './net.js';
 import { myState, mouse, setPointerClaim, setEditingProbe } from './controller.js';
 import { makeSection, toast, flashHint, collapseAll, panelFrame } from './ui.js';
@@ -1117,6 +1117,20 @@ function paintSky(body) {
     gq.value = getGrassQuality();
     const shed = getGrassShed(), eff = getGrassDensity();
     const active = shed < 1 && gq.value !== 'off';
+    // Applied truth (#74): the same report the programmatic surface serves —
+    // one source, so the row can never claim a density the renderer didn't.
+    // A false cap outranks governor detail for the row's scarce pixels.
+    const rep = getGrassApplied();
+    const bad = rep.field && rep.status !== 'applied';
+    if (bad) {
+      const names = rep.strokes.filter((s) => !s.ok).map((s) => s.stroke).join(', ');
+      gqStateEye.textContent = `⚠${rep.status}`;
+      gqStateEar.textContent = `grass cap ${gq.value} ${rep.status}` +
+        (names ? `: stroke ${names} has no working density dial` : '');
+      gqRow.title = `your cap asked for ×${eff} but the renderer did not fully apply it` +
+        ` (${rep.status}${names ? `: ${names}` : ''}) — affected strokes draw at their built density`;
+      return;
+    }
     gqStateEye.textContent = active ? `⚙${shed}→${eff}` : '';
     gqStateEar.textContent = active ? `auto governor dial ${shed}, drawing ${eff}` : '';
     gqRow.title = active

--- a/client/lib/flora.js
+++ b/client/lib/flora.js
@@ -211,6 +211,8 @@ export async function buildFloraField(rawArgs, { scene, heightFn }) {
   try {
     for (const st of strokes) {
       const f = await mod.createFlora({ ...st, heightFn });
+      // named so an applied-truth report (#74) can identify the stroke
+      f.strokeLabel = `${fields.length}:${st.species ?? 'grass'}`;
       wireDensityDial(f);
       mask.wire(f.material);
       group.add(f.mesh);

--- a/client/lib/flora_field.js
+++ b/client/lib/flora_field.js
@@ -21,11 +21,12 @@ export function strokeApplied(f, eff, i = 0) {
   // a stroke that planted nothing draws nothing — any factor is vacuously on
   if (!total) return { stroke, total: 0, drawn: 0, expected: 0, dial: false, ok: true, why: 'empty' };
   const drawn = f.mesh?.count ?? total;
+  const stemDrawn = f.stemMesh?.count;
   const expected = densityCount(total, eff);
   const dial = typeof f.setDensity === 'function';
-  const ok = drawn === expected;
+  const ok = drawn === expected && (stemDrawn == null || stemDrawn === expected);
   return {
-    stroke, total, drawn, expected, dial, ok,
+    stroke, total, drawn, ...(stemDrawn != null ? { stemDrawn } : {}), expected, dial, ok,
     why: ok ? 'applied' : dial ? 'count-mismatch' : 'no-density-dial',
   };
 }

--- a/client/lib/flora_field.js
+++ b/client/lib/flora_field.js
@@ -3,6 +3,57 @@
 // grass verb owns: possibly several engine strokes composed under one group.
 
 import { ownHook, releaseHook } from './autohooks.js';
+import { densityCount } from './grass_quality.js';
+
+// ---- applied truth (#74) ---------------------------------------------------
+// The density dial can silently no-op: wireDensityDial returns early when a
+// stroke's expected instanced attributes are absent (vegetation.js version
+// skew), leaving the stroke without setDensity, and the composed dial
+// optional-chains every child. Policy arithmetic then reports a density the
+// renderer never applied. These reports read the LIVE draw state — the
+// instanced mesh's actual count — never the arithmetic, so a resident-facing
+// surface can say when the cap did not take.
+
+/** One stroke's draw truth for a requested density factor. */
+export function strokeApplied(f, eff, i = 0) {
+  const stroke = f.strokeLabel ?? `stroke ${i}`;
+  const total = f.count ?? 0;
+  // a stroke that planted nothing draws nothing — any factor is vacuously on
+  if (!total) return { stroke, total: 0, drawn: 0, expected: 0, dial: false, ok: true, why: 'empty' };
+  const drawn = f.mesh?.count ?? total;
+  const expected = densityCount(total, eff);
+  const dial = typeof f.setDensity === 'function';
+  const ok = drawn === expected;
+  return {
+    stroke, total, drawn, expected, dial, ok,
+    why: ok ? 'applied' : dial ? 'count-mismatch' : 'no-density-dial',
+  };
+}
+
+/** The whole field's draw truth. `off` (eff ≤ 0) is enforced by group
+ *  visibility — terrain hides the group — so it applies even where count
+ *  dialing is unsupported; any positive factor needs every live stroke's
+ *  actual count to match what densityCount requested. */
+export function fieldApplied({ fields, groupVisible }, eff) {
+  if (eff <= 0) {
+    const ok = groupVisible === false;
+    return {
+      status: ok ? 'applied' : 'not-applied',
+      via: 'visibility',
+      strokes: fields.map((f, i) => ({
+        stroke: f.strokeLabel ?? `stroke ${i}`, total: f.count ?? 0,
+        drawn: ok ? 0 : (f.mesh?.count ?? f.count ?? 0), expected: 0,
+        dial: typeof f.setDensity === 'function', ok,
+        why: ok ? 'hidden' : 'group-still-visible',
+      })),
+    };
+  }
+  const strokes = fields.map((f, i) => strokeApplied(f, eff, i));
+  const live = strokes.filter((s) => s.total > 0);
+  const status = live.every((s) => s.ok) ? 'applied'
+    : live.some((s) => s.ok) ? 'partial' : 'unavailable';
+  return { status, via: 'count', strokes };
+}
 
 /** Compose stroke fields (createFlora results) + a clearing mask handle into
  *  ONE setGrass-shaped field. The caller supplies the parent group (THREE
@@ -14,6 +65,9 @@ export function composeField({ group, fields, mask }) {
     update: fields[0]?.update,
     setPushers: (list) => { for (const f of fields) f.setPushers?.(list); },
     setDensity: (k) => { for (const f of fields) f.setDensity?.(k); },
+    /** live draw truth for a requested factor (#74) — group.visible read at
+     *  call time so `off` reports what the scene actually shows */
+    applied: (eff) => fieldApplied({ fields, groupVisible: group.visible }, eff),
     // The engine registered these itself; marking them says the meadow retires
     // them, so no subsystem that claims per-frame hooks by diffing the global
     // array may adopt one that appeared while ITS own async build was in

--- a/client/lib/terrain.js
+++ b/client/lib/terrain.js
@@ -77,8 +77,29 @@ export function setGrassDensity(f) {
   budget.shedTo(f);
   applyGrassBudget();
 }
-/** effective density — what this machine actually draws */
+/** effective REQUESTED density — what the two dials agreed to ask for.
+ *  Whether the renderer actually applied it is getGrassApplied()'s answer:
+ *  a stroke without a working count dial draws denser than this number. */
 export const getGrassDensity = () => budget.effective();
+
+/** The full budget→draw chain, honestly (#74): the resident's chosen level,
+ *  the governor's shed, the requested effective factor, and what the
+ *  renderer verifiably APPLIED — read from live instance counts, never from
+ *  policy arithmetic. status: 'applied' | 'partial' | 'unavailable' |
+ *  'not-applied' | 'unknown' (field predates draw-state reporting) |
+ *  'no-field'. Strokes carry per-stroke truth so partial failure names the
+ *  affected stroke(s). Shared authored grass state is never touched. */
+export function getGrassApplied() {
+  const base = {
+    quality: budget.quality, cap: budget.cap,
+    shed: budget.shed, requested: budget.effective(),
+  };
+  if (!currentGrass) return { ...base, field: false, status: 'no-field', strokes: [] };
+  const rep = currentGrass.applied?.(base.requested);
+  // a field that cannot report draw state must not read as success
+  if (!rep) return { ...base, field: true, status: 'unknown', strokes: [] };
+  return { ...base, field: true, ...rep };
+}
 
 // The resident's own dial (#60): full | medium | low | off, persisted per
 // browser. Never a verb — the shared field is world state, the draw cost is

--- a/client/lib/ui.js
+++ b/client/lib/ui.js
@@ -294,7 +294,9 @@ export function buildHelp() {
       <b>sky</b> and set <b>clouds⚙</b> — that setting is yours alone and is
       never shared with the world. <b>grass⚙</b> in the same panel caps how
       much of the meadow your machine draws (<b>off</b> hides it entirely,
-      for you only) — the shared field itself is untouched. The client will
+      for you only) — the shared field itself is untouched. If a field can't
+      be thinned (older vegetation), the row says so with ⚠ instead of
+      pretending the cap took. The client will
       also turn both down by itself if the frame rate drops.</p>
     <h2>Your layout</h2>
     <p class="sub">Every panel moves and resizes, and where you put it is

--- a/tools/grass-quality-test.ts
+++ b/tools/grass-quality-test.ts
@@ -10,12 +10,11 @@
 // (re-grow) and arrives before the first field loads. None of it is ever a
 // world verb.
 //
-// Negative control: this suite FAILS on current main, and the FIRST section
-// fails there for the right reason — it evaluates flora.js's shipped dial
-// expression (source-extracted, runnable on both trees) and demonstrates the
-// behavioral delta directly: factor 0 keeps 50 instances on main, 0 here.
-// The later sections need grass_quality.js and are skipped on main with an
-// explicit novelty-not-behavior note.
+// Negative control: this suite FAILS on the branch base. Most failures are
+// necessarily novelty because main has no applied-truth report; the behavioral
+// anchor is the source-extracted shipped dial below, which demonstrates the
+// silent no-op live (request 0.35 while an incompatible stroke draws 800/800)
+// before main proves it has no surface capable of naming that mismatch.
 //
 // The APPLIED-TRUTH sections (#74) extend the contract: the dial can
 // silently no-op (wireDensityDial leaves a stroke without setDensity when
@@ -188,7 +187,7 @@ const wireDial = wdMatch
 
 /** A stroke shaped to createFlora's contract: instance total, live mesh
  *  count, and (when compatible) the instanced attributes the dial expects. */
-const mkStroke = (n: number, { attrs = true, label = "" } = {}) => {
+const mkStroke = (n: number, { attrs = true, label = "", stem = false } = {}) => {
   const mk = (itemSize: number) => ({
     itemSize,
     array: Float32Array.from({ length: n * itemSize }, (_, i) => i),
@@ -199,6 +198,7 @@ const mkStroke = (n: number, { attrs = true, label = "" } = {}) => {
     count: n,
     strokeLabel: label || undefined,
     mesh: { count: n, geometry: { getAttribute: (nm: string) => table[nm] } },
+    ...(stem ? { stemMesh: { count: n } } : {}),
   } as any;
 };
 
@@ -215,6 +215,16 @@ console.log("\nthe silent no-op seam (flora's shipped wireDensityDial, both tree
   good.setDensity?.(0.35);
   check("a dialed stroke's LIVE count follows densityCount",
     good.mesh.count === densityCount(1000, 0.35), `count=${good.mesh.count}`);
+  const shrub = mkStroke(1000, { label: "shrub", stem: true });
+  wireDial?.(shrub); shrub.setDensity?.(0.35);
+  check("shrub report covers both leaf and stem draw meshes",
+    ff.strokeApplied?.(shrub, 0.35)?.ok === true
+      && ff.strokeApplied?.(shrub, 0.35)?.stemDrawn === densityCount(1000, 0.35));
+  shrub.stemMesh.count = 900;
+  check("shrub stem mismatch makes the live report fail",
+    ff.strokeApplied?.(shrub, 0.35)?.ok === false
+      && ff.strokeApplied?.(shrub, 0.35)?.stemDrawn === 900,
+    JSON.stringify(ff.strokeApplied?.(shrub, 0.35)));
 
   const group: any = { visible: true };
   const field: any = ff.composeField({ group, fields: [good, yucca], mask: null });

--- a/tools/grass-quality-test.ts
+++ b/tools/grass-quality-test.ts
@@ -16,6 +16,16 @@
 // behavioral delta directly: factor 0 keeps 50 instances on main, 0 here.
 // The later sections need grass_quality.js and are skipped on main with an
 // explicit novelty-not-behavior note.
+//
+// The APPLIED-TRUTH sections (#74) extend the contract: the dial can
+// silently no-op (wireDensityDial leaves a stroke without setDensity when
+// its instanced attributes are absent; the composed dial optional-chains),
+// so every inspection surface must distinguish chosen / governor shed /
+// effective REQUESTED / effective APPLIED, read from live instance counts.
+// Their negative control also runs on both trees: flora.js's shipped
+// wireDensityDial (source-extracted) demonstrates the silent no-op LIVE, and
+// main then fails the "can this tree name it?" checks with the false success
+// it actually reports (policy 0.35, stroke drawing its full built count).
 
 import { plugin } from "bun";
 const here = (f: string) => new URL(f, import.meta.url).pathname;
@@ -165,6 +175,137 @@ console.log("\nterrain lifecycle (the real setGrass/setGrassDensity path)");
 
   check("unknown level via terrain refused",
     terrain.setGrassQuality("mega") === "low" && terrain.getGrassQuality() === "low");
+}
+
+// ---- applied truth (#74) --------------------------------------------------
+// flora.js's SHIPPED wireDensityDial, source-extracted so the silent-no-op
+// mechanism is demonstrated on both trees, not retyped into the test.
+const floraSrc = await Bun.file(here("../client/lib/flora.js")).text();
+const wdMatch = floraSrc.match(/function wireDensityDial\(field\) \{[\s\S]*?\n\}/);
+const wireDial = wdMatch
+  ? new Function("densityCount", `${wdMatch[0]}; return wireDensityDial;`)(densityCount)
+  : null;
+
+/** A stroke shaped to createFlora's contract: instance total, live mesh
+ *  count, and (when compatible) the instanced attributes the dial expects. */
+const mkStroke = (n: number, { attrs = true, label = "" } = {}) => {
+  const mk = (itemSize: number) => ({
+    itemSize,
+    array: Float32Array.from({ length: n * itemSize }, (_, i) => i),
+    needsUpdate: false,
+  });
+  const table: any = attrs ? { aPosRot: mk(4), aScaleVar: mk(2), aPhase: mk(1) } : {};
+  return {
+    count: n,
+    strokeLabel: label || undefined,
+    mesh: { count: n, geometry: { getAttribute: (nm: string) => table[nm] } },
+  } as any;
+};
+
+const ff = await import("../client/lib/flora_field.js");
+
+console.log("\nthe silent no-op seam (flora's shipped wireDensityDial, both trees)");
+{
+  check("wireDensityDial extracted from flora.js", typeof wireDial === "function");
+  const good = mkStroke(1000, { label: "0:grass" });
+  const yucca = mkStroke(800, { attrs: false, label: "1:yucca" });
+  wireDial?.(good); wireDial?.(yucca);
+  check("a stroke with instanced attributes gets a dial", typeof good.setDensity === "function");
+  check("missing attributes leave NO dial — the seam is real", yucca.setDensity === undefined);
+  good.setDensity?.(0.35);
+  check("a dialed stroke's LIVE count follows densityCount",
+    good.mesh.count === densityCount(1000, 0.35), `count=${good.mesh.count}`);
+
+  const group: any = { visible: true };
+  const field: any = ff.composeField({ group, fields: [good, yucca], mask: null });
+  field.setDensity(0.35);
+  check("the composed dial silently no-ops on the dial-less stroke",
+    yucca.mesh.count === 800, `count=${yucca.mesh.count}`);
+  check("this tree can NAME that no-op (field.applied)",
+    typeof field.applied === "function",
+    "main claims density 0.35 while 1:yucca draws 800/800 — success from policy arithmetic alone");
+  const rep = field.applied?.(0.35);
+  check("mixed field reports PARTIAL and identifies the stroke",
+    rep?.status === "partial"
+      && rep.strokes.some((s: any) => !s.ok && s.stroke === "1:yucca" && s.why === "no-density-dial")
+      && rep.strokes.some((s: any) => s.ok && s.stroke === "0:grass"),
+    JSON.stringify(rep ?? "no applied() on this tree"));
+  check("a planted-nothing stroke is vacuously applied, never a failure",
+    ff.strokeApplied?.({ count: 0, mesh: { count: 0 } }, 0.35)?.ok === true);
+}
+
+console.log("\nthe applied report through terrain (getGrassApplied)");
+{
+  const gApplied = (terrain as any).getGrassApplied;
+  check("terrain exports getGrassApplied", typeof gApplied === "function",
+    "no applied surface on this tree — getGrassDensity() reports intent only");
+  const rep0 = gApplied?.() ?? null;
+
+  terrain.setGrassQuality("low");
+
+  // acceptance 1+2: a compatible field under `low`
+  const g2 = mkStroke(1000, { label: "0:grass" }); wireDial?.(g2);
+  terrain.setGrass(ff.composeField({ group: { visible: true }, fields: [g2], mask: null }));
+  let rep = gApplied?.();
+  check("low on a compatible field: APPLIED, consistent with live mesh.count",
+    rep?.status === "applied" && rep.strokes[0]?.drawn === g2.mesh.count
+      && g2.mesh.count === densityCount(1000, 0.35),
+    JSON.stringify(rep ?? rep0));
+  check("the report carries the whole chain: chosen, cap, shed, requested",
+    rep?.quality === "low" && near(rep?.cap, 0.35) && near(rep?.shed, 1) && near(rep?.requested, 0.35));
+
+  // acceptance 3: an incompatible field must not read as success at 0.35
+  const g3 = mkStroke(800, { attrs: false, label: "0:yucca" }); wireDial?.(g3);
+  terrain.setGrass(ff.composeField({ group: { visible: true }, fields: [g3], mask: null }));
+  rep = gApplied?.();
+  check("low on an incompatible field: UNAVAILABLE, not success at 0.35",
+    rep?.status === "unavailable" && rep.strokes[0]?.drawn === 800,
+    JSON.stringify(rep ?? `getGrassDensity()=${terrain.getGrassDensity()} with stroke drawing 800/800`));
+  check("getGrassDensity still names the REQUEST — truth lives in the report",
+    near(terrain.getGrassDensity(), 0.35));
+
+  // acceptance 5: off and restore where count dialing is unsupported
+  terrain.setGrassQuality("off");
+  rep = gApplied?.();
+  check("off is honestly APPLIED via visibility even without a dial",
+    rep?.status === "applied" && rep?.via === "visibility", JSON.stringify(rep));
+  terrain.setGrassQuality("low");
+  rep = gApplied?.();
+  check("restore from off re-evaluates: UNAVAILABLE again, not remembered success",
+    rep?.status === "unavailable", JSON.stringify(rep));
+
+  // full asks for every instance — an undialed stroke drawing all of them is truth
+  terrain.setGrassQuality("full");
+  rep = gApplied?.();
+  check("full on an incompatible field is honestly applied (it IS drawing full)",
+    rep?.status === "applied", JSON.stringify(rep));
+  terrain.setGrassQuality("low");
+
+  // acceptance 6: re-grow preserves the choice, re-evaluates capability
+  const g4 = mkStroke(600, { label: "0:grass" }); wireDial?.(g4);
+  terrain.setGrass(ff.composeField({ group: { visible: true }, fields: [g4], mask: null }));
+  rep = gApplied?.();
+  check("re-grow preserves the choice and re-evaluates applied capability",
+    rep?.quality === "low" && rep?.status === "applied"
+      && g4.mesh.count === densityCount(600, 0.35), JSON.stringify(rep));
+
+  // a field that predates draw-state reporting must fail legibly
+  terrain.setGrass(mkField());
+  rep = gApplied?.();
+  check("a field that cannot report draw state is UNKNOWN, not success",
+    rep?.status === "unknown", JSON.stringify(rep));
+
+  terrain.clearGrass();
+  rep = gApplied?.();
+  check("no field at all says so", rep?.status === "no-field" && rep?.field === false);
+}
+
+console.log("\none report for every surface (source-level)");
+{
+  const bsrc = await Bun.file(here("../client/lib/build.js")).text();
+  check("the browser grass⚙ row reads the SAME report (getGrassApplied) as code does",
+    /getGrassApplied\(\)/.test(bsrc),
+    "build.js renders dial state from policy arithmetic only");
 }
 
 console.log("\nnever a verb (source-level)");


### PR DESCRIPTION
Closes #74. Off merged main `ad9eed2`, one commit, client + tests only. No live mutation, no deploy; shared authored grass state untouched (local-only, never a verb — the existing source-level checks still assert it).

## The problem (issue #74)

`wireDensityDial` returns early when a stroke's expected instanced attributes (`aPosRot`/`aScaleVar`/`aPhase`) are absent, leaving the stroke without `setDensity`; `composeField`'s dial optional-chains every child. So a resident could choose `low`, watch it persist, see `getGrassDensity() === 0.35` — while an incompatible field kept drawing its full built density. Every inspection surface reported policy arithmetic, never draw state.

## What changed

- **`flora_field.js` — `strokeApplied` / `fieldApplied` / `field.applied(eff)`**: draw truth read from the **live `mesh.count`** against `densityCount`'s expectation, never the arithmetic. `off` is judged by **group visibility** (that is how terrain enforces it), so it stays honest where count dialing is unsupported; any positive factor requires every live stroke's actual count to match the request. A planted-nothing stroke is vacuously applied. DOM-free, unit-tested.
- **`flora.js`**: strokes get `strokeLabel` (`index:species`) so partial failure **identifies the affected stroke(s)**.
- **`terrain.js` — `getGrassApplied()`**: the full chain in one report — `{quality, cap, shed, requested, field, status, via, strokes}`, status `applied | partial | unavailable | not-applied | unknown | no-field`. A field that predates draw-state reporting is `unknown`, never success. `getGrassDensity()`'s docstring now says what it returns: the REQUEST.
- **`build.js`**: the grass⚙ row consults the **same report** as the programmatic surface (acceptance 7 by construction) — on `partial`/`unavailable`/`unknown` it shows `⚠status`, names the affected strokes in the title, and says so in the aria-live text. `ui.js` help names the behavior.

## Acceptance → checks

1. compatible + incompatible fields built from flora.js's **shipped `wireDensityDial`** (source-extracted, not retyped) ✓
2. `low` on compatible: `applied`, `drawn === mesh.count === densityCount(1000, 0.35)` ✓
3. `low` on incompatible: `unavailable`, drawn 800/800 — not success at 0.35 ✓
4. mixed field: `partial`, names `1:yucca`, `why: no-density-dial` ✓
5. `off` honestly applied via visibility without a dial; restore re-evaluates to `unavailable`, not remembered success ✓ (plus: `full` on an incompatible field is honestly applied — it IS drawing full)
6. re-grow preserves the choice, re-evaluates capability ✓
7. browser row and programmatic surface read one report (source-level check) ✓

## Receipts (all run at `e259c8e`)

- `tools/grass-quality-test.ts`: **branch 55/55, exit 0**. **Main control: 41 pass / 14 fail, exit 1** — the silent no-op is demonstrated live on main by its own `wireDensityDial` + `composeField`, then main fails the naming checks with its false success printed (`getGrassDensity()=0.35 with stroke drawing 800/800`). The 41 legacy checks stay green on both trees.
- Neighbors: `flora.test.ts` 42/42 · `forecast-test.ts` 77/77 · `skywatch-test.ts` 33/33 · `look-test.ts` 4/4. `comptest` needs a live sequencer on :8993 — not run, same caveat as prior branches.

Worktree `/private/tmp/cc-eido-grass-applied` clean at `e259c8e`; main control at `/private/tmp/cc-grass-applied-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)