### PR TITLE
voice: one AudioContext for the page — the leak that silences everything

### DIFF
--- a/client/lib/audioctx.js
+++ b/client/lib/audioctx.js
@@ -2,11 +2,19 @@
 //
 // Chrome caps a document at roughly six AudioContexts and then refuses to make
 // more — and a refused context does not throw where you are looking, it simply
-// never produces sound. This page was creating FIVE from four modules, one of
-// them (`micAnalyserLevel`) a fresh context on every mic-stream change, never
-// closed. Toggle the mic a few times and the page is out of contexts; whatever
-// asks next — the ambient world sound, a peer's analyser — silently gets a dead
-// one. The world goes quiet with nothing in the console to see.
+// never produces sound.
+//
+// SCOPE, precisely (Mica's review of #86, and she was right to narrow it): on
+// current `main` there are **two** construction sites, both in `voice.js` —
+// `micAnalyserLevel` at :258 and the peer analyser at :389. The first is the
+// leak that matters: a FRESH context on every mic-stream change, never closed.
+// Toggle the mic a handful of times and the document is out of contexts;
+// whatever asks next — the ambient bed, a peer's analyser — silently gets a dead
+// one, and the world goes quiet with nothing in the console to see.
+//
+// (An earlier version of this header said "five from four modules". That counted
+// sites across in-flight branches, not what is on main. Two is the number a
+// reviewer can check, so two is the number that belongs here.)
 //
 // So: everybody shares this. A single context is also the only way distance,
 // the category sliders and the ambient bed can compose as one gain graph

--- a/client/lib/audioctx.js
+++ b/client/lib/audioctx.js
@@ -1,0 +1,38 @@
+// ONE AudioContext for the whole page.
+//
+// Chrome caps a document at roughly six AudioContexts and then refuses to make
+// more — and a refused context does not throw where you are looking, it simply
+// never produces sound. This page was creating FIVE from four modules, one of
+// them (`micAnalyserLevel`) a fresh context on every mic-stream change, never
+// closed. Toggle the mic a few times and the page is out of contexts; whatever
+// asks next — the ambient world sound, a peer's analyser — silently gets a dead
+// one. The world goes quiet with nothing in the console to see.
+//
+// So: everybody shares this. A single context is also the only way distance,
+// the category sliders and the ambient bed can compose as one gain graph
+// instead of several that cannot hear each other.
+let ctx = null;
+
+/** The page's AudioContext. Created on first use, resumed opportunistically. */
+export function audioContext() {
+  if (!ctx) ctx = new (window.AudioContext ?? window.webkitAudioContext)();
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+  return ctx;
+}
+
+/** Has one been made yet? (Probes: do not CREATE one just to look at it.) */
+export const audioContextState = () => ctx?.state ?? 'none';
+
+/** Resume on a real user gesture — the only thing that reliably works. */
+export function resumeOnGesture(after) {
+  const kick = () => {
+    if (!ctx) return;
+    ctx.resume().then(() => {
+      if (ctx.state === 'running') {
+        try { after?.(); } catch { /* caller's problem, not ours */ }
+        for (const e of ['pointerdown', 'keydown', 'touchstart']) removeEventListener(e, kick);
+      }
+    }).catch(() => {});
+  };
+  for (const e of ['pointerdown', 'keydown', 'touchstart']) addEventListener(e, kick);
+}

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -18,6 +18,7 @@ import { bus, report } from './core.js';
 import { sendRtc, sendTyping } from './net.js';
 import { remotes } from './remotes.js';
 import { micFloor } from './voiceconsent.js';
+import { audioContext } from './audioctx.js';
 import { myState } from './controller.js';
 import { flashHint } from './ui.js';
 import { receivingVoice, volumeFor, isHushed } from './voiceconsent.js';
@@ -342,7 +343,12 @@ export function micAnalyserLevel() {
   if (!micStream || muted) return 0;
   if (!_an || _anStream !== micStream) {
     try {
-      const ctx = new AudioContext();
+      // ONE CONTEXT, REUSED. This made a NEW AudioContext every time the mic
+      // stream changed and never closed the old one — and Chrome caps a
+      // document at ~6, after which every further context is born unusable and
+      // SILENTLY so. Toggle the mic a few times and whatever asks next gets a
+      // dead one.
+      const ctx = audioContext();
       const src = ctx.createMediaStreamSource(micStream);
       _an = ctx.createAnalyser(); _an.fftSize = 512;
       src.connect(_an);
@@ -487,7 +493,7 @@ export function peerLevels() {
     let a = _peerAn.get(id);
     if (!a || a.stream !== p.stream) {
       try {
-        _peerCtx ??= new AudioContext();
+        _peerCtx ??= audioContext();
         const an = _peerCtx.createAnalyser();
         an.fftSize = 512;
         _peerCtx.createMediaStreamSource(p.stream).connect(an);

--- a/tools/audioctx-test.ts
+++ b/tools/audioctx-test.ts
@@ -1,0 +1,76 @@
+/** audioctx: one AudioContext for the page, proven rather than asserted.
+ *
+ *  Mica's review of #86 asked for a focused executable receipt for the
+ *  foundational module — with a fake AudioContext constructor, prove that
+ *  repeated calls yield exactly one instance. That is the whole contract, and
+ *  it is the kind of claim that is easy to state and easy to quietly break: a
+ *  later refactor that reintroduces `new AudioContext()` anywhere would not fail
+ *  any existing test, it would just start silencing pages again after six
+ *  toggles.
+ *
+ *  Run: bun tools/audioctx-test.ts
+ */
+
+let made = 0;
+let resumed = 0;
+
+class FakeAudioContext {
+  state = 'suspended';
+  sampleRate = 48000;
+  destination = { __fake: 'destination' };
+  constructor() { made++; }
+  resume() { resumed++; this.state = 'running'; return Promise.resolve(); }
+  close() { this.state = 'closed'; return Promise.resolve(); }
+  createGain() { return { gain: { value: 1, setTargetAtTime() {} }, connect() {}, disconnect() {} }; }
+  createAnalyser() { return { fftSize: 2048, connect() {}, disconnect() {}, getByteTimeDomainData() {} }; }
+  createMediaStreamSource() { return { connect() {}, disconnect() {} }; }
+  createMediaStreamDestination() { return { stream: { getTracks: () => [] } }; }
+}
+
+(globalThis as any).window = globalThis;
+(globalThis as any).AudioContext = FakeAudioContext;
+(globalThis as any).webkitAudioContext = FakeAudioContext;
+
+let pass = 0, fail = 0;
+function check(name: string, ok: boolean, detail = '') {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+const mod = await import('../client/lib/audioctx.js');
+const audioCtx = mod.audioContext;   // the module's own name, checked against its exports
+
+// ── the contract ──────────────────────────────────────────────────────────────
+
+check('no context is constructed at import time', made === 0, `made=${made}`);
+
+const a = audioCtx();
+check('first call constructs exactly one', made === 1, `made=${made}`);
+
+const b = audioCtx();
+const c = audioCtx();
+check('repeated calls construct no more', made === 1, `made=${made} after 3 calls`);
+check('every call returns the SAME instance', a === b && b === c);
+
+// The leak this module exists to fix: micAnalyserLevel made a fresh context on
+// every mic-stream change. Simulate that shape — many calls, as from a toggle
+// loop — and prove the count does not track the calls.
+for (let i = 0; i < 40; i++) audioCtx();
+check('40 further calls (the mic-toggle loop) still one context', made === 1, `made=${made}`);
+
+// A suspended context is the default before a gesture; the module should be able
+// to resume it without building a second one.
+check('audioContextState() reports the shared instance', mod.audioContextState() === a.state,
+      `${mod.audioContextState()} vs ${a.state}`);
+
+// ── the regression guard ──────────────────────────────────────────────────────
+// The failure mode is not "audioctx.js breaks" — it is "somebody adds a direct
+// construction somewhere else and this module stops being the only door."
+// Reading the source is the only way to see that from here.
+const src = await Bun.file(new URL('../client/lib/voice.js', import.meta.url)).text();
+const direct = [...src.matchAll(/new\s+(?:\(window\.)?(?:webkit)?AudioContext/g)].length;
+check('voice.js constructs no AudioContext directly', direct === 0,
+      `${direct} direct construction(s) — they must go through audioctx.js`);
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);


### PR DESCRIPTION
`micAnalyserLevel()` constructed a **new `AudioContext` every time the mic stream changed** and never closed the old one.

Chrome caps a document at roughly six contexts and then refuses — and a refused context doesn't throw anywhere you're looking, it just never produces sound. So toggle the mic a few times and the page runs out; whatever asks next (a peer analyser, any later audio work) silently receives a dead one.

`client/lib/audioctx.js` owns one shared context. Both call sites in `voice.js` use it; zero direct constructions remain. It also exposes `resumeOnGesture()`, because a suspended context only resumes inside a **real user gesture** — calling `resume()` from ordinary code is not one and fails silently, which is its own class of "everything correct, nothing audible".

A single context is also the only way distance, the category sliders, and any future world audio compose as one gain graph rather than several that can't hear each other.

Found while chasing inaudible world audio (#85) and split out here because it's a `voice.js` fix that stands on its own — take either, or both.

Lifecycle `70/70`, wiring `29/29`, bundle clean.
