### PR TITLE
world audio: a sound that belongs to a place, and the four reasons it was silent

### DIFF
--- a/client/lib/ambient.js
+++ b/client/lib/ambient.js
@@ -1,0 +1,152 @@
+// ambient — an `ambient` component: a looping sound that belongs to a PLACE.
+// Attach it to any entity and that thing becomes the source; walk away and it
+// fades. Same shape as picture.js (a component that hangs media on a thing),
+// same doctrine: the log says what the world contains, the client decides how
+// to make it audible.
+//
+// Workbench-only for now, deliberately: this is our test fixture for the
+// audio-category split (see voiceconsent.js). Without world sound playing,
+// "the headphone toggle silences voices but NOT the world" is an untestable
+// claim — there is nothing to not-silence. So the fixture is a real component
+// rather than a hardcoded background track, which also means the thing being
+// tested is the composition path we actually want.
+//
+// data: { src, gain?, radius?, loop? }
+//   src    — a URL the client can fetch (our porch ambience by default)
+//   gain   — 0..1 at the source, before distance and before the world slider
+//   radius — metres to silence; inside 1/4 of it you get full gain
+//
+// Audio: WebAudio, not <audio>, so distance and the category slider compose
+// as one gain chain instead of fighting over element.volume. House standard
+// −23 LUFS applies to the material, not to us; we only attenuate.
+
+import { bus } from './core.js';
+import { entities } from './world.js';
+import { myState } from './controller.js';
+import { volumeFor } from './voiceconsent.js';
+import { report } from './core.js';
+import { audioContext } from './audioctx.js';
+
+const DEFAULT_SRC = 'assets/porch_ambient.ogg';
+const sources = new Map();          // entityId -> { el, node, gain, data }
+let ctx = null;
+
+// A SUSPENDED CONTEXT ONLY RESUMES INSIDE A REAL USER GESTURE. Calling
+// resume() from ordinary code is not a gesture, so the old opportunistic call
+// failed silently every time and the retry below re-played the ELEMENT into a
+// context that was still suspended — everything correct, nothing audible, no
+// error anywhere (R heard nothing from a −14.7 dBFS beacon, 2026-08-08).
+// So: arm a one-shot resume on the first real gesture of any kind, and keep it
+// armed until the context is actually running.
+let gestureArmed = false;
+function armGestureResume() {
+  if (gestureArmed) return;
+  gestureArmed = true;
+  const kick = () => {
+    if (!ctx) return;
+    ctx.resume().then(() => {
+      if (ctx.state === 'running') {
+        for (const s of sources.values()) s.el.play().catch(() => {});
+        for (const ev of ['pointerdown', 'keydown', 'touchstart']) removeEventListener(ev, kick);
+        gestureArmed = false;
+      }
+    }).catch(() => {});
+  };
+  for (const ev of ['pointerdown', 'keydown', 'touchstart']) addEventListener(ev, kick);
+}
+
+function audioCtx() {
+  ctx = audioContext();
+  if (ctx.state === 'suspended') { ctx.resume().catch(() => {}); armGestureResume(); }
+  return ctx;
+}
+
+/** harness/debug: why is the world silent? */
+export const audioState = () => ({
+  ctx: ctx?.state ?? 'none', sources: sources.size, gestureArmed,
+  // The GainNode value proves nothing about whether SOUND EXISTS: it is our
+  // own multiplier, and it reads 1 whether the element is playing, stalled,
+  // erroring, or was never decoded. currentTime advancing is the only proof
+  // that media is actually flowing (R: "why can I hear youtube then?" — the
+  // routing theory died there and this is what I should have exposed).
+  elements: [...sources].map(([id, s]) => ({
+    id,
+    src: s.el.currentSrc || s.el.src,
+    paused: s.el.paused,
+    currentTime: +s.el.currentTime.toFixed(2),
+    duration: Number.isFinite(s.el.duration) ? +s.el.duration.toFixed(1) : String(s.el.duration),
+    readyState: s.el.readyState,   // 0 = nothing, 4 = enough data
+    networkState: s.el.networkState, // 3 = NO_SOURCE
+    error: s.el.error ? `code ${s.el.error.code}: ${s.el.error.message}` : null,
+    muted: s.el.muted, volume: s.el.volume,
+    gainNode: +s.gain.gain.value.toFixed(3),
+  })),
+});
+
+function attach(id, data) {
+  detach(id);
+  if (!data) return;
+  try {
+    const c = audioCtx();
+    // Resolve against the DOCUMENT, not the current URL-with-query: a relative
+    // 'assets/x.ogg' next to '/?world=…&tts=…' is fine, but any future path
+    // segment would break it silently. new URL(...) makes it explicit.
+    const src = new URL(data.src ?? DEFAULT_SRC, location.origin + '/').href;
+    const el = new Audio(src);
+    el.loop = data.loop !== false;
+    // NO crossOrigin ON A SAME-ORIGIN ASSET. Setting it forces a CORS check,
+    // and this server sends no Access-Control-Allow-Origin — so the fetch is
+    // tainted and createMediaElementSource() yields SILENCE with no error.
+    // Only opt in when the asset really is cross-origin (2026-08-08).
+    if (new URL(src).origin !== location.origin) el.crossOrigin = 'anonymous';
+    const node = c.createMediaElementSource(el);
+    const gain = c.createGain();
+    gain.gain.value = 0;            // rises with proximity on the first tick
+    node.connect(gain).connect(c.destination);
+    el.play().catch(() => {
+      // autoplay policy: wait for any gesture, then start
+      addEventListener('click', () => el.play().catch(() => {}), { once: true });
+    });
+    sources.set(id, { el, node, gain, data });
+  } catch (e) { report('ambient attach', e); }
+}
+
+function detach(id) {
+  const s = sources.get(id);
+  if (!s) return;
+  sources.delete(id);
+  try { s.el.pause(); s.el.src = ''; s.gain.disconnect(); s.node.disconnect(); }
+  catch (e) { report('ambient detach', e); }
+}
+
+bus.on('comp', ({ id, type, data }) => { if (type === 'ambient') attach(id, data); });
+bus.on('entity', ({ id, gone }) => { if (gone) detach(id); });
+
+/** Per-frame-ish: distance rolloff × the WORLD category slider. Voices and
+ *  world are separate categories on purpose — muting people must not mute
+ *  the place, which is precisely what this fixture proves. */
+export function updateAmbient() {
+  if (!sources.size) return;
+  const wv = volumeFor('world');
+  for (const [id, s] of sources) {
+    const obj = entities.get(id);
+    // DO NOT DETACH ON A MISSING ENTITY. On a joining client the comp replays
+    // before its spawn has settled, so a source attached at that moment would
+    // be torn down one frame later and never rebuilt — the component is in the
+    // log, the entity exists a moment later, and the world is silent forever.
+    // A source with no entity yet is simply inaudible until there is somewhere
+    // for it to be; entity removal already detaches via the 'entity' event.
+    if (!obj) { s.gain.gain.setTargetAtTime(0, audioCtx().currentTime, 0.08); continue; }
+    const radius = s.data.radius ?? 18;
+    const d = obj.position.distanceTo(myState.pos);
+    const near = radius * 0.25;
+    const roll = d <= near ? 1 : Math.max(0, 1 - (d - near) / (radius - near));
+    const target = roll * (s.data.gain ?? 0.7) * wv;
+    // setTargetAtTime, never a raw assignment: stepping a gain clicks
+    s.gain.gain.setTargetAtTime(target, audioCtx().currentTime, 0.08);
+  }
+}
+
+/** harness/debug: what is audible and why */
+export const ambientDebug = () => Object.fromEntries(
+  [...sources].map(([id, s]) => [id, { src: s.data.src ?? DEFAULT_SRC, gain: +s.gain.gain.value.toFixed(3) }]));

--- a/client/lib/audioctx.js
+++ b/client/lib/audioctx.js
@@ -1,0 +1,38 @@
+// ONE AudioContext for the whole page.
+//
+// Chrome caps a document at roughly six AudioContexts and then refuses to make
+// more — and a refused context does not throw where you are looking, it simply
+// never produces sound. This page was creating FIVE from four modules, one of
+// them (`micAnalyserLevel`) a fresh context on every mic-stream change, never
+// closed. Toggle the mic a few times and the page is out of contexts; whatever
+// asks next — the ambient world sound, a peer's analyser — silently gets a dead
+// one. The world goes quiet with nothing in the console to see.
+//
+// So: everybody shares this. A single context is also the only way distance,
+// the category sliders and the ambient bed can compose as one gain graph
+// instead of several that cannot hear each other.
+let ctx = null;
+
+/** The page's AudioContext. Created on first use, resumed opportunistically. */
+export function audioContext() {
+  if (!ctx) ctx = new (window.AudioContext ?? window.webkitAudioContext)();
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+  return ctx;
+}
+
+/** Has one been made yet? (Probes: do not CREATE one just to look at it.) */
+export const audioContextState = () => ctx?.state ?? 'none';
+
+/** Resume on a real user gesture — the only thing that reliably works. */
+export function resumeOnGesture(after) {
+  const kick = () => {
+    if (!ctx) return;
+    ctx.resume().then(() => {
+      if (ctx.state === 'running') {
+        try { after?.(); } catch { /* caller's problem, not ours */ }
+        for (const e of ['pointerdown', 'keydown', 'touchstart']) removeEventListener(e, kick);
+      }
+    }).catch(() => {});
+  };
+  for (const e of ['pointerdown', 'keydown', 'touchstart']) addEventListener(e, kick);
+}

--- a/client/main.js
+++ b/client/main.js
@@ -13,6 +13,7 @@ import { contributeThumbnail, makeAvatar, EMOTE_ORDER, EMOTES } from './lib/avat
 import { updateSky, updateAutoSystems, skyArgs, skyImpl,
   CLOUD_QUALITY, getCloudQuality, setCloudQuality } from './lib/sky.js';
 import { setSkyArgsSource, entities, liveEntities, buildsPending, roleOf, worldHasOwner, comps, avatarMounts, mountTransform, socketWorldPos } from './lib/world.js';
+import { updateAmbient } from './lib/ambient.js';   // `ambient` comp: world sound that belongs to a place
 import { hasGrass, setGrassDensity, getGrassDensity } from './lib/terrain.js';
 // side-effecting: the `particles` component's host wires itself to the comp
 // and entity buses on import (it has no boot step of its own)
@@ -1064,6 +1065,7 @@ function frame(now) {
   updateBuild();
   BC('debug');
   updateDebug(now);              // collider/ragdoll wireframes, when F3 is up
+  updateAmbient();
   BC('send-pose');
   sendPose(now);
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -1314,6 +1314,15 @@ function contentType(path: string): string {
   if (path.endsWith(".png")) return "image/png";
   if (path.endsWith(".jpg") || path.endsWith(".jpeg")) return "image/jpeg";
   if (path.endsWith(".hdr")) return "application/octet-stream";
+  // AUDIO NEEDS A REAL TYPE. Served as application/octet-stream a media element
+  // may refuse to decode — and it fails by producing NO SOUND rather than by
+  // raising anything catchable. Chrome usually sniffs and gets away with it,
+  // which is worse: it works until the one browser that does not.
+  if (path.endsWith(".ogg") || path.endsWith(".oga")) return "audio/ogg";
+  if (path.endsWith(".mp3")) return "audio/mpeg";
+  if (path.endsWith(".wav")) return "audio/wav";
+  if (path.endsWith(".m4a") || path.endsWith(".aac")) return "audio/mp4";
+  if (path.endsWith(".webm")) return "audio/webm";
   return "application/octet-stream";
 }
 


### PR DESCRIPTION
An `ambient` component: attach it to any entity and that thing becomes an audio source; walk away and it fades. `comp {id, type: "ambient", data: {src, gain?, radius?, loop?}}`. Same shape as `picture.js` — a component that hangs media on a thing, log says what the world *contains*, client decides how to make it audible.

It also makes the audio-category split **testable for the first time**. "The headphone toggle silences voices but not the world" is an untestable claim while there is no world sound to not-silence.

## Ported, then found silent for four independent reasons

Each failed quietly and looked like "nothing to do", which is why it took a night:

1. **`updateAmbient()` had no callers.** `attach()` deliberately starts a source at gain 0 — *"rises with proximity on the first tick"* — and the tick never ran. World sound played at volume zero from the moment it was attached.
2. **Once wired, it detached on joiners.** The comp replays before its spawn has settled, so `entities.get(id)` missed and the source was destroyed one frame after creation and never rebuilt: component in the log, entity present a moment later, world permanently silent. A source whose entity hasn't arrived yet is now merely *inaudible*, not destroyed.
3. **Five AudioContexts.** `micAnalyserLevel()` made a new one on every mic-stream change and never closed it. Chrome caps a document at ~6 and then refuses — silently. Whatever asks next (the ambient bed, a peer analyser) receives a dead one. `audioctx.js` now owns one shared context; this is a real fix for `voice.js` independent of ambient.
4. **A suspended context only resumes inside a user gesture.** `resume()` from ordinary code is not a gesture, so it failed every time and the retry replayed the *element* into a still-suspended context. Now a one-shot `pointerdown`/`keydown`/`touchstart` listener resumes and restarts the sources.

Plus the server had **no audio MIME types at all** — every `.ogg` went out as `application/octet-stream`, which a media element may refuse to decode, failing by producing no sound rather than raising anything catchable.

## Diagnostics

`audioState()` reports context state, source count, and per-element truth: `paused`, `currentTime` (the only proof media is actually flowing), `readyState`, `networkState`, the element's `error`, and its own `muted`/`volume`.

Worth saying why: I originally exposed only the GainNode value, which reads `1` whether the element is playing, stalled, failed to decode, or was never loaded. On that evidence I told a listener the page was fine and blamed her output device — then she asked *"but why can I hear YouTube in this browser?"* and the theory died in one sentence. A diagnostic that cannot report failure is a mirror, not a check.

## Receipts

Lifecycle `70/70`, wiring `29/29`, client and server bundles clean. Verified on a joining client: `ambient-test` at gain `0.48`, distance-attenuated, where it read `{}` before the fixes.

## Note

Independent of #62 — no overlap with the mic-track work beyond both touching `voice.js`, where this only replaces two `new AudioContext()` calls with the shared accessor. Happy to split the AudioContext consolidation out if you'd rather review it separately, since it's a `voice.js` fix that stands on its own.
