### PR TITLE
a malformed raw place can no longer take the door down (#88)

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -1065,6 +1065,10 @@ export class WorldAgent {
     // door (#88). applyEntry now keeps such state out; this holds if it
     // arrives anyway.
     if (!isFiniteVec3(e.pos) || !Number.isFinite(s) || !Number.isFinite(e.yaw ?? 0)) {
+      // If position is readable, the entity has moved and any box at its old
+      // address is now a ghost floor. Retaining existing support is correct
+      // only when position itself is unreadable and the move did not land.
+      if (isFiniteVec3(e.pos)) this.dropSupport(id);
       this.noteMalformed("support-sync", { id, pos: e.pos, yaw: e.yaw, scale: e.scale });
       return;
     }

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -9,6 +9,7 @@ import * as TSL from "three/tsl";
 import { NoiseGate, SHORT_STINT_MS, APPROACH_REFRACT_MS, APPROACH_RADIUS, REARM_RADIUS,
   ACTIVITY_RADIUS_M, ACTIVITY_PULSE_MS, ACTIVITY_REFRESH_MS, MOVER_MIN_M } from "./denoise.ts";
 import { HeadlessBody, setHeightField, registerSupport, removeSupport } from "./physics.ts";
+import { isFiniteVec3 } from "./shape.ts";
 // The same pure sky fold + weather derivation the browser client and the
 // sequencer run — text-tier perception must land on the SAME hour and
 // weather every renderer shows (issue #29's shared-fact boundary).
@@ -352,6 +353,15 @@ export class WorldAgent {
     this.onEvent?.({ ts: now, kind: "activity", who: "world", text: `${who}${bits.join("; ")}` });
   }
 
+  /** A malformed log entry is WORLD data, not this agent's mistake — say so
+   *  a few times, then stay quiet: a poisoned tail replays on every
+   *  reconnect and must not flood the log with the same diagnosis (#88). */
+  private malformedSeen = 0;
+  private noteMalformed(verb: string, args: unknown) {
+    if (this.malformedSeen++ >= 5) return;
+    console.error(`[agent ${this.name}] malformed ${verb} entry — position kept: ${JSON.stringify(args)?.slice(0, 160)}`);
+  }
+
   /** A build act (spawn/place/light/remove) near this body counts as activity. */
   private noteBuild(actor: string | undefined, pos: number[] | undefined | null) {
     if (!actor || actor === this.name || actor === "world") return;
@@ -690,8 +700,17 @@ export class WorldAgent {
       if (live) this.noteBuild(actor, args.pos);
     } else if (verb === "place") {
       const e = this.entities.get(args.id);
-      if (e) { e.pos = args.pos; if (args.yaw != null) e.yaw = args.yaw; if (args.scale != null) e.scale = args.scale; }
-      if (live) this.noteBuild(actor, args.pos);
+      if (e) {
+        // mirror the server fold's partial-update semantics: a place without
+        // a usable pos KEEPS the prior position. Assigning args.pos
+        // unconditionally is how one malformed raw packet crash-looped the
+        // whole door — undefined walked into the support transform (#88).
+        if (isFiniteVec3(args.pos)) e.pos = args.pos;
+        else if (args.pos != null || args.x != null || args.y != null || args.z != null) this.noteMalformed(verb, args);
+        if (args.yaw != null) e.yaw = args.yaw;
+        if (args.scale != null) e.scale = args.scale;
+      }
+      if (live) this.noteBuild(actor, isFiniteVec3(args.pos) ? args.pos : e?.pos);
       this.trackSupport(this.syncSupport(args.id));   // support follows the thing it belongs to
     } else if (verb === "remove") {
       if (live) this.noteBuild(actor, this.entities.get(args.id)?.pos);
@@ -738,7 +757,7 @@ export class WorldAgent {
       if (e) {
         // a dismount stamps where the ride let go; the support must be built
         // from THAT, not from the transform the thing had before it mounted
-        if (Array.isArray(args.pos) && args.pos.length === 3) e.pos = args.pos;
+        if (isFiniteVec3(args.pos)) e.pos = args.pos;
         if (args.yaw != null) e.yaw = args.yaw;
         this.trackSupport(this.syncSupport(args.id));   // stand it back up
       }
@@ -1038,8 +1057,18 @@ export class WorldAgent {
     // started moving, or got mounted, while its geometry was in flight —
     // replay folds a mount right behind the spawn that triggered this fetch
     if (this.hasActiveMotion(e) || this.mounts.has(id)) { this.dropSupport(id); return; }
-    this.dropSupport(id);
     const s = e.scale ?? 1;
+    // A transform that cannot be a place in the world registers NOTHING —
+    // and abstains BEFORE the drop, leaving whatever support already stands.
+    // This is the layer that turned one malformed packet into everyone's
+    // outage: undefined rode e.pos into fitSupportBox and killed the shared
+    // door (#88). applyEntry now keeps such state out; this holds if it
+    // arrives anyway.
+    if (!isFiniteVec3(e.pos) || !Number.isFinite(s) || !Number.isFinite(e.yaw ?? 0)) {
+      this.noteMalformed("support-sync", { id, pos: e.pos, yaw: e.yaw, scale: e.scale });
+      return;
+    }
+    this.dropSupport(id);
     const xform = { position: e.pos, yaw: e.yaw ?? 0, scale: s };
     const [w, h, d] = [g.bbox.size[0] * s, g.bbox.size[1] * s, g.bbox.size[2] * s];
     const ids: string[] = [];

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -940,7 +940,7 @@ class Session {
         // malformed place in the log is permanent history every replayer
         // must survive (#88)
         const why = rawShapeError(String(a.verb), (a.args ?? {}) as Record<string, unknown>);
-        if (why) return text(`refused ${a.verb}: ${why}`);
+        if (why) return { content: [{ type: "text", text: `refused ${a.verb}: ${why}` }], isError: true };
         ag.verb(String(a.verb), a.args ?? {});
         return text(`sent ${a.verb}`);
       }

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -36,6 +36,7 @@ import {
   CHAT, EIDO, CAP, tags, capabilityMatches, MCPL_ADVERTISEMENT, FEATURE_SETS,
 } from "./declaration.ts";
 import { WorldAgent } from "./agent.ts";
+import { rawShapeError } from "./shape.ts";
 import { MANIFEST_WITH_REVISION, ManifestAnnouncer } from "./manifest.ts";
 import { verifyToken } from "../server/aid1.ts";
 import sharp from "sharp";
@@ -934,7 +935,15 @@ class Session {
         return text(`placed light [${id}] at (${x.toFixed(1)}, ${y.toFixed(1)}, ${z.toFixed(1)})`);
       }
       case "remove": ag.verb("remove", { id: a.id }); return text(`removed ${a.id}`);
-      case "world_verb": ag.verb(String(a.verb), a.args ?? {}); return text(`sent ${a.verb}`);
+      case "world_verb": {
+        // the raw door forwards verbatim, so shape is checked HERE — a
+        // malformed place in the log is permanent history every replayer
+        // must survive (#88)
+        const why = rawShapeError(String(a.verb), (a.args ?? {}) as Record<string, unknown>);
+        if (why) return text(`refused ${a.verb}: ${why}`);
+        ag.verb(String(a.verb), a.args ?? {});
+        return text(`sent ${a.verb}`);
+      }
       case "measure": {
         const base = (process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws").replace(/^ws/, "http").replace(/\/ws$/, "");
         const q = a.id

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -40,6 +40,7 @@
 
 import { plugin } from "bun";
 import { fileURLToPath } from "node:url";
+import { isFiniteVec3 } from "./shape.ts";
 
 const STUB = fileURLToPath(new URL("../tools/core-stub.mjs", import.meta.url));
 
@@ -112,6 +113,15 @@ export async function registerSupport(
   holder: string, id: string, min: number[], max: number[],
   xform: { position: number[]; yaw?: number; scale?: number },
 ) {
+  // Last line of defense (#88): this runs detached (`void registerSupport`),
+  // so a throw here is an unhandled rejection that takes the WHOLE DOOR
+  // down — every agent in the process, not the one with the bad entity.
+  // A box or transform that is not finite geometry abstains instead.
+  if (![min, max, xform?.position].every(isFiniteVec3)
+      || !Number.isFinite(xform.yaw ?? 0) || !Number.isFinite(xform.scale ?? 1)) {
+    console.error(`[physics] support ${id} abstained — non-finite geometry/transform`);
+    return;
+  }
   const m = await loadSim();
   if (!m) return;
   (holders.get(id) ?? holders.set(id, new Set()).get(id)!).add(holder);

--- a/mcpl/shape.ts
+++ b/mcpl/shape.ts
@@ -1,0 +1,39 @@
+// Raw world-log shape (#88).
+//
+// `world_verb` forwards args VERBATIM into the world log — nothing between
+// the tool call and the sequencer re-shapes them, so a convenience-shaped
+// packet becomes durable history that every replayer must survive forever.
+// The typed tools normalize ({x,y,z} -> pos:[x,y,z]); raw speaks the log's
+// own vocabulary — and the door's job is to refuse a packet that is not in
+// it, WITH THE EXPECTED SHAPE NAMED, before it becomes history. That is the
+// incident: a raw place carrying {x,y,z} was accepted, folded as a no-op,
+// and crashed every agent that later replayed it.
+//
+// Validation is deliberately minimal — the shape of what is present, not
+// policy. Rank, locks and rate stay the server's; this only answers "is
+// that even a place".
+
+export const isFiniteVec3 = (v: unknown): v is [number, number, number] =>
+  Array.isArray(v) && v.length === 3 && v.every((n) => typeof n === "number" && Number.isFinite(n));
+
+/** Why these raw args cannot enter the log as this verb — null when they can. */
+export function rawShapeError(verb: string, args: Record<string, unknown>): string | null {
+  if (verb === "place") {
+    if (typeof args.id !== "string" || !args.id)
+      return "raw place wants {id, pos:[x,y,z], yaw?, scale?} — missing id";
+    if ("x" in args || "y" in args || "z" in args)
+      return "raw place takes pos:[x,y,z] — the {x,y,z} convenience shape belongs to the typed place tool, not the log";
+    if (args.pos !== undefined && !isFiniteVec3(args.pos))
+      return `raw place pos must be a finite [x,y,z] — got ${JSON.stringify(args.pos)?.slice(0, 80)}`;
+    if (args.yaw !== undefined && !Number.isFinite(args.yaw))
+      return "raw place yaw must be a finite number";
+    if (args.scale !== undefined && !Number.isFinite(args.scale))
+      return "raw place scale must be a finite number";
+  } else if (verb === "spawn" || verb === "dismount" || verb === "light") {
+    // same trap, other doors: pos is optional on these, but a pos that IS
+    // given must be the log's shape
+    if (args.pos !== undefined && !isFiniteVec3(args.pos))
+      return `raw ${verb} pos must be a finite [x,y,z]`;
+  }
+  return null;
+}

--- a/tools/incident-88-door-test.ts
+++ b/tools/incident-88-door-test.ts
@@ -1,0 +1,107 @@
+// Does the DOOR actually refuse, at the surface a resident touches?
+//
+// The shipped incident test calls `rawShapeError` directly — a unit test of a
+// pure function. Nothing exercises `world_verb`'s wiring, and nothing checks
+// the string a resident gets back. Sill's clause is about exactly that string:
+// "the tool/result must not say merely `sent place`".
+//
+// So: boot a world + the real MCPL door, connect a raw MCP host, and read the
+// tool result for (a) the exact incident packet and (b) a well-formed place.
+// A raw world watcher confirms nothing entered history on the refusal.
+//
+//   EIDOVERSE_DIR=... WPORT=8908 MPORT=8909 bun tools/incident-88-door-test.ts
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const WPORT = Number(process.env.WPORT ?? 8908);
+const MPORT = Number(process.env.MPORT ?? 8909);
+const worldsDir = mkdtempSync(join(tmpdir(), "eido-i89door-"));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, extra = "") => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${name}${extra ? `  — ${extra}` : ""}`);
+  ok ? pass++ : fail++;
+};
+
+const world = Bun.spawn(["bun", "server/server.ts"], {
+  env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir, JOIN_TOKEN: "", VERB_RATE: "5000" },
+  stdout: "ignore", stderr: "ignore",
+});
+const mcpl = Bun.spawn(["bun", "mcpl/net-server.ts"], {
+  env: { ...process.env, MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws` },
+  stdout: "ignore", stderr: "ignore",
+});
+
+try {
+  await sleep(3000);
+
+  // raw world watcher: what actually enters history
+  const seen: any[] = [];
+  const watcher = new WebSocket(`ws://127.0.0.1:${WPORT}/ws`);
+  await new Promise<void>((res, rej) => {
+    const t = setTimeout(() => rej(new Error("watcher join timeout")), 8000);
+    watcher.onmessage = (ev) => { const m = JSON.parse(String(ev.data)); seen.push(m);
+      if (m.type === "snapshot") { clearTimeout(t); res(); } };
+    watcher.onopen = () => watcher.send(JSON.stringify({ type: "join", world: "commons", id: "i89-watcher", avatar: "a.vrm" }));
+  });
+
+  const host = new WebSocket(`ws://127.0.0.1:${MPORT}/?token=dev-token`);
+  const pending = new Map<number, (m: any) => void>();
+  let nextId = 10;
+  const call = (name: string, args: any) => new Promise<any>((res, rej) => {
+    const id = nextId++;
+    pending.set(id, res);
+    setTimeout(() => rej(new Error(`rpc ${name} timeout`)), 8000);
+    host.send(JSON.stringify({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } }));
+  });
+  await new Promise<void>((res, rej) => {
+    const t = setTimeout(() => rej(new Error("mcpl init timeout")), 8000);
+    host.onopen = () => host.send(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: { experimental: { mcpl: {} } }, clientInfo: { name: "i89", version: "0" } } }));
+    host.onmessage = (ev) => {
+      const m = JSON.parse(String(ev.data));
+      if (m.id === 1) { host.send(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })); clearTimeout(t); return res(); }
+      const w = pending.get(m.id); if (w) { pending.delete(m.id); w(m); }
+    };
+  });
+  await sleep(2000);
+
+  const textOf = (m: any) => String(m?.result?.content?.[0]?.text ?? JSON.stringify(m).slice(0, 200));
+
+  // something to place
+  const spawned = await call("world_verb", { verb: "spawn", args: { id: "tower", lib: "eidoverse/assets/models/crate_large_red.glb", pos: [3, 0, 0], yaw: 0 } });
+  console.log(`     spawn -> ${textOf(spawned)}`);
+  await sleep(800);
+
+  // ---- the exact incident packet, through the real door -------------------
+  seen.length = 0;
+  const bad = await call("world_verb", { verb: "place", args: { id: "tower", x: 15, y: 0, z: -7, yaw: 2.4, scale: 0.5 } });
+  const badText = textOf(bad);
+  await sleep(800);
+  check("the incident packet does NOT come back as `sent place`", !/^sent place/.test(badText), badText);
+  check("...it comes back as an explicit refusal", /refused/.test(badText), badText);
+  check("...and the refusal is machine-legible as an error", bad?.result?.isError === true, `isError=${bad?.result?.isError}`);
+  check("...naming the shape the log wants", badText.includes("pos:[x,y,z]"), badText);
+  const entered = seen.filter((m) => m.type === "log" && m.entry?.verb === "place");
+  check("...and nothing entered history", entered.length === 0, `entries=${entered.length}`);
+
+  // ---- the well-formed control -------------------------------------------
+  seen.length = 0;
+  const good = await call("world_verb", { verb: "place", args: { id: "tower", pos: [-4, 0, 0], yaw: 2.4, scale: 0.5 } });
+  const goodText = textOf(good);
+  await sleep(800);
+  check("a well-formed raw place still passes the door", /^sent place/.test(goodText), goodText);
+  const landed = seen.filter((m) => m.type === "log" && m.entry?.verb === "place");
+  check("...and DOES enter history", landed.length >= 1, `entries=${landed.length}`);
+
+  watcher.close(); host.close();
+} catch (e) {
+  fail++;
+  console.log(`\x1b[31mFATAL\x1b[0m ${(e as Error).message}\n${(e as Error).stack}`);
+} finally {
+  world.kill(); mcpl.kill();
+}
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/incident-88-edge-test.ts
+++ b/tools/incident-88-edge-test.ts
@@ -1,0 +1,233 @@
+// Independent review probes for PR #89 (incident #88).
+//
+// Three questions the shipped incident test does not ask:
+//
+//  A. `applyEntry(place)` validates `pos` but folds `yaw`/`scale` verbatim.
+//     `syncSupport` then abstains BEFORE its drop on a non-finite transform,
+//     so an entity that DID move (valid pos) but carries a poisoned scale
+//     keeps its old support box at the address it has left. That is a ghost
+//     floor, which is the class this PR's own neighbour (#53 B1) blocked on.
+//     The vector is not hypothetical: `scale:[0.5,0.5,0.5]` is the exact
+//     wrong guess Sill named out loud before asking for the signature.
+//
+//  B. the same place with a SCALAR scale — the control that proves A is not
+//     the probe trivially failing.
+//
+//  C. the diagnostic cap across repeated reconnect/replay: the entry is
+//     durable, so the tail replays on every reconnect. Is the bound global
+//     to the agent, or does it reset per replay (i.e. a slow flood)?
+//
+// Writes go through a RAW socket, not the MCPL door — deliberately. The door
+// refuses all of these. The threat model #88 is written against is a log that
+// already contains such an entry, plus writers that are not the MCPL door.
+//
+//   EIDOVERSE_DIR=... PORT=8904 bun tools/incident-88-edge-test.ts
+
+import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (process.env.__EIDO_TEST_CACHE_OFF !== "1") {
+  const child = Bun.spawnSync({
+    cmd: [process.execPath, import.meta.path, ...process.argv.slice(2)],
+    env: { ...process.env, BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0", __EIDO_TEST_CACHE_OFF: "1" },
+    stdout: "inherit", stderr: "inherit",
+  });
+  process.exit(child.exitCode ?? 1);
+}
+
+// Count the agent's own diagnostics before anything else can emit them.
+let malformedLines = 0, physicsAbstains = 0;
+const realError = console.error.bind(console);
+console.error = (...a: any[]) => {
+  const s = a.map(String).join(" ");
+  if (s.includes("] malformed ")) malformedLines++;
+  if (s.includes("[physics] support") && s.includes("abstained")) physicsAbstains++;
+  realError(...a);
+};
+
+const { WorldAgent } = await import("../mcpl/agent.ts");
+const { setHeightField } = await import("../mcpl/physics.ts");
+
+let rejections = 0;
+process.on("unhandledRejection", (e) => { rejections++; realError("  [unhandledRejection]", e); });
+
+const PORT = Number(process.env.PORT ?? 8904);
+const URL_ = process.env.URL ?? `ws://127.0.0.1:${PORT}/ws`;
+const worldsDir = mkdtempSync(join(tmpdir(), "ew-i89-"));
+const LIB = "eidoverse/assets/models/crate_large_red.glb";
+const DECK_Y = 2.003;
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let server: ReturnType<typeof spawn> | null = null;
+async function startServer() {
+  if (process.env.URL) return;
+  server = spawn("bun", [join(import.meta.dir, "..", "server", "server.ts")], {
+    env: { ...process.env, PORT: String(PORT), WORLDS_DIR: worldsDir, JOIN_TOKEN: "",
+           VERB_RATE: "5000", MSG_RATE: "5000" },
+    stdio: "ignore",
+  });
+  for (let i = 0; i < 80; i++) {
+    try { if ((await fetch(`http://127.0.0.1:${PORT}/avatars`)).ok) return; } catch { /* not up */ }
+    await sleep(100);
+  }
+  throw new Error("server did not start");
+}
+
+function hand(world: string, name: string) {
+  return new Promise<any>((res) => {
+    const ws = new WebSocket(`${URL_}?name=${name}`);
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", world, id: name, token: "" }));
+    ws.onmessage = (e) => {
+      const m = JSON.parse(String(e.data));
+      if (m.type === "snapshot") res({
+        verb: (v: string, a: any) => ws.send(JSON.stringify({ type: "verb", verb: v, args: a })),
+        send: (o: any) => ws.send(JSON.stringify(o)),
+        close: () => ws.close(),
+      });
+    };
+  });
+}
+
+let hipsOffset = 0.68;
+const restsOn = (rootY: number, surfaceY: number) => Math.abs(rootY - (surfaceY - hipsOffset)) < 0.35;
+
+async function dropOver(h: any, ag: any, name: string, at: number[], overY: number) {
+  h.send({ type: "puppet", target: name, ragdoll: { lean: [1, 0, 0] } });
+  await sleep(2200);
+  h.send({ type: "bodydrag", target: name, grab: { joint: "hips" } });
+  await sleep(250);
+  h.send({ type: "bodydrag", target: name, pose: { hips: [0, 0, 0, 1] }, p: [at[0], overY + 0.4, at[1]], yaw: 0 });
+  await sleep(250);
+  h.send({ type: "bodydrag", target: name, end: true, pose: { hips: [0, 0, 0, 1] }, p: [at[0], overY + 1.2, at[1]], yaw: 0 });
+  await sleep(9000);
+  return ag.pos.y as number;
+}
+
+/** Where does the sim think this support box is, right now? */
+async function boxAt(id: string): Promise<number[] | null> {
+  await setHeightField(null);                       // warms the ./core.js stub plugin (#53 review note)
+  const { colliders } = await import("../client/lib/colliders.js");
+  const e = (colliders as Map<string, any>).get(id);
+  if (!e) return null;
+  const p = e.obj.position;
+  return [p.x, p.y, p.z];
+}
+
+try {
+  console.log(`\nPR #89 review probes: ${URL_}\n`);
+  await startServer();
+  {
+    const HTTP = URL_.replace(/^ws/, "http").replace(/\/ws$/, "");
+    const g = await (await fetch(`${HTTP}/geom?lib=${encodeURIComponent(LIB)}`)).json() as any;
+    if (!(g?.geometry ?? g)?.bbox) throw new Error(`library not served — set EIDOVERSE_DIR`);
+  }
+
+  // ---- A. poisoned scale on a place that DOES move ------------------------
+  console.log("A. a place with a valid pos and a VECTOR scale (Sill's stated wrong guess)");
+  {
+    const W = `i89-ghost-${Date.now().toString(36)}`;
+    const h = await hand(W, "stagehand");
+    h.verb("spawn", { id: "deck", lib: LIB, pos: [3, 0, 0], yaw: 0 });
+    await sleep(600);
+    const ag = new WorldAgent({ url: URL_, name: "i89-a", world: W });
+    await ag.connect();
+    await sleep(1500);
+
+    h.send({ type: "puppet", target: "i89-a", ragdoll: { lean: [1, 0, 0] } });
+    await sleep(3000);
+    hipsOffset = -ag.pos.y;
+    console.log(`     hips offset ${hipsOffset.toFixed(2)}m`);
+
+    const before = await boxAt(`${W}/deck`);
+    check("the crate's support box starts at its spawn spot", !!before && Math.abs(before![0] - 3) < 1e-6,
+      `box=${JSON.stringify(before)}`);
+
+    // valid pos — the crate really moves — with the scale shape Sill said he
+    // would have guessed. Raw socket: the MCPL door refuses this one.
+    h.verb("place", { id: "deck", pos: [-4, 0, 0], yaw: 0, scale: [0.5, 0.5, 0.5] });
+    await sleep(1800);
+
+    const e = ag.entities.get("deck");
+    check("the agent folds the move — the crate is at the new address",
+      !!e && Math.abs((e.pos as number[])[0] - -4) < 1e-6, `pos=${JSON.stringify(e?.pos)}`);
+    check("...and folds the poisoned scale verbatim, unvalidated",
+      Array.isArray(e?.scale), `scale=${JSON.stringify(e?.scale)}`);
+    check("no unhandled rejection — the door stays up", rejections === 0, `rejections=${rejections}`);
+
+    const after = await boxAt(`${W}/deck`);
+    check("THE QUESTION: the support box is not left at the address the crate left",
+      after == null || Math.abs(after[0] - -4) < 1e-6,
+      `box=${JSON.stringify(after)} entity=${JSON.stringify(e?.pos)}`);
+
+    // and behaviorally, at the abandoned address
+    await ag.walkTo(3, 0, false, 8000);
+    const y = await dropOver(h, ag, "i89-a", [3, 0], DECK_Y);
+    check("a body released where the crate USED to be falls to the terrain",
+      restsOn(y, 0), `root=${y.toFixed(2)} deck=${(DECK_Y - hipsOffset).toFixed(2)} terrain=${(-hipsOffset).toFixed(2)}`);
+    h.close(); ag.close?.();
+  }
+
+  // ---- B. control: the same move with a SCALAR scale ----------------------
+  console.log("\nB. control — the identical move with scale as a scalar");
+  {
+    const W = `i89-ctl-${Date.now().toString(36)}`;
+    const h = await hand(W, "stagehand");
+    h.verb("spawn", { id: "deck", lib: LIB, pos: [3, 0, 0], yaw: 0 });
+    await sleep(600);
+    const ag = new WorldAgent({ url: URL_, name: "i89-b", world: W });
+    await ag.connect();
+    await sleep(1500);
+    h.verb("place", { id: "deck", pos: [-4, 0, 0], yaw: 0, scale: 0.5 });
+    await sleep(1800);
+    const after = await boxAt(`${W}/deck`);
+    check("a well-formed scale moves the support box with the crate",
+      !!after && Math.abs(after[0] - -4) < 1e-6, `box=${JSON.stringify(after)}`);
+    h.close(); ag.close?.();
+  }
+
+  // ---- C. the diagnostic cap across repeated reconnect --------------------
+  console.log("\nC. the durable entry replays on every reconnect — is the bound global?");
+  {
+    const W = `i89-cap-${Date.now().toString(36)}`;
+    const h = await hand(W, "stagehand");
+    h.verb("spawn", { id: "deck", lib: LIB, pos: [3, 0, 0], yaw: 0 });
+    await sleep(400);
+    // the exact incident packet, straight into history
+    h.verb("place", { id: "deck", x: 15, y: 0, z: -7, yaw: 2.4, scale: 0.5 });
+    await sleep(600);
+
+    const beforeCount = malformedLines;
+    const ag = new WorldAgent({ url: URL_, name: "i89-c", world: W });
+    await ag.connect();
+    await sleep(1200);
+    const afterJoin = malformedLines - beforeCount;
+
+    // force 8 non-deliberate socket closes; each auto-reconnect replays the tail
+    const RECONNECTS = 8;
+    for (let i = 0; i < RECONNECTS; i++) {
+      (ag as any).ws?.close();
+      await sleep(2200);                              // 1.5s backoff + join + replay
+    }
+    const total = malformedLines - beforeCount;
+    check(`the join itself names the malformed entry`, afterJoin >= 1, `lines=${afterJoin}`);
+    check(`${RECONNECTS} reconnects later the bound has held (<= 5 total for this agent)`,
+      total <= 5, `total=${total} after ${RECONNECTS} replays`);
+    check("the body is still connected and alive after the reconnect storm",
+      rejections === 0 && (ag as any).joined === true, `rejections=${rejections} joined=${(ag as any).joined}`);
+    console.log(`     [physics] abstain lines during the whole run: ${physicsAbstains}`);
+    h.close(); ag.close?.();
+  }
+} finally {
+  server?.kill();
+}
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/incident-88-test.ts
+++ b/tools/incident-88-test.ts
@@ -1,0 +1,258 @@
+// Incident #88: one malformed raw `place` took the whole MCPL door down.
+//
+//   bun tools/incident-88-test.ts              # spawns its own scratch server
+//   URL=ws://host:8940/ws bun tools/...        # or against a running one
+//
+// The packet was raw `world_verb place` carrying the typed tool's convenience
+// shape — {id, x, y, z, yaw, scale} — where the log wants pos:[x,y,z]. The
+// server fold ignored the missing pos (partial update), so the world was
+// fine; PR #53's replay assigned `e.pos = args.pos` unconditionally, and the
+// undefined rode the support transform into `fitSupportBox(position[0])` as
+// an unhandled rejection in a detached async call. Every agent that lived in
+// the process died with it, and every reconnect replaying the tail died
+// again.
+//
+// Three layers, each tested against the exact incident packet:
+//   1. the door (mcpl/shape.ts, wired into world_verb) refuses it with the
+//      expected shape named, BEFORE it becomes history;
+//   2. the agent fold (applyEntry) mirrors the server's partial-update
+//      semantics if such an entry reaches history anyway — position kept,
+//      yaw/scale folded, live AND replay;
+//   3. support registration abstains on non-finite geometry instead of
+//      killing the shared door.
+// Plus the control the incident spec demands: a well-formed raw
+// place{pos:[...]} still moves the thing and re-syncs its support.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Same cache guard as the rest of the suite (#13): tests need deterministic
+// resolver behavior, and this file reaches the plugin indirectly through
+// WorldAgent -> physics.ts.
+if (process.env.__EIDO_TEST_CACHE_OFF !== '1') {
+  const child = Bun.spawnSync({
+    cmd: [process.execPath, import.meta.path, ...process.argv.slice(2)],
+    env: {
+      ...process.env,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: '0',
+      __EIDO_TEST_CACHE_OFF: '1',
+    },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.exit(child.exitCode ?? 1);
+}
+
+const { WorldAgent } = await import("../mcpl/agent.ts");
+const { rawShapeError } = await import("../mcpl/shape.ts");
+
+// The crash was an unhandled rejection in `void registerSupport(...)` — on
+// broken code it kills the process and this test with it. Counting instead
+// of dying turns "the door fell over" into an assertion.
+let rejections = 0;
+process.on("unhandledRejection", (e) => { rejections++; console.error("  [unhandledRejection]", e); });
+
+const EXTERNAL = process.env.URL;
+const PORT = Number(process.env.PORT ?? 8996);
+const URL_ = EXTERNAL ?? `ws://127.0.0.1:${PORT}/ws`;
+const TOKEN = process.env.TOKEN ?? "";
+const worldsDir = mkdtempSync(join(tmpdir(), "ew-i88-"));
+
+const LIB = "eidoverse/assets/models/crate_large_red.glb";
+const DECK_Y = 2.003;                                   // deck top, local y, scale 1
+
+// The EXACT packet from the incident log (world eanpa, 2026-08-09 ~15:06Z),
+// id renamed to this world's entity.
+const INCIDENT_ARGS = { id: "deck", x: 15, y: 0, z: -7, yaw: 2.4, scale: 0.5 };
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---- server ----------------------------------------------------------------
+
+let server: ReturnType<typeof spawn> | null = null;
+async function startServer() {
+  if (EXTERNAL) return;
+  server = spawn("bun", [join(import.meta.dir, "..", "server", "server.ts")], {
+    env: { ...process.env, PORT: String(PORT), WORLDS_DIR: worldsDir, JOIN_TOKEN: "",
+           VERB_RATE: "5000", MSG_RATE: "5000" },
+    stdio: "ignore",
+  });
+  for (let i = 0; i < 80; i++) {
+    try { if ((await fetch(`http://127.0.0.1:${PORT}/avatars`)).ok) return; } catch { /* not up */ }
+    await sleep(100);
+  }
+  throw new Error("server did not start");
+}
+
+/** A bare socket: authors the scene and plays the dragger's hand. */
+function hand(world: string, name: string) {
+  return new Promise<any>((res) => {
+    const ws = new WebSocket(`${URL_}?name=${name}`);
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", world, id: name, token: TOKEN }));
+    ws.onmessage = (e) => {
+      const m = JSON.parse(String(e.data));
+      if (m.type === "snapshot") res({
+        verb: (v: string, a: any) => ws.send(JSON.stringify({ type: "verb", verb: v, args: a })),
+        send: (o: any) => ws.send(JSON.stringify(o)),
+        close: () => ws.close(),
+      });
+    };
+  });
+}
+
+/** Knock a body down, drag it over `at`, release; where did its root settle? */
+async function dropOver(h: any, ag: any, name: string, at: number[], overY: number) {
+  h.send({ type: "puppet", target: name, ragdoll: { lean: [1, 0, 0] } });
+  await sleep(2200);
+  h.send({ type: "bodydrag", target: name, grab: { joint: "hips" } });
+  await sleep(250);
+  h.send({ type: "bodydrag", target: name, pose: { hips: [0, 0, 0, 1] },
+           p: [at[0], overY + 0.4, at[1]], yaw: 0 });
+  await sleep(250);
+  h.send({ type: "bodydrag", target: name, end: true, pose: { hips: [0, 0, 0, 1] },
+           p: [at[0], overY + 1.2, at[1]], yaw: 0 });
+  await sleep(9000);
+  return ag.pos.y as number;
+}
+
+let hipsOffset = 0.68;
+const restsOn = (rootY: number, surfaceY: number) => Math.abs(rootY - (surfaceY - hipsOffset)) < 0.35;
+
+const near3 = (a: number[] | undefined, b: number[]) =>
+  !!a && a.length === 3 && a.every((v, i) => Math.abs(v - b[i]) < 1e-6);
+
+// ---- the run ---------------------------------------------------------------
+
+try {
+  console.log(`\nincident #88 — malformed raw place vs the door: ${URL_}\n`);
+
+  // ---- 1. THE DOOR: world_verb now refuses the exact incident packet ------
+  // rawShapeError is the function the world_verb case calls verbatim; these
+  // are the door's semantics, tested at the seam the door imports.
+  {
+    const why = rawShapeError("place", { ...INCIDENT_ARGS });
+    check("the exact incident packet is refused", why != null, "accepted");
+    check("...and the refusal names the log's shape", !!why && why.includes("pos:[x,y,z]"), why ?? "");
+    check("a well-formed raw place passes", rawShapeError("place", { id: "t", pos: [15, 0, -7], yaw: 2.4, scale: 0.5 }) == null,
+      rawShapeError("place", { id: "t", pos: [15, 0, -7], yaw: 2.4, scale: 0.5 }) ?? "");
+    check("a partial raw place (yaw/scale only) passes — the fold is partial-update",
+      rawShapeError("place", { id: "t", scale: 0.5 }) == null);
+    check("non-finite pos is refused", rawShapeError("place", { id: "t", pos: [NaN, 0, 0] }) != null);
+    check("a 2-vector pos is refused", rawShapeError("place", { id: "t", pos: [1, 2] }) != null);
+    check("a missing id is refused", rawShapeError("place", { pos: [1, 2, 3] }) != null);
+    check("spawn with a malformed pos is refused", rawShapeError("spawn", { id: "t", lib: "x.glb", pos: { x: 1 } }) != null);
+    check("verbs without a pos contract are untouched", rawShapeError("mount", { id: "t", to: "u" }) == null);
+  }
+
+  await startServer();
+
+  // From a detached worktree, server.ts's EIDOVERSE_DIR default points at a
+  // directory that does not exist and /geom answers "no such asset" — which
+  // silently turns every support assertion below into a no-op (#53 review).
+  // Refuse to run rather than pass against empty air.
+  {
+    const HTTP = URL_.replace(/^ws/, "http").replace(/\/ws$/, "");
+    const g = await (await fetch(`${HTTP}/geom?lib=${encodeURIComponent(LIB)}`)).json() as any;
+    if (!(g?.geometry ?? g)?.bbox) throw new Error(`library not served (${JSON.stringify(g).slice(0, 120)}) — set EIDOVERSE_DIR`);
+  }
+
+  // ---- 2. THE POISONED LOG: the incident sequence past the door -----------
+  // A raw socket writes the packet straight into history — the position the
+  // fleet is actually in: the malformed entry from 08-09 is durable in
+  // eanpa's log, and pre-#88 stacks and browser writers exist. The agent
+  // must survive it LIVE, a fresh join must survive REPLAYING it, and both
+  // must fold it the way the server does: position kept, yaw/scale applied.
+  {
+    const W = `i88-poison-${Date.now().toString(36)}`;
+    const h = await hand(W, "stagehand");
+    h.verb("spawn", { id: "deck", lib: LIB, pos: [3, 0, 0], yaw: 0 });
+    await sleep(600);
+
+    const ag = new WorldAgent({ url: URL_, name: "i88-bot", world: W });
+    await ag.connect();
+    await sleep(1200);
+
+    // calibrate the rig's hips offset on flat ground in THIS world
+    h.send({ type: "puppet", target: "i88-bot", ragdoll: { lean: [1, 0, 0] } });
+    await sleep(3000);
+    hipsOffset = -ag.pos.y;
+    check("a body knocked down on flat terrain reports a stable hips offset",
+      hipsOffset > 0.3 && hipsOffset < 1.2, `offset=${hipsOffset.toFixed(2)}m`);
+
+    // the incident preamble: a body mounts the structure and dismounts again
+    h.verb("mount", { id: "stagehand", to: "deck", slot: "deck" });
+    await sleep(400);
+    h.verb("dismount", { id: "stagehand" });
+    await sleep(400);
+
+    // ...and the malformed write, exactly as logged
+    h.verb("place", INCIDENT_ARGS);
+    await sleep(1500);
+
+    check("LIVE: the agent is still alive after receiving the entry", rejections === 0 && ag.pos != null,
+      `rejections=${rejections}`);
+    const live = ag.entities.get("deck");
+    check("LIVE: position kept — the malformed pos never lands", near3(live?.pos, [3, 0, 0]),
+      `pos=${JSON.stringify(live?.pos)}`);
+    check("LIVE: yaw and scale fold as partial updates, like the server",
+      live?.yaw === 2.4 && live?.scale === 0.5, `yaw=${live?.yaw} scale=${live?.scale}`);
+
+    // THE crash loop: a fresh agent replays the tail containing the entry
+    const rep = new WorldAgent({ url: URL_, name: "i88-rep", world: W });
+    await rep.connect();
+    await sleep(1500);
+    const fold = rep.entities.get("deck");
+    check("REPLAY: a fresh agent joins over the poisoned tail and lives",
+      rejections === 0 && fold != null, `rejections=${rejections}`);
+    check("REPLAY: its fold matches the server's", near3(fold?.pos, [3, 0, 0]) && fold?.scale === 0.5,
+      `pos=${JSON.stringify(fold?.pos)} scale=${fold?.scale}`);
+
+    // support survived, and it is the FOLDED thing's support: the crate is
+    // half-scale at its old spot, so a released body rests at half deck
+    // height there — not on the phantom full-height deck, not on terrain.
+    await ag.walkTo(3, 0, false, 8000);
+    const y = await dropOver(h, ag, "i88-bot", [3, 0], DECK_Y * 0.5);
+    check("SUPPORT: a body released over the old spot rests on the half-scale deck",
+      restsOn(y, DECK_Y * 0.5), `root=${y.toFixed(2)} half-deck=${(DECK_Y * 0.5 - hipsOffset).toFixed(2)} terrain=${(-hipsOffset).toFixed(2)}`);
+
+    check("...and the whole scene drew no unhandled rejections", rejections === 0, `rejections=${rejections}`);
+    h.close(); ag.close?.(); rep.close?.();
+  }
+
+  // ---- 3. THE CONTROL: a well-formed raw place still does its job ---------
+  {
+    const W = `i88-valid-${Date.now().toString(36)}`;
+    const h = await hand(W, "stagehand");
+    h.verb("spawn", { id: "deck", lib: LIB, pos: [3, 0, 0], yaw: 0 });
+    await sleep(600);
+    const ag = new WorldAgent({ url: URL_, name: "i88-ctl", world: W });
+    await ag.connect();
+    await sleep(1200);
+
+    h.verb("place", { id: "deck", pos: [-4, 0, 0], yaw: 0 });
+    await sleep(1200);
+    check("a valid raw place{pos} moves the entity", near3(ag.entities.get("deck")?.pos, [-4, 0, 0]),
+      `pos=${JSON.stringify(ag.entities.get("deck")?.pos)}`);
+
+    await ag.walkTo(3, 0, false, 8000);
+    const gone = await dropOver(h, ag, "i88-ctl", [3, 0], DECK_Y);
+    check("support LEAVES the old spot", restsOn(gone, 0), `root=${gone.toFixed(2)}`);
+
+    await ag.walkTo(-4, 0, false, 10_000);
+    const there = await dropOver(h, ag, "i88-ctl", [-4, 0], DECK_Y);
+    check("...and ARRIVES at the new one", restsOn(there, DECK_Y), `root=${there.toFixed(2)}`);
+    h.close(); ag.close?.();
+  }
+} finally {
+  server?.kill();
+}
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Fixes #88 — the 08-09 15:08Z MCPL door crash-loop.

## What happened
A raw `world_verb place` carrying the typed tool's convenience shape — `{id, x, y, z, yaw, scale}` where the log wants `pos:[x,y,z]` — was accepted verbatim, folded by the server as a partial-update no-op, and then crashed every `WorldAgent` that received or replayed it: `applyEntry(place)` assigned `e.pos = args.pos` unconditionally, and the `undefined` rode the support transform into `fitSupportBox(position[0])` as an unhandled rejection inside a detached `void registerSupport(...)` call — killing the whole process, not the one agent. Every reconnect replayed the tail entry and died again.

## The layered repair (issue items 1–5)
1. **The door** (`mcpl/shape.ts`, wired into `net-server.ts`'s `world_verb`): raw `place` shape is validated before sequencer transmission — `{x,y,z}` is refused **with the log's shape named**; non-finite/short `pos`, non-finite `yaw`/`scale`, missing `id` likewise. `spawn`/`dismount`/`light` get the same finite-`pos` check when a pos is given. Validation is shape-only; rank/locks/rate stay the server's.
2. **The agent fold** (`agent.ts`): `applyEntry(place)` mirrors the server fold's partial-update semantics — position kept unless `args.pos` is a finite 3-vector, `yaw`/`scale` still folded, bounded diagnostic (5 then quiet, so a poisoned tail can't flood on every reconnect). `dismount`'s pos guard tightened from `Array.isArray && length===3` to finiteness.
3. **Support abstention**: `syncSupport` abstains **before its drop** on a non-finite transform (existing support stands); `registerSupport` abstains on non-finite geometry instead of throwing in a detached call. Malformed state from any already-poisoned or foreign-written log degrades one entity's support instead of the shared door.
4+5. **Regression** (`tools/incident-88-test.ts`): the exact incident packet at all three layers — door refusal (shape named, position untouched), live receipt, and a fresh agent replaying the poisoned tail — plus support-consistency drops and the valid raw `place{pos:[...]}` control (moves + re-syncs support). Includes an `unhandledRejection` counter so the pre-fix failure mode reads as a failing assertion instead of a dead test process, and a loud precondition when `/geom` serves nothing (the detached-worktree `EIDOVERSE_DIR` trap from the #53 reviews).

## Receipts (this Mac, macOS arm64, Bun 1.3.14, scratch sequencers on lsof-verified-free ports)
- `incident-88-test`: **20/20** on this branch · **14/20 on pristine main** with 4 unhandled rejections carrying the incident's exact stack (`fitSupportBox` ← `registerSupport`) — the test discriminates.
- Regressions, this branch: support **12/12** · support-lifecycle **22/22** · collider **34/34** · knockdown **15/15** · avatar **18/18** · parts **11/11** · ragdoll **59/59** · smoke **85/85**.
- Port hygiene: the 89xx squatters from both #53 reviews are still there (8951/8971/8987/8989/8991/8995/8998 — 8998's `bun server.ts` has been up since Aug 2). First `support-test` run polled a squatted port and got a tainted pass; re-ran on verified-free 8925.

## Notes for review
- Agent fold is deliberately **stricter than the server fold** on malformed pos: the server's `if (a.pos)` would assign any truthy value (e.g. a 2-vector), the agent keeps prior position. Divergence only exists for packets the door now refuses; aligning the server fold is a possible follow-up.
- Server-side shape-check ("before it becomes history", like `grant`'s) would harden against non-MCPL writers too — left as a follow-up since the issue scopes validation to the raw `world_verb` door.
- The eanpa world's log still contains the 08-09 malformed entry; layer 2/3 is what makes that durable history safe to replay.
- Rollback/Bun-transpiler-cache containment from the incident is independent of this PR and not addressed here.

No deploy from this branch; production remains rolled back at `5493f43` until this is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)