### PR TITLE
mic: a noise gate as a smoothed gain, and going quiet stops being a teardown

### DIFF
--- a/client/lib/audioctx.js
+++ b/client/lib/audioctx.js
@@ -28,6 +28,11 @@ export function audioContext() {
   return ctx;
 }
 
+/** TEST-ONLY: drop the cached context so a suite can swap the constructor
+ *  (deterministic graph-construction failure needs a FRESH broken context —
+ *  the cache would happily keep serving the working one). */
+export function __resetForTest() { ctx = null; }
+
 /** Has one been made yet? (Probes: do not CREATE one just to look at it.) */
 export const audioContextState = () => ctx?.state ?? 'none';
 

--- a/client/lib/audiopanel.js
+++ b/client/lib/audiopanel.js
@@ -17,6 +17,7 @@ import { audioPrefs, setVolume, receivingVoice, setReceiveVoice,
   sttConsented, setSttConsent, isHushed, setHush,
   micFloor, setMicFloor } from './voiceconsent.js';
 import { micAnalyserLevel } from './voice.js';
+import { gateUnavailable, ungatedConsent, allowUngated } from './micgate.js';
 import { bus } from './core.js';
 
 // The panel's row layout, carried BY THE MODULE. Found live 2026-08-06 (R,
@@ -137,6 +138,18 @@ function paint(body) {
       cat === 'world' ? p.volWorld : cat === 'tts' ? p.volTts : p.volVoices));
   }
   body_.append(micFloorRow());
+  // B2 (#90): the gate-unavailable escape hatch. Hidden while the gate works;
+  // when the graph cannot be built the mic REFUSES to transmit and this row
+  // appears — the explicit, user-visible choice to go raw. Never silent.
+  {
+    const row = checkRow('transmit UNGATED (voice gate unavailable)',
+      'the noise gate could not be built on this device — checking this transmits your raw microphone, room noise and all',
+      ungatedConsent(), (on) => allowUngated(on));
+    row.style.display = gateUnavailable() ? '' : 'none';
+    row.style.color = '#fa5';
+    bus.on('voice-gate-unavailable', () => { row.style.display = ''; });
+    body_.append(row);
+  }
   body_.append(checkRow('speech-to-text',
     'sends your mic audio to your browser vendor’s cloud to transcribe',
     sttConsented(), (on) => setSttConsent(on)));

--- a/client/lib/micgate.js
+++ b/client/lib/micgate.js
@@ -58,7 +58,7 @@ import { report } from './core.js';
 const ATTACK_TAU = 0.008;
 const RELEASE_TAU = 0.12;
 
-let _ctx = null, _src = null, _gain = null, _dest = null, _timer = null;
+let _ctx = null, _src = null, _gain = null, _dest = null;
 let _rawStream = null, _gatedStream = null, _level = () => 0;
 
 /** Wrap a mic stream in the gate graph. Returns the stream to hand to WebRTC —
@@ -77,6 +77,11 @@ export function gateStream(stream, levelFn) {
     // is doing at the instant the mic opens — the exact leak the settle window
     // exists to prevent, and the one R heard as "picking up background noise".
     _gain.gain.value = 0;
+  // A fresh lane IS closed — say so. `_wanted` outlives the graph it described;
+  // without this reset gateOpenness() reports the pre-release value (1 if the
+  // gate was open when the device was released), so micTransmitting() claims
+  // "audible now" before a single driveGate tick has run on the new lane.
+  _wanted = 0;
     _dest = _ctx.createMediaStreamDestination();
     _src.connect(_gain);
     _gain.connect(_dest);
@@ -236,7 +241,6 @@ export function attachSource(stream) {
  *  consent, never for going quiet: this is the path that costs a renegotiation
  *  to undo. */
 export function release() {
-  if (_timer) { clearInterval(_timer); _timer = null; }
   try { _src?.disconnect(); } catch { /* already gone */ }
   try { _gain?.disconnect(); } catch { /* already gone */ }
   // Deliberately does NOT stop the destination's tracks: they belong to the

--- a/client/lib/micgate.js
+++ b/client/lib/micgate.js
@@ -1,0 +1,264 @@
+// micgate — the noise gate as a GAIN, not a switch.
+//
+// R, 2026-08-09: "why not do the WebAudio graph now? I'm worried we'll forget
+// about it if we wait." Right on both counts — and "later" is how a boolean gate
+// becomes permanent.
+//
+// WHY A GRAPH AT ALL. Gating with `track.enabled` is binary and abrupt: the
+// track goes from full to digital silence between one 40ms tick and the next.
+// That is an audible click at both ends, and the opening click lands on your
+// first consonant — the worst possible place. BasisVR gates with a smoothed
+// gain (BasisLocalMicrophoneDriver: `_noiseGateGain` lerped toward 0/1 with
+// attack/release coefficients), which is the right shape and needs per-sample
+// access we did not have while handing the raw device track to WebRTC.
+//
+// The graph:
+//
+//     voiceSource()  →  MediaStreamSource  →  GainNode  →  MediaStreamDestination
+//                                               ↑                     ↓
+//                                        gate (this file)    the track WebRTC sends
+//
+// The analyser still reads the SOURCE side, not the gated side — measuring after
+// the gate would be a feedback loop: gain drops, measured level drops, gate
+// closes harder, and it latches shut. The gate must always judge the true input.
+//
+// 🔴 This wraps humans AND agents alike, because voiceSource() is the one seam
+// both come through (a human gets a microphone, an agent gets its synthesizer).
+// An agent's speech is loud and continuous, so it sails through the gate — but
+// it means an agent whose synth emits room tone between utterances is quiet for
+// the same reason a human is, with no second code path to maintain.
+
+import { audioContext } from './audioctx.js';
+import { report } from './core.js';
+
+// 🔴 THESE ARE PER-CALL RATES, AND OUR CALL CADENCE IS NOT THEIRS. BasisVR's
+// 0.10/0.05 are per 20ms audio frame; driveGate() runs on the 40ms onset tick,
+// and a naive copy took 300ms to reach 90% gain — an audible fade-in on the
+// first word, which is worse than the click it replaces. Measured, not assumed
+// (a syllable is ~80-150ms, so the attack must finish well inside one).
+//
+// Measured at the 40ms cadence: attack 0.35 → ~90% open in 160ms (inside a
+// syllable); release 0.18 → down to 10% in ~440ms, a soft tail rather than the
+// 1.5s smear 0.06 produced. Attack faster than release, always: opening late
+// loses a consonant, closing early cuts a word in half. And the 700ms hang-time
+// runs BEFORE this fade even begins, so a pause mid-sentence never reaches it.
+// TIME CONSTANTS, in seconds — setTargetAtTime reaches ~63% of the target in one
+// tau and ~95% in three. Attack 0.02s → audibly open in ~60ms, inside a syllable
+// (~80-150ms), so the first consonant survives. Release 0.12s → a soft ~360ms
+// tail, and the 700ms hang-time runs BEFORE the fade even starts, so a pause
+// mid-sentence never reaches it. Attack always faster than release: opening late
+// loses a consonant, closing early cuts a word in half.
+// 🔴 R: "lower the gate time to start capturing? The first syllable sounds a
+// little chopped off." Two things were eating the attack and only one was this
+// constant: the 40ms TICK is a floor on how fast the gate can react at all, so
+// the true worst case was tick + envelope. Tick is 20ms now (below the ~30ms
+// where a missing onset becomes audible) and tau is 0.008s — ~95% open in 24ms,
+// so worst case ~44ms instead of ~160ms. A plosive is ~20-40ms, so this is the
+// difference between "puh" and "uh".
+const ATTACK_TAU = 0.008;
+const RELEASE_TAU = 0.12;
+
+let _ctx = null, _src = null, _gain = null, _dest = null, _timer = null;
+let _rawStream = null, _gatedStream = null, _level = () => 0;
+
+/** Wrap a mic stream in the gate graph. Returns the stream to hand to WebRTC —
+ *  or the original stream unchanged if the graph cannot be built, because a
+ *  voice that works ungated beats no voice at all. */
+export function gateStream(stream, levelFn) {
+  release();
+  _rawStream = stream;
+  _level = levelFn || (() => 0);
+  try {
+    _ctx = audioContext();
+    if (!_ctx || typeof _ctx.createMediaStreamDestination !== 'function') return stream;
+    _src = _ctx.createMediaStreamSource(stream);
+    _gain = _ctx.createGain();
+    // Start CLOSED. Opening on the first frame would broadcast whatever the room
+    // is doing at the instant the mic opens — the exact leak the settle window
+    // exists to prevent, and the one R heard as "picking up background noise".
+    _gain.gain.value = 0;
+    _dest = _ctx.createMediaStreamDestination();
+    _src.connect(_gain);
+    _gain.connect(_dest);
+    _gatedStream = _dest.stream;
+
+    // Carry the original track's identity forward where it matters: muting still
+    // operates on the RAW track (see voice.js), so both streams stay live and the
+    // gate only decides how much of the raw signal reaches the destination.
+    return _gatedStream;
+  } catch (e) {
+    report('mic gate graph', e);
+    release();
+    return stream;                       // ungated beats silent
+  }
+}
+
+/** Drive the gain from the gate decision. `open` is the gate's boolean; the
+ *  smoothing lives here so the decision logic stays readable. */
+export function driveGate(open) {
+  if (!_gain || !_ctx) return;
+  // 🔴 DO NOT DOUBLE-SMOOTH. This used to compute a lerped step and then hand it
+  // to setTargetAtTime — which is ITSELF an exponential approach, so the gain
+  // never actually reached the step, and reading .value back on the next tick
+  // fed that lag forward. The result was a gate that never fully closed: R heard
+  // her own monitor ignoring the sensitivity setting entirely (2026-08-09).
+  //
+  // setTargetAtTime already IS the envelope. Target the true endpoint (1 or 0)
+  // and let the time constant do the shaping — one smoothing stage, not two.
+  const target = open ? 1 : 0;
+  const tau = open ? ATTACK_TAU : RELEASE_TAU;
+  try {
+    _gain.gain.setTargetAtTime(target, _ctx.currentTime, tau);
+  } catch { _gain.gain.value = target; }
+  _wanted = target;
+}
+
+
+// ── MONITOR: hear your own lane, exactly as the room hears it ───────────────
+// R, 2026-08-09: "can you feed my own audio lane back to me for this test so I
+// can hear myself?" — the only way to judge whether the gate clips a consonant
+// or trails too long is to hear the GATED signal, not the raw mic.
+//
+// 🔴 Tapped AFTER the gain node, so it carries the gate: when the gate closes,
+// the monitor goes quiet too. A monitor on the raw source would sound perfect
+// while the room heard nothing, which is precisely the confusion this is meant
+// to resolve.
+//
+// 🔴 FEEDBACK: on speakers this WILL howl — mic hears monitor hears mic. Ship it
+// at a low default, and say so in the UI rather than discovering it at volume.
+let _mon = null, _delay = null, _wanted = 0;
+// Long enough to be heard as a separate event rather than as an echo of your
+// own voice. Tunable live via setMonitorDelay() while testing.
+let MONITOR_DELAY = 0.4;
+export function setMonitor(on, level = 0.35) {
+  if (!_ctx || !_gain) return false;
+  if (!on) {
+    if (_mon) {
+      try { _mon.disconnect(); } catch { /* gone */ }
+      try { _delay?.disconnect(); } catch { /* gone */ }
+      _mon = null; _delay = null;
+    }
+    return false;
+  }
+  if (!_mon) {
+    _mon = _ctx.createGain();
+    // A DELIBERATE DELAY. R, 2026-08-09: "can you delay the sound a bit so it's
+    // easier to hear? It's so quick it's actually hard to tell if I'm hearing it
+    // in the environment or in my headphones." Zero-latency monitoring is
+    // correct for performing and useless for TESTING — it phases with your own
+    // voice conducting through your skull and becomes indistinguishable from the
+    // room. 400ms is past the echo threshold (~50ms), so it reads as a distinct
+    // repeat you can compare against what you just said: did the gate clip the
+    // start of that word, or not?
+    _delay = _ctx.createDelay(2.0);
+    _delay.delayTime.value = MONITOR_DELAY;
+    _gain.connect(_delay);
+    _delay.connect(_mon);
+    _mon.connect(_ctx.destination);
+  }
+  // setTargetAtTime, not a bare assignment: a step change in a monitor path is
+  // an audible click straight into your ears.
+  try { _mon.gain.setTargetAtTime(level, _ctx.currentTime, 0.02); }
+  catch { _mon.gain.value = level; }
+  return true;
+}
+export const monitoring = () => !!_mon;
+
+/** Is any signal actually reaching the wire right now? The honest answer to
+ *  "am I being broadcast", read from the gain itself rather than inferred. */
+// Reports the gate's INTENT, not the instantaneous .value: during a fade the
+// real gain is mid-slope, and an indicator that flickers through every envelope
+// would misreport 'am I being heard' at exactly the moments that matter.
+export const gateOpenness = () => (_gain ? _wanted : 0);
+export const gateGainNow = () => (_gain ? _gain.gain.value : 0);
+export const isGated = () => !!_gain;
+
+// ── MIX A SYNTHESIZED VOICE INTO THE SAME LANE ─────────────────────────────
+// 🔴 R, 2026-08-09: "sometimes I toggle the mic and it seems to be live and
+// sometimes not... fine if I toggle it first before touching TTS, and it breaks
+// forever if I touch TTS first."
+//
+// Exact diagnosis. voiceSource() was an EITHER/OR: `if (isTtsEnabled()) return
+// synth-track; else return microphone`. That is an agent-shaped assumption — a
+// synthesizer REPLACES the mic — and it is wrong for a human who has a voice AND
+// wants TTS. Enable TTS first and the mic toggle silently hands the mesh a
+// generator instead of a microphone, forever, with every check reporting healthy.
+//
+// A synth is not a replacement for a mouth; it is another thing that makes sound
+// in the same room. So it mixes in AFTER the gate: your room noise must clear a
+// threshold, but synthesized speech is already the signal and must never be
+// gated by it.
+let _synthSrc = null;
+export function mixSynthTrack(track) {
+  if (!_ctx || !_dest) return false;
+  unmixSynth();
+  if (!track) return false;
+  try {
+    _synthSrc = _ctx.createMediaStreamSource(new MediaStream([track]));
+    _synthSrc.connect(_dest);          // past the gate, deliberately
+    return true;
+  } catch (e) { report('mix synth', e); _synthSrc = null; return false; }
+}
+export function unmixSynth() {
+  try { _synthSrc?.disconnect(); } catch { /* already gone */ }
+  _synthSrc = null;
+}
+
+/** Detach the DEVICE from the lane, keeping the lane itself alive.
+ *
+ *  🔴 This is the one that matters for reconnect cost. The GainNode and the
+ *  MediaStreamDestination stay — so the track every peer's sender holds is still
+ *  live, and no renegotiation is needed when the mic comes back. Only the
+ *  source-side connection goes away, because its device track just stopped.
+ *
+ *  R, 2026-08-09: "we don't want to tear down audio tracks at all unless someone
+ *  leaves or unchecks the connect-to-audio box — that's how we ran into people
+ *  not hearing each other and unmute lag while it sets it all up again." */
+export function detachSource() {
+  try { _src?.disconnect(); } catch { /* already gone */ }
+  _src = null;
+  _rawStream = null;
+  if (_gain) _gain.gain.value = 0;        // lane open, silent
+}
+
+/** Reconnect a new device stream into the EXISTING lane. Returns the same gated
+ *  stream the senders already hold, so nothing downstream changes. */
+export function attachSource(stream) {
+  if (!_ctx || !_gain || !_dest) return null;
+  try { _src?.disconnect(); } catch { /* fine */ }
+  _src = _ctx.createMediaStreamSource(stream);
+  _src.connect(_gain);
+  _rawStream = stream;
+  return _gatedStream;
+}
+
+/** Full teardown — the lane included. ONLY for leaving the world or revoking
+ *  consent, never for going quiet: this is the path that costs a renegotiation
+ *  to undo. */
+export function release() {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+  try { _src?.disconnect(); } catch { /* already gone */ }
+  try { _gain?.disconnect(); } catch { /* already gone */ }
+  // Deliberately does NOT stop the destination's tracks: they belong to the
+  // stream WebRTC holds, and stop() is a one-way door. The caller's own sender
+  // cleanup owns that.
+  _src = _gain = _dest = null;
+  _gatedStream = null;
+  _rawStream = null;
+}
+
+/** The RAW stream, for anything that must measure the true input — the analyser
+ *  especially. Measuring the gated output would make the gate self-latching. */
+export const rawStream = () => _rawStream;
+
+/** Retune the monitor delay live, in seconds (0…2). For finding the spacing that
+ *  makes a clipped consonant obvious rather than ambiguous. */
+export function setMonitorDelay(sec) {
+  MONITOR_DELAY = Math.max(0, Math.min(2, Number(sec) || 0));
+  if (_delay && _ctx) {
+    try { _delay.delayTime.setTargetAtTime(MONITOR_DELAY, _ctx.currentTime, 0.05); }
+    catch { _delay.delayTime.value = MONITOR_DELAY; }
+  }
+  return MONITOR_DELAY;
+}
+export const monitorDelay = () => MONITOR_DELAY;

--- a/client/lib/micgate.js
+++ b/client/lib/micgate.js
@@ -64,13 +64,30 @@ let _rawStream = null, _gatedStream = null, _level = () => 0;
 /** Wrap a mic stream in the gate graph. Returns the stream to hand to WebRTC —
  *  or the original stream unchanged if the graph cannot be built, because a
  *  voice that works ungated beats no voice at all. */
+// ── declared vs effective (#90 review B2, 2026-08-11) ───────────────────────
+// If the gate graph cannot be built, the OLD behavior returned the raw device
+// stream — every room sound transmitted ungated while the UI still showed
+// sensitivity controls. A privacy control that silently downgrades to "off"
+// is worse than none. Now: construction failure REFUSES the stream (caller
+// gets null and must not transmit) unless the user has explicitly chosen
+// ungated transmission via allowUngated(true). Machine-visible either way.
+let _gateUnavailable = false;   // the graph could not be built on this device
+let _ungatedConsent = false;    // explicit "transmit raw anyway" choice
+export const gateUnavailable = () => _gateUnavailable;
+export const ungatedConsent = () => _ungatedConsent;
+export function allowUngated(on) { _ungatedConsent = !!on; }
+
 export function gateStream(stream, levelFn) {
   release();
   _rawStream = stream;
   _level = levelFn || (() => 0);
   try {
     _ctx = audioContext();
-    if (!_ctx || typeof _ctx.createMediaStreamDestination !== 'function') return stream;
+    if (!_ctx || typeof _ctx.createMediaStreamDestination !== 'function') {
+      _gateUnavailable = true;
+      return _ungatedConsent ? stream : null;   // fail CLOSED, not raw
+    }
+    _gateUnavailable = false;
     _src = _ctx.createMediaStreamSource(stream);
     _gain = _ctx.createGain();
     // Start CLOSED. Opening on the first frame would broadcast whatever the room
@@ -94,7 +111,11 @@ export function gateStream(stream, levelFn) {
   } catch (e) {
     report('mic gate graph', e);
     release();
-    return stream;                       // ungated beats silent
+    // FAIL CLOSED (B2): "ungated beats silent" was the old rule, and it made
+    // the sensitivity UI a lie whenever WebAudio broke. Silent-with-a-reason
+    // beats secretly-raw; allowUngated(true) is the explicit way back.
+    _gateUnavailable = true;
+    return _ungatedConsent ? stream : null;
   }
 }
 

--- a/client/lib/micgate.js
+++ b/client/lib/micgate.js
@@ -264,6 +264,13 @@ export function attachSource(stream) {
 export function release() {
   try { _src?.disconnect(); } catch { /* already gone */ }
   try { _gain?.disconnect(); } catch { /* already gone */ }
+  // Disposal OWNERSHIP (#90 review): this module built the monitor tap and the
+  // synth mix-in, so this module disconnects them — a release that leaves its
+  // own nodes wired into a dead graph is the asymmetric repair again.
+  try { _mon?.disconnect(); } catch { /* already gone */ }
+  try { _synthSrc?.disconnect(); } catch { /* already gone */ }
+  _mon = null;
+  _synthSrc = null;
   // Deliberately does NOT stop the destination's tracks: they belong to the
   // stream WebRTC holds, and stop() is a one-way door. The caller's own sender
   // cleanup owns that.

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -876,22 +876,15 @@ export function releaseMicrophone() {
   _micReleased = true;
   muted = false;
   stopOnsetWatch();
-  for (const [id, p] of [...peers]) {
-    try {
-      for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
-    } catch (e) { report('voice untrack', e); }
-    // 🔴 DO NOT DESTROY THE PEER. This used to dropPeer() when receive was off —
-    // the same mistake as tearing down on 'disconnected', with a different
-    // trigger: we close the connection, the FAR END keeps a live pc to a peer
-    // that no longer exists, and neither side can recover. Ours cannot rebuild
-    // (both rebuild paths need a mic we just released); theirs will not, because
-    // they still hold us in `peers` so their reconciler skips us.
-    //
-    // Wanting neither to send nor receive is a DIRECTION ('inactive'), not a
-    // reason to hang up. renegotiate() carries that, the mesh stays warm, and
-    // consenting again is a renegotiation instead of a rebuild.
-    renegotiate(id);
-  }
+  // 🔴 NO UNTRACK, NO RENEGOTIATION — that is the whole contract (#90 B3).
+  // Everything above this line promised the standing lane: senders keep the
+  // live destination track (currently carrying silence — gain zero, source
+  // detached), so reacquiring is attachSource(newDevice) into the SAME graph
+  // with zero SDP churn. A removeTrack+renegotiate loop lived here anyway,
+  // quietly doing the teardown the comments forswore — every reacquire paid
+  // the renegotiation the design existed to avoid, and the lifecycle suite
+  // never pinned it. Privacy is not weakened by its removal: the device is
+  // stopped (OS indicator off) and the lane transmits silent frames only.
   flashHint('🎙 released');
   bus.emit('voice', { on: false });
 }

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -565,6 +565,13 @@ export async function toggleMic(name) {
   // stable ones; this covers the strangers.
   for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
   _micLive = true;
+  // 🔴 TURNING THE MIC ON IS AN UNMUTE. The off-path clears `muted`; this path
+  // did not — so a user who muted and then pressed the mic button was wedged:
+  // micOn() stayed false (it requires !muted), every press re-entered THIS
+  // branch, and the raw tracks it re-enables were live while micOn/isMuted/
+  // micTransmitting all reported silence. Broadcasting while every light says
+  // muted is the display-vs-real-state bug in its worst costume.
+  muted = false;
   flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');
   bus.emit('voice', { on: true });
   startOnsetWatch();

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -17,7 +17,10 @@
 import { bus, report } from './core.js';
 import { sendRtc, sendTyping } from './net.js';
 import { remotes } from './remotes.js';
-import { micFloor } from './voiceconsent.js';
+import { micFloor, gateThreshold } from './voiceconsent.js';
+import { voiceSource, setGeneratorRebuildHook } from './voicesource.js';
+import { gateStream, attachSource, detachSource, driveGate, gateOpenness,
+         setMonitor, monitoring, release as releaseGate } from './micgate.js';
 import { audioContext } from './audioctx.js';
 import { myState } from './controller.js';
 import { flashHint } from './ui.js';
@@ -31,10 +34,46 @@ const RTC_CFG = { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] };
 const FULL_M = 3, SILENT_M = 20;   // full volume inside 3m, gone by 20m
 
 let micStream = null;
+// The pre-gate device stream. The analyser MUST measure this, not micStream:
+// measuring the gated output makes the gate self-latching (gain drops →
+// measured level drops → gate closes harder → never reopens).
+let _rawMic = null;
+// True when the DEVICE is gone but the LANE is still standing — the state that
+// makes coming back cheap.
+let _micReleased = false;
 let muted = false;
 const peers = new Map();           // id -> { pc, audio }
 let myId = null;
-export const micOn = () => !!micStream;
+// TRANSMITTING, not "a stream object exists". Going quiet now disables the
+// track instead of stopping it (see toggleMic), so micStream outlives mic-off
+// and `!!micStream` would leave the HUD stuck reading ON. Every caller of
+// micOn() is UI asking "am I being heard right now?" — this is that question.
+// 🔴 NOT track.enabled ANY MORE. The noise gate now toggles `enabled` between
+// words, so reading it here would make the HUD flicker "mic off" in every pause
+// — the control would look broken precisely while it worked. `muted` is the
+// user's intent and does not move on its own, which is the question every caller
+// is actually asking: am I open to the room?
+// 🔴 THREE STATES, NOT TWO. `muted` and "mic off" are different things and used
+// to be told apart by track.enabled — which the NOISE GATE now owns, toggling it
+// between words. When I repointed micOn() at `muted` I collapsed them, and
+// toggleMic's off-path (which sets enabled=false but muted=false) then left
+// micOn() permanently TRUE: R, 2026-08-09, "I'm not sure what the microphone
+// option does? It's just stuck on and I can't do anything with it."
+//
+//   _micLive false          → mic off: nothing is captured, the row reads off
+//   _micLive true + muted   → open but deliberately silent
+//   _micLive true + !muted  → open; the gate decides moment to moment
+let _micLive = false;
+export const micOn = () => !!micStream && _micLive && !muted;
+/** Am I audible RIGHT NOW — i.e. is the gate open this instant? For a live
+ *  indicator, not for state. This is the affordance R asked for: "we have no
+ *  affordance to say when audio is getting broadcasted." */
+export const micTransmitting = () =>
+  // Read the GAIN, not a boolean. With a smoothed gate there is no on/off flag
+  // to consult — the honest question is "how much of me is reaching the wire",
+  // and 0.05 is the point where a listener would call it audible rather than
+  // the tail of a fade.
+  !!micStream && !muted && gateOpenness() > 0.05;
 export const isMuted = () => muted;
 
 function humanIds() {
@@ -149,10 +188,42 @@ function peerFor(id) {
     audio.play().catch(() => addEventListener('click', () => audio.play().catch(() => {}), { once: true }));
   };
   pc.onicecandidate = (e) => { if (e.candidate) sendRtc(id, { ice: e.candidate }); };
+  // restartIce() does not send anything by itself — it raises negotiationneeded
+  // and waits for the application to offer. With no handler the flag was set and
+  // nothing ever went out, so an ICE restart would have been a silent no-op.
+  // renegotiate() is exactly the "offer if we can, queue if mid-flight" path
+  // this needs, so route the event there rather than writing a second one.
+  pc.addEventListener?.('negotiationneeded', () => { renegotiate(id); });
   pc.addEventListener?.('connectionstatechange', () => (window.__iceLog ??= []).push(`conn[${id}]=${pc.connectionState}`));
   pc.addEventListener?.('iceconnectionstatechange', () => (window.__iceLog ??= []).push(`icestate[${id}]=${pc.iceConnectionState}`));
   pc.onconnectionstatechange = () => {
-    if (['failed', 'closed', 'disconnected'].includes(pc.connectionState)) dropPeer(id);
+    const st = pc.connectionState;
+    // 🔴 'disconnected' IS NOT 'failed'. It means ICE consent checks stopped
+    // arriving — a wifi blip, a handover, a laptop lid — and it recovers on its
+    // own most of the time. MDN is explicit: "don't call close() on
+    // disconnected — you'd be discarding a connection that may well recover."
+    // We were tearing the peer down instantly, so a momentary blip permanently
+    // destroyed a working link and nothing rebuilt it: the peer is gone from the
+    // map, so no renegotiation can reach it, and the other end still holds a
+    // live connection to a peer that no longer exists. That is the one-way
+    // audio, and it explains why it survives mic toggles (the peer is not
+    // there to re-offer) and why a full restart FLIPS which side is deaf (only
+    // the restarted side rebuilds).
+    //
+    // Give it a grace period and try an ICE restart before giving up. Only
+    // 'failed' and 'closed' are terminal.
+    if (st === 'failed' || st === 'closed') { clearTimeout(p._discoTimer); dropPeer(id); return; }
+    if (st === 'connected') { clearTimeout(p._discoTimer); p._discoTimer = null; return; }
+    if (st === 'disconnected' && !p._discoTimer) {
+      p._discoTimer = setTimeout(() => {
+        p._discoTimer = null;
+        if (pc.connectionState !== 'disconnected') return;    // recovered on its own
+        // Still down after the grace window: ask ICE to find a new path rather
+        // than destroying the peer. restartIce() renegotiates in place, which
+        // keeps the transceivers — and therefore the agreed direction — intact.
+        try { pc.restartIce?.(); } catch (e) { report('voice ice restart', e); }
+      }, 6000);
+    }
   };
   return p;
 }
@@ -160,6 +231,11 @@ function peerFor(id) {
 function dropPeer(id) {
   const p = peers.get(id);
   if (!p) return;
+  // A pending disconnect timer outlives the peer it was watching unless it is
+  // cleared here — it would fire against a closed pc and try to restart ICE on
+  // a connection nobody holds.
+  clearTimeout(p._discoTimer);
+  p._discoTimer = null;
   peers.delete(id);
   try { p.pc.close(); } catch (e) { report('voice close', e); }
   p.audio.srcObject = null;
@@ -379,37 +455,100 @@ async function processSignal(p, from, payload) {
 
 export async function toggleMic(name) {
   myId = name ?? myId;
-  if (micStream) {
-    // SEND state only. Going quiet must not deafen you: listening is a
-    // separate permission (review catch — the old teardown dropped every
-    // peer, including inbound legs, which then had no trigger to re-offer
-    // until the next roster event, so muting yourself silently deafened you
-    // for an unbounded time). We remove OUR track from each peer and keep
-    // the connection alive; if we are not listening either, THEN the peer
-    // has no purpose and comes down.
-    for (const t of micStream.getTracks()) t.stop();
-    micStream = null;
+  if (micOn()) {
+    // GOING QUIET IS A DATA CHANGE, NOT A CONNECTION CHANGE (R, 2026-08-08).
+    //
+    // This used to stop() the track, removeTrack() it from every peer, and
+    // renegotiate — three destructive operations to express "don't transmit".
+    // Four of the six voice bugs fixed this week were in the renegotiation
+    // that followed, and stop() manufactures precisely the `audio:ended`
+    // sender state that the live one-way-audio blocker shows in the field.
+    // The identical intent was already implemented correctly ten lines below
+    // in toggleMute (track.enabled = false, zero renegotiation, zero bugs) —
+    // it simply had no callers, while the HUD button called this.
+    //
+    // So: disable the track. It stays live, the sender stays bound, the
+    // transceiver stays sendonly, the SDP does not change, and coming back is
+    // one assignment rather than getUserMedia + renegotiate. Muting cannot
+    // deafen you because no peer is touched at all.
+    for (const t of (_rawMic || micStream).getTracks()) t.enabled = false;
     stopOnsetWatch();
+    _micLive = false;                // the state the checkbox and HUD icon read
     muted = false;
-    for (const [id, p] of [...peers]) {
-      try {
-        for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
-      } catch (e) { report('voice untrack', e); }
-      if (!receivingVoice()) dropPeer(id);
-      else renegotiate(id);          // tell them our track is gone; keep theirs
-    }
+    driveGate(false);                // close the lane; never tear it down
     flashHint('🎙 off');
     bus.emit('voice', { on: false });
+      // 🔴 MIC OFF = TTS TAKES OVER, if it was left enabled (R, 2026-08-09).
+      // MIC BEATS TTS is a priority, not a toggle: the TTS setting stands while
+      // the mic wins, so the moment the mic drops the synth must actually be
+      // wired in — otherwise "drops back to TTS without touching anything" is
+      // just silence, and the user has no way to tell an armed voice from a
+      // broken one. Fixing only the mic-on direction would be exactly the
+      // asymmetric repair voicesource.js warns about two lines up from its own
+      // mix site.
+      import('./voicesource.js').then(async (vs) => {
+        if (!vs.isTtsEnabled?.() || !vs.canSynthesize?.()) return;
+        const m = await import('./micgate.js');
+        if (!m.isGated?.()) return;              // no lane; voiceSource handles it
+        vs.startPacer?.();
+        m.mixSynthTrack(vs.ensureGenerator());
+      }).catch(() => {});
     return false;
   }
-  try {
-    micStream = await navigator.mediaDevices.getUserMedia({
-      audio: { echoCancellation: true, noiseSuppression: true },
-    });
-  } catch (e) {
-    report('microphone', e);
-    flashHint('microphone unavailable — check browser permission');
-    return false;
+  // Coming back. If we still hold the stream (the normal case now — mic-off
+  // only disables it) re-enabling IS the whole acquisition step: no
+  // getUserMedia, so no permission re-prompt and no new track object. Then we
+  // fall THROUGH to the same attach/renegotiate/court-peers path a fresh mic
+  // takes; returning early here skipped peer creation entirely, which the
+  // lifecycle suite caught at once (mic ON with no peer courted).
+  // 🔴 `micStream` DOES NOT MEAN "A DEVICE IS CAPTURING". After
+  // releaseMicrophone() it deliberately SURVIVES — the lane stays up so the mesh
+  // needs no renegotiation on the way back (R: "we just mute the lane", and
+  // recovering a torn-down audio path costs seconds). But its tracks are STOPPED
+  // and a stopped track cannot be revived. Branching on micStream alone sent the
+  // return-from-release path into the re-enable branch below, where it flipped
+  // `enabled` on dead tracks: getUserMedia was never called, no device was ever
+  // reacquired, and the mic silently never came back after any release.
+  //
+  // `_micReleased` is the variable that answers "is there a device behind this
+  // lane" — and it is ALREADY the discriminator twelve lines down, where
+  // attachSource decides whether to reuse the standing graph. Same question,
+  // same answer, both places.
+  if (micStream && !_micReleased) {
+    // 🔴 THE SAME TRACK THE OFF-PATH TOUCHED. micStream is the GATED output now,
+    // so re-enabling its track does nothing for the RAW device track that mic-off
+    // disabled — the mic came back once and was silent forever after (R,
+    // 2026-08-09: "it enables correctly only the first time. Once toggled again,
+    // it never comes back"). Asymmetric repair, in the one file that has a whole
+    // memory note about asymmetric repair. Both paths name (_rawMic || micStream)
+    // so they cannot drift apart again.
+    for (const t of (_rawMic || micStream).getTracks()) t.enabled = true;
+  } else {
+    try {
+      // WHERE THE VOICE COMES FROM is a property of this body, not a hardcoded
+      // device call: a human gets the microphone, an agent gets its own
+      // synthesizer, and everything downstream is identical either way. See
+      // voicesource.js — the alternative was a second WebRTC client holding
+      // the same identity, which produced 543 takeovers on 2026-08-08.
+      const rawMic = await voiceSource();
+      // GATE THE STREAM BEFORE WEBRTC EVER SEES IT. micStream becomes the GATED
+      // stream, so every existing path (addTrack, replaceTrack, the senders)
+      // carries gated audio with no further changes. The raw stream is kept for
+      // measurement and for mute.
+      _rawMic = rawMic;
+      // Reuse the EXISTING lane if one is standing: attachSource returns the
+      // same gated stream the senders already hold, so coming back from a
+      // release costs ZERO renegotiation. Only build a new graph when there is
+      // none — that rebuild is the "unmute lag while it sets it all up again"
+      // R described.
+      const reused = _micReleased ? attachSource(rawMic) : null;
+      micStream = reused || gateStream(rawMic, micAnalyserLevel);
+      _micReleased = false;
+    } catch (e) {
+      report('microphone', e);
+      flashHint('microphone unavailable — check browser permission');
+      return false;
+    }
   }
   // Attach FIRST, renegotiate second. applyDirection is where the track is
   // adopted, but renegotiate() bails on a peer that is not 'stable' — and a
@@ -425,6 +564,7 @@ export async function toggleMic(name) {
   // have-local-offer (Mica, #34). renegotiate() above already covers the
   // stable ones; this covers the strangers.
   for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
+  _micLive = true;
   flashHint('🎙 live — speak, neighbors hear · <b>mute</b> in the dock');
   bus.emit('voice', { on: true });
   startOnsetWatch();
@@ -441,20 +581,171 @@ export async function toggleMic(name) {
 // must not land on the new one — answers carry no negotiation identity of
 // their own, so we supply it (Mica, #62 review).
 let _peerGen = 0;
-let _onsetTimer = null, _above = false, _lastOnset = 0;
+let _onsetTimer = null, _above = false, _lastOnset = 0, _openUntil = 0;
+// When this open began, and whether it has been announced — see onsetTick.
+let _openedAt = 0, _announced = false;
+// ADAPTIVE FLOOR. R, 2026-08-09 mid-call: "lol mic sensitivity still needs
+// work" — the 🎙 indicator fired on nothing and missed real speech.
+//
+// The old gate compared raw RMS to a FIXED 0.04. That cannot work across
+// machines: RMS scales with mic gain, distance and OS-level AGC, so 0.04 is
+// deafening on a headset and unreachable on a laptop array two feet away. One
+// constant against an unnormalised signal is the whole bug.
+//
+// So measure the ROOM and gate relative to it. `_noise` tracks the quiet level
+// with a slow one-sided follower — falls fast toward quiet, rises slowly — so a
+// long utterance cannot drag the floor up behind itself and gate you out
+// mid-sentence, while a fan switching on is absorbed within a few seconds.
+// Speech has to clear the noise by a MARGIN, which is what makes it work the
+// same in a silent room and a loud one.
+//
+// The slider still matters: it scales the margin (sensitivity), rather than
+// naming an absolute level nobody can reason about.
+let _noise = 0.01;
+let _settle = 0;
+// BasisVR's block tracker: 6 × 0.4s minima. See onsetTick.
+let _blocks = new Array(6).fill(Infinity), _blockIdx = 0, _blocksFilled = 0,
+    _blockMin = Infinity, _blockStart = 0;
 function onsetTick() {
-  const floor = micFloor();
   const level = micAnalyserLevel();
-  if (!_above && level >= floor) {
-    _above = true;
-    const now = Date.now();
-    if (now - _lastOnset > 1500) { _lastOnset = now; sendTyping(null, 'mic'); }
-  } else if (_above && level < floor * 0.6) _above = false;
+  // 🔴 DRIVE THE GATE BEFORE ANY EARLY RETURN. Both of the bails below (muted /
+  // silent, and the settle window) used to skip gateAudio() entirely — so the
+  // gain simply KEPT ITS LAST VALUE. If the gate happened to be open when you
+  // stopped talking into silence, or during the first second after unmuting, it
+  // stayed open and the monitor played straight through: R, twice, "hear myself
+  // isn't obeying the mic sensitivity". A control loop that skips its output
+  // stage is not a control loop.
+  if (level <= 0) { gateAudio(Date.now()); return; }   // muted: close, do not learn
+
+  // LEARN BEFORE JUDGING. The floor starts cold at 0.01, so in a loud room the
+  // first second reads as "way above the floor" and fires the 🎙 at the room
+  // itself — which is exactly what R saw: "it seemed like mic sensitivity was
+  // picking up a fair amount of background noise". Simulation put essentially
+  // every remaining false trigger in this window. Spend the first ~1s measuring
+  // only. Erring here is free: nobody speaks in the first tick after unmuting,
+  // and a missed onset costs an icon, not audio (audio always flows).
+  if (_settle < 8) {
+    _settle++;
+    const a0 = level < _noise ? 0.3 : 0.5;
+    _noise += (level - _noise) * a0;
+    gateAudio(Date.now());               // measuring, but still CLOSED — not frozen
+    return;
+  }
+
+  // NOISE FLOOR: minimum-of-block-minima, ported from BasisVR
+  // (BasisNoiseFloorTracker, MIT — R: "I'll bet money BasisVR already solved
+  // this"; she was right, and their design is better than the follower I
+  // hand-tuned). 6 blocks × 0.4s: take the quietest RMS in each block, then the
+  // quietest block. The floor therefore tracks the quietest moment in the last
+  // ~2.4s, so SPEECH CAN NEVER RAISE IT — structurally, not by tuning. My
+  // exponential follower could be dragged up by a long utterance and gate the
+  // speaker out mid-sentence; this cannot, and needed no rate constant at all.
+  const nowT = Date.now();
+  if (level < _blockMin) _blockMin = level;
+  if (nowT - _blockStart >= 400) {
+    _blockStart = nowT;
+    _blocks[_blockIdx] = _blockMin;
+    _blockIdx = (_blockIdx + 1) % 6;
+    if (_blocksFilled < 6) _blocksFilled++;
+    _blockMin = Infinity;
+  }
+  _noise = Math.max(1e-5, Math.min(_blockMin, ...(_blocks.slice(0, _blocksFilled))));
+
+  // THRESHOLD IS MULTIPLICATIVE, not additive — also theirs (AutoGateOverNoise
+  // = 2.5). This is the same lesson as "a fixed 0.04 cannot work across mics",
+  // one level up: an ADDITIVE margin is still an absolute number, so it is
+  // wrong at a different gain. `floor × k` scales with the signal and is the
+  // only form that behaves the same on a headset and a laptop array.
+  //
+  // The slider picks k over 1.6…5.0, with 2.5 (their default) mid-scale.
+  // FIXED THRESHOLD, Discord-style. The noise floor is still measured (it drives
+  // nothing now but is kept for the meter and for diagnosing "why did it not
+  // open"), but the GATE compares against an absolute dB level the user set.
+  // That is what makes the marker stay put while the level moves past it.
+  const on = gateThreshold();
+  const off = on * 0.7;                    // ~3 dB of hysteresis
+
+  const now = Date.now();
+  if (level >= on) {
+    _openUntil = now + 700;               // hang-time: see gateAudio()
+    if (!_above) { _above = true; _openedAt = now; _announced = false; }
+    // 🔴 THE PILL AND THE AUDIO MUST AGREE. R: "sometimes I can see the TTS voice
+    // threshold getting triggered (pill over the head) without hearing anything
+    // through hear-myself — these should have the exact same gate."
+    //
+    // They shared the threshold but not the OBSERVABLE. The pill fired the instant
+    // `_above` flipped; the audio rides an envelope, so a single-tick spike (a
+    // cough, a key) trips the flag and is nearly inaudible before the gate shuts.
+    // Announce only once the gate has been open long enough to have actually
+    // PASSED audio — one envelope's worth. The pill then means "the room heard
+    // something", which is what a pill over your head claims.
+    if (!_announced && now - _openedAt >= 60 && now - _lastOnset > 1500) {
+      _announced = true; _lastOnset = now; sendTyping(null, 'mic');
+    }
+  } else if (_above && level < off && now > _openUntil) _above = false;
+  gateAudio(now);
 }
+
+// 🔴 THE GATE MUST GATE THE AUDIO, NOT JUST THE ICON. R, 2026-08-09: "I would
+// DEFINITELY gate the mic sensitivity to cover the full audio channel so every
+// little background noise isn't broadcasted to the room. That's extra confusing
+// because we have no affordance to say when audio is getting broadcasted."
+//
+// She is right and I had this backwards: I spent an hour tuning this thing as an
+// INDICATOR problem, when the indicator was reporting truthfully — audio really
+// was always flowing. Your keyboard, your fan and your family went to the room
+// whenever the mic was open, and the only thing the threshold changed was a
+// glyph. A "sensitivity" control that does not control what anyone hears is
+// worse than none, because it reads as if it does.
+//
+// track.enabled is the right mechanism: universal (unlike
+// MediaStreamTrackGenerator, which is Chromium-only), synchronous, spec-mandated
+// to render silence, and already what mute uses — so this cannot fight it.
+//
+// HANG-TIME, not a hard cut. Speech is full of gaps: stops, breaths, the pause
+// before a clause. Closing the instant level drops chops words in half, so the
+// gate stays open 700ms past the last sound above threshold and only then
+// closes. Cost is 700ms of room tone after each utterance; the alternative is
+// being unintelligible.
+function gateAudio(now) {
+  if (!micStream || muted) { driveGate(false); return; }   // mute is authoritative
+  driveGate(_above || now <= _openUntil);
+}
+/** What the gate is actually doing right now — for the meter and for tuning.
+ *  Exposed because "why did it not trigger" is unanswerable from the outside:
+ *  the same RMS means different things in different rooms. */
+export const micGateInfo = () => ({
+  level: micAnalyserLevel(), noise: _noise,
+  // 🔴 ONE formula, not a copy. This drifted the moment the gate went
+  // multiplicative — it still carried the old additive margin, so the panel and
+  // the gate reported DIFFERENT thresholds. Derived from the same expression
+  // now; if the gate changes, this cannot silently disagree.
+  on: gateThreshold(),
+  // 🔴 THRESHOLD *PLUS HANG-TIME* — R: "turn the bar gold when it's streaming
+  // live audio over the threshold + hangtime". `_above` alone goes false the
+  // instant your level dips, but the gate is still open for another 700ms and
+  // the room is still hearing you. Reporting _above would make the bar flicker
+  // dark through every pause in a sentence while audio was flowing: an
+  // indicator that contradicts the thing it indicates.
+  speaking: _above || Date.now() <= _openUntil,
+});
 function startOnsetWatch() {
   if (_onsetTimer) return;
   _above = false;
-  _onsetTimer = setInterval(onsetTick, 120);
+  // Re-measure the room on every mic open. A floor learned in a quiet session
+  // would gate you out of a loud one — and worse, a floor learned while a fan
+  // was running stays high after it stops. Start low and let the follower rise;
+  // erring quiet costs a few false 🎙 in the first second, erring loud costs
+  // your first sentence.
+  _noise = 0.01;
+  _settle = 0;
+  _blocks = new Array(6).fill(Infinity); _blockIdx = 0; _blocksFilled = 0;
+  _blockMin = Infinity; _blockStart = Date.now();                            // re-learn the room, then judge
+  // 40ms, not 120: the tick interval is the WORST-CASE CLIP on the first
+  // syllable now that this gates audio. 120ms removes an audible chunk of a
+  // word's attack; 40ms is under the threshold where a missing onset is
+  // perceptible, and the work per tick is one FFT read.
+  _onsetTimer = setInterval(onsetTick, 20);
 }
 function stopOnsetWatch() {
   if (_onsetTimer) { clearInterval(_onsetTimer); _onsetTimer = null; }
@@ -463,10 +754,14 @@ function stopOnsetWatch() {
 
 // live mic level 0..1 for UI (the mic glyph's hot-glow) — analyser built
 // lazily on first ask, rebuilt if the stream changed
-let _an = null, _anStream = null, _anBuf = null;
+let _an = null, _anStream = null, _anBuf = null, _anCtx = null;
 export function micAnalyserLevel() {
+  // muted → 0 (nothing is being sent, and the gate must not learn a floor from
+  // a muted mic). But NOT gated → 0: the gate needs the true input level to
+  // decide when to reopen, which is the whole reason we measure the raw side.
   if (!micStream || muted) return 0;
-  if (!_an || _anStream !== micStream) {
+  const measured = _rawMic || micStream;
+  if (!_an || _anStream !== measured) {
     try {
       // ONE CONTEXT, REUSED. This made a NEW AudioContext every time the mic
       // stream changed and never closed the old one — and Chrome caps a
@@ -474,10 +769,10 @@ export function micAnalyserLevel() {
       // SILENTLY so. Toggle the mic a few times and whatever asks next gets a
       // dead one.
       const ctx = audioContext();
-      const src = ctx.createMediaStreamSource(micStream);
+      const src = ctx.createMediaStreamSource(measured);
       _an = ctx.createAnalyser(); _an.fftSize = 512;
       src.connect(_an);
-      _anStream = micStream;
+      _anStream = measured;
       _anBuf = new Float32Array(_an.fftSize);
     } catch { return 0; }
   }
@@ -487,13 +782,98 @@ export function micAnalyserLevel() {
   return Math.sqrt(s / _anBuf.length);
 }
 
+// Kept as the explicit verb for "go quiet without touching the mic button's
+// meaning" — it is now the SAME mechanism toggleMic uses (track.enabled), so
+// the two can no longer disagree. Before 2026-08-08 this was the correct
+// implementation with zero callers while the HUD used the destructive path.
 export function toggleMute() {
   if (!micStream) return false;
   muted = !muted;
-  for (const t of micStream.getTracks()) t.enabled = !muted;
+  // Unmuting hands control back to the NOISE GATE, it does not open the mic.
+  // Setting enabled=true here would broadcast whatever the room is doing until
+  // the next tick closed it again — a small leak, but exactly the one this gate
+  // exists to prevent. Muting still forces false immediately: mute must be
+  // instant and must never wait for a tick.
+  // Mute acts on the RAW device track, not the gated output: the gated stream's
+  // track is a graph destination, and disabling it would fight the gain node
+  // rather than replace it. Muting at the source is also the honest thing — the
+  // microphone genuinely stops contributing.
+  for (const t of (_rawMic || micStream).getTracks()) t.enabled = !muted;
+  if (!muted) { _above = false; _openUntil = 0; }   // gate decides from here
+  driveGate(false);                                  // and close it immediately
   flashHint(muted ? '🔇 muted' : '🎙 unmuted');
   bus.emit('voice', { on: true, muted });
   return muted;
+}
+
+/** Release the microphone device entirely — the OS/browser recording indicator
+ *  goes away. This is the ONLY path that stops tracks, and it is deliberately
+ *  not what the HUD mic button does: it costs a permission re-prompt and a
+ *  renegotiation to undo, so it is a privacy action, not a "go quiet" action. */
+export function releaseMicrophone() {
+  if (!micStream) return;
+  // 🔴 STOP THE DEVICE, NEVER THE GRAPH OUTPUT. Two separate rules meet here:
+  //
+  // (1) The raw device track MUST stop, or the OS recording indicator stays lit
+  //     while this function's whole promise is that it goes away. micStream is
+  //     now a graph destination, so stopping only that would leave the actual
+  //     microphone recording.
+  //
+  // (2) The GATED track must NOT stop. stop() is a one-way door (see the note in
+  //     ontrack above — the same mistake cost us a permanently-deaf peer), and a
+  //     MediaStreamDestination track cannot be restarted, so re-enabling the mic
+  //     would need a whole new graph and a renegotiation to hand the new track
+  //     to every peer. R, 2026-08-09: "we don't want to tear down audio tracks
+  //     at all unless someone leaves or unchecks the connect-to-audio box —
+  //     that's how we ran into people not hearing each other and unmute lag
+  //     while it sets it all up again. Now we just mute the lane."
+  //
+  // So: kill the device, leave the lane in place at zero gain. The senders keep
+  // a live track, no renegotiation is needed, and reacquiring the mic reconnects
+  // a new source into the SAME graph.
+  for (const t of (_rawMic || micStream).getTracks()) t.stop();
+  driveGate(false);              // lane stays up, gain to zero
+  detachSource();                // lane (GainNode + destination) SURVIVES
+  _rawMic = null;
+  // micStream KEEPS naming the gated stream. Its track is still live and still
+  // held by every sender, so the mesh needs no renegotiation when the mic comes
+  // back — that rebuild is exactly the "unmute lag while it sets it all up
+  // again" R described. Audibility is decided by `muted` and the gate; this
+  // variable only means "a lane exists".
+  // 🔴 THE DEVICE IS GONE, SO SAY SO. micOn() is `micStream && _micLive &&
+  // !muted`, and micStream deliberately SURVIVES here (the lane stays up so the
+  // mesh needs no renegotiation). That makes _micLive the only variable left
+  // that can express "no device is capturing" — and without this line it stayed
+  // true, so micOn() reported an open mic after a release. toggleMic() then took
+  // its already-on branch and muted a lane with nothing behind it instead of
+  // reacquiring the device: the mic button silently stopped working after any
+  // release, and getUserMedia was never called again.
+  //
+  // This is a STATE correction, not a teardown. Nothing is stopped here that
+  // wasn't already stopped four lines up; the graph, the senders and the track
+  // all stay exactly where they are.
+  _micLive = false;
+  _micReleased = true;
+  muted = false;
+  stopOnsetWatch();
+  for (const [id, p] of [...peers]) {
+    try {
+      for (const sender of p.pc.getSenders()) if (sender.track) p.pc.removeTrack(sender);
+    } catch (e) { report('voice untrack', e); }
+    // 🔴 DO NOT DESTROY THE PEER. This used to dropPeer() when receive was off —
+    // the same mistake as tearing down on 'disconnected', with a different
+    // trigger: we close the connection, the FAR END keeps a live pc to a peer
+    // that no longer exists, and neither side can recover. Ours cannot rebuild
+    // (both rebuild paths need a mic we just released); theirs will not, because
+    // they still hold us in `peers` so their reconciler skips us.
+    //
+    // Wanting neither to send nor receive is a DIRECTION ('inactive'), not a
+    // reason to hang up. renegotiate() carries that, the mesh stays warm, and
+    // consenting again is a renegotiation instead of a rebuild.
+    renegotiate(id);
+  }
+  flashHint('🎙 released');
+  bus.emit('voice', { on: false });
 }
 
 export function initVoice(name) {
@@ -532,8 +912,11 @@ export function initVoice(name) {
   // review). A live mic re-offers on the roster event that follows.
   bus.on('participant-teardown', (id) => dropPeer(id));
   bus.on('roster', () => {
-    // arrivals get an offer while we're live; departures get torn down
-    if (micStream) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
+    // Arrivals get an offer while we're LIVE; departures get torn down.
+    // micOn(), not micStream: since mic-off keeps the stream and only disables
+    // the track, `micStream` is truthy while muted and would court strangers we
+    // have nothing to say to. Transmitting is the condition that matters.
+    if (micOn()) for (const id of humanIds()) if (!peers.has(id)) offerTo(id);
     for (const id of [...peers.keys()]) if (!remotes.has(id)) dropPeer(id);
   });
   // Two clocks on purpose. Distance is a slow fact — 300ms is plenty and
@@ -554,6 +937,58 @@ export function initVoice(name) {
       // human voice you had stopped attending to. (Field report from a live
       // desk test: a teardown-on-toggle cut the utterance mid-word.)
       p.wantVolume = isHushed() ? 0 : roll * volumeFor('voices');
+    }
+
+    // ── RECONCILE: the roster is the truth, the peer map is a cache ──────────
+    // 🔴 A REPAIR ONLY ONE ROLE CAN TRIGGER IS NOT A REPAIR. Both rebuild sites
+    // (mic-on, and the recvReady flip) require micStream — so a listener who
+    // joined MUTED, which is the default, could never rebuild a peer that
+    // vanished. That is the same asymmetry class as the disconnected/dropPeer
+    // bug: the two ends permanently disagree about whether a connection exists,
+    // and only one of them is able to do anything about it.
+    //
+    // This runs for everyone, mic or no mic. Someone in the roster with no peer
+    // is a hole; offerTo() builds a recvonly connection when we have no mic,
+    // which is exactly what a listener wants.
+    //
+    // Cheap by construction: it is a set difference over a handful of ids on a
+    // loop that already walks the peers, and offerTo() is a no-op once the peer
+    // exists. Deliberately NOT dropping peers absent from the roster — a peer
+    // missing from a momentarily-stale roster must not be torn down, which is
+    // the mistake this whole file is recovering from.
+    for (const id of humanIds()) {
+      if (peers.has(id)) continue;
+      // Only offer to ids that outrank us, or we and a peer who is ALSO
+      // reconciling both offer at once and manufacture glare every 300ms.
+      // The lower id offers; the higher waits to be offered to.
+      if ((myId ?? '') < id) offerTo(id);
+    }
+
+    // ── THE TIMEOUT THAT WAS NOT THERE ───────────────────────────────────────
+    // 🔴 `_offeredAt` was WRITTEN twice and READ nowhere; GLARE_GRACE_MS was
+    // declared and never used. Both are fossils of a stale-offer timeout that
+    // got removed when the glare test moved to `_everStable` — and nothing
+    // replaced the recovery it provided.
+    //
+    // So an offer that is simply never answered wedges FOREVER. Every existing
+    // heal path is reactive: they notice have-local-offer when something else
+    // arrives. If their tab was backgrounded, the sequencer dropped the
+    // point-to-point message, or they reloaded mid-exchange, nothing arrives —
+    // renegotiate() bails on non-stable, and the reconciler above skips us
+    // because peers.has(id) is true. The peer exists and is permanently deaf.
+    //
+    // A generous timeout: a real answer comes back in well under a second, so
+    // 12s is far past any legitimate round trip and only catches the dead.
+    for (const [id, p] of peers) {
+      if (p.pc.signalingState !== 'have-local-offer' || !p._offeredAt) continue;
+      if (Date.now() - p._offeredAt < 12000) continue;
+      p._offeredAt = null;
+      // Roll back to stable and re-offer rather than dropping the peer: the far
+      // end may be perfectly healthy and merely never have received our SDP.
+      // Tearing down here would be the disconnected/dropPeer mistake again.
+      p.pc.setLocalDescription({ type: 'rollback' })
+        .then(() => offerTo(id))
+        .catch((e) => report('voice stale offer', e));
     }
   }, 300);
   // LINEAR, not exponential. An exponential approach spends most of its life
@@ -652,3 +1087,156 @@ export function peerLevels() {
   }
   return out;
 }
+
+/** Sender-side truth for probes: what track, if any, each peer is actually
+ *  sending — id, readyState and enabled. Pair it with genTrackInfo() to answer
+ *  "am I feeding the track I am sending?", which no local success check can. */
+// A REBUILT SOURCE MUST REACH THE SENDERS. When the synthesizer's generator
+// dies and is re-made, the new track is a different object; every sender still
+// holds the dead one and transmits silence forever while ICE and direction look
+// perfectly healthy — indistinguishable from the audio:ended blocker seen in
+// the field. replaceTrack needs no renegotiation, so the repair is cheap and
+// safe in any signaling state.
+setGeneratorRebuildHook((track) => {
+  if (!micStream) return;
+  // Keep the local stream in step where it CAN be — a synthetic or stubbed
+  // source is not always a real MediaStream (the suite caught this hook
+  // throwing on removeTrack, inside the very recovery it exists to perform).
+  // Re-binding the senders is the part that matters; stream bookkeeping is not
+  // worth failing the repair for.
+  try {
+    if (typeof micStream.removeTrack === 'function' && typeof micStream.addTrack === 'function') {
+      for (const t of micStream.getTracks()) if (t !== track) micStream.removeTrack(t);
+      if (!micStream.getTracks().includes(track)) micStream.addTrack(track);
+    }
+  } catch (e) { report('voice stream rebind', e); }
+  for (const p of peers.values()) {
+    for (const s of p.pc.getSenders()) {
+      if (s.track && s.track.kind !== 'audio') continue;
+      s.replaceTrack(track).catch((e) => report('voice track rebind', e));
+    }
+  }
+});
+
+export function senderTrackInfo() {
+  const out = [];
+  for (const [id, p] of peers) {
+    for (const s of p.pc.getSenders()) {
+      if (s.track?.kind && s.track.kind !== 'audio') continue;
+      out.push({ peer: id, track: s.track
+        ? { id: s.track.id, readyState: s.track.readyState, enabled: s.track.enabled } : null });
+    }
+  }
+  return { micOn: micOn(), hasStream: !!micStream,
+    localTracks: micStream ? micStream.getTracks().map((t) => ({ id: t.id, readyState: t.readyState, enabled: t.enabled })) : [],
+    senders: out };
+}
+
+
+// ONE-WAY AUDIO IS A DIRECTION QUESTION, AND NOTHING ELSE COULD ANSWER IT.
+// R, 2026-08-09: Digi could hear her and she could not hear Digi; a full Chrome
+// restart FLIPPED which side was deaf. That flip is the whole diagnosis — a
+// symptom that swaps with join order lives in negotiation, not in the mic. But
+// every check we had (mic on? track live? peer connected?) reports fine on BOTH
+// sides of a one-way link, because each end is individually healthy.
+//
+// What is NOT observable without this: `direction` is the local preference and
+// `currentDirection` is what the WIRE actually agreed. They can disagree — that
+// is precisely what a direction set outside a renegotiation looks like — and
+// only currentDirection explains silence. Also dumps whether our sender has a
+// live track and whether the inbound track is enabled, since a track silenced by
+// a receive-toggle stays enabled=false forever and produces the same symptom.
+//
+// Paste voiceDiag() from both browsers; the asymmetry names the culprit.
+export function voiceDiag() {
+  const out = [];
+  for (const [id, p] of peers.entries()) {
+    const tx = [], rx = [];
+    for (const t of p.pc.getTransceivers?.() ?? []) {
+      const kind = t.receiver?.track?.kind || t.sender?.track?.kind;
+      if (kind && kind !== 'audio') continue;
+      tx.push(`want=${t.direction} wire=${t.currentDirection ?? '—'}`);
+      const st = t.sender?.track, rt = t.receiver?.track;
+      rx.push(`send:${st ? `${st.readyState}/${st.enabled ? 'on' : 'OFF'}` : 'none'}`
+        + ` recv:${rt ? `${rt.readyState}/${rt.enabled ? 'on' : 'OFF'}` : 'none'}`);
+    }
+    out.push({
+      peer: id,
+      signaling: p.pc.signalingState,
+      conn: p.pc.connectionState,
+      ice: p.pc.iceConnectionState,
+      everStable: !!p._everStable,
+      transceivers: tx,
+      tracks: rx,
+    });
+  }
+  return { me: myId, mic: micStream ? 'open' : 'CLOSED',
+    wantDirection: wantDirection(), peers: out };
+}
+/** WHY IS MY MIC NOT LIVE — the one question voiceDiag() cannot answer, because
+ *  a mic that silently became a synth generator looks identical to a healthy one
+ *  from every angle we had. R, 2026-08-09: "sometimes I toggle the mic and it
+ *  seems to be live and sometimes not, and it's just silently failing."
+ *
+ *  The decisive fact is WHAT KIND OF TRACK we are sending. A real microphone
+ *  track has a deviceId and a label from the OS; a MediaStreamTrackGenerator has
+ *  neither. Nothing else distinguishes them — same kind, same readyState, same
+ *  enabled. */
+/** Is there a microphone at all?
+ *
+ *  R, 2026-08-09: "maybe if there isn't a live mic detected, it can't be turned
+ *  on?" — which dissolves the objection I had to mic-beats-TTS. My worry was an
+ *  agent silently muted by a mic it never asked for; an agent has no capture
+ *  device, so with this guard the mic cannot be on and the case stops existing.
+ *
+ *  enumerateDevices() works BEFORE permission is granted: labels come back empty
+ *  until the user consents, but the entries are there, so presence can be
+ *  checked without prompting. Deliberately fails OPEN — if enumeration throws or
+ *  the API is missing we return true and let getUserMedia be the real gate,
+ *  because refusing a mic that exists is worse than offering one that does not.
+ */
+export async function hasMicDevice() {
+  try {
+    const devs = await navigator.mediaDevices?.enumerateDevices?.();
+    if (!devs) return true;
+    return devs.some((d) => d.kind === 'audioinput');
+  } catch { return true; }
+}
+
+export function micDiag() {
+  const raw = _rawMic?.getAudioTracks?.()[0] || null;
+  const sent = micStream?.getAudioTracks?.()[0] || null;
+  const settings = (t) => { try { return t?.getSettings?.() || {}; } catch { return {}; } };
+  const kindOf = (t) => {
+    if (!t) return 'none';
+    const s = settings(t);
+    // A real device reports a deviceId; a generator or a graph destination does not.
+    if (s.deviceId) return `microphone (${t.label || 'unnamed'})`;
+    return t.label ? `synthetic (${t.label})` : 'synthetic/graph output';
+  };
+  return {
+    micLive: micOn(), muted, gateOpen: gateOpenness() > 0.05,
+    rawSource: kindOf(raw),
+    sentToPeers: kindOf(sent),
+    rawEnabled: raw ? raw.enabled : null,
+    sentEnabled: sent ? sent.enabled : null,
+    // The tell: if these disagree about being a microphone, the mic silently
+    // became something else.
+    verdict: !raw ? 'NO DEVICE — nothing was ever opened'
+      : !sent ? 'no track being sent'
+      : /microphone/.test(kindOf(raw)) ? 'ok: a real microphone is the source'
+      : 'BROKEN: the source is not a microphone',
+  };
+}
+if (typeof window !== 'undefined') window.micDiag = micDiag;
+if (typeof window !== 'undefined') window.voiceDiag = voiceDiag;
+
+
+// Self-monitoring: hear your own GATED lane, exactly as the room hears it.
+// Exposed from voice.js so the panel has one import for everything voice-shaped,
+// and so a monitor can never outlive the mic it is monitoring.
+export function setSelfMonitor(on) {
+  if (on && !micStream) return false;     // nothing to monitor yet
+  return setMonitor(on);
+}
+export const selfMonitoring = () => monitoring();

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -541,8 +541,12 @@ export async function toggleMic(name) {
       // release costs ZERO renegotiation. Only build a new graph when there is
       // none — that rebuild is the "unmute lag while it sets it all up again"
       // R described.
-      const reused = _micReleased ? attachSource(rawMic) : null;
-      micStream = reused || gateStream(rawMic, micAnalyserLevel);
+      // A SYNTHETIC source bypasses the gate outright: no room noise to gate,
+      // and the gate's WebAudio graph cannot even carry it on a stalled clock
+      // (headless). The generator track goes on the senders as-is — frames as
+      // data, paced by the wall clock, exactly as designed.
+      const reused = rawMic.synthetic ? null : (_micReleased ? attachSource(rawMic) : null);
+      micStream = rawMic.synthetic ? rawMic : (reused || gateStream(rawMic, micAnalyserLevel));
       _micReleased = false;
     } catch (e) {
       report('microphone', e);

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -487,11 +487,11 @@ export async function toggleMic(name) {
       // asymmetric repair voicesource.js warns about two lines up from its own
       // mix site.
       import('./voicesource.js').then(async (vs) => {
-        if (!vs.isTtsEnabled?.() || !vs.canSynthesize?.()) return;
+        const sp = vs.synthProvider?.();
+        if (!sp?.available?.()) return;
         const m = await import('./micgate.js');
         if (!m.isGated?.()) return;              // no lane; voiceSource handles it
-        vs.startPacer?.();
-        m.mixSynthTrack(vs.ensureGenerator());
+        m.mixSynthTrack(sp.start());
       }).catch(() => {});
     return false;
   }

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -547,6 +547,15 @@ export async function toggleMic(name) {
       // data, paced by the wall clock, exactly as designed.
       const reused = rawMic.synthetic ? null : (_micReleased ? attachSource(rawMic) : null);
       micStream = rawMic.synthetic ? rawMic : (reused || gateStream(rawMic, micAnalyserLevel));
+      // B2: a null gate is a REFUSAL, not a fallback. Stop the device we just
+      // opened (no capture without a lane), tell the user the true state, and
+      // do not transmit. allowUngated(true) + retry is the explicit override.
+      if (!micStream) {
+        for (const t of rawMic.getTracks?.() ?? []) t.stop();
+        flashHint('voice gate unavailable — NOT transmitting (raw-mic override available in audio panel)');
+        bus.emit('voice-gate-unavailable', {});
+        return false;
+      }
       _micReleased = false;
     } catch (e) {
       report('microphone', e);

--- a/client/lib/voiceconsent.js
+++ b/client/lib/voiceconsent.js
@@ -23,7 +23,17 @@ const KEY = 'eido.audio.prefs';
 // so a refusal would be re-prompted on the next mic-on — turning a no into a
 // recurring negotiation, which is the opposite of asking once (review catch).
 const DEFAULTS = { recvVoice: false, volVoices: 1, volWorld: 0.6, volTts: 1, sttConsent: null,
-  micFloor: 0.04 };  // speech-onset gate: mic level below this is keyboard, not voice
+  // Sensitivity, not an absolute level: it scales the margin a sound must clear
+  // ABOVE the measured room noise (see onsetTick). 0.06 is the lowest value that
+  // took zero false triggers across 200 simulated room/noise combinations while
+  // never missing speech, so the slider has honest room in both directions.
+  // 60% = -24 dBFS. R's number, found by TESTING IT IN HER ROOM — "seems like
+  // 60% is a good place" — which beats my four earlier defaults, every one of
+  // them reasoned from published reference levels rather than measured against
+  // a real mic at a real gain. The slider is honest and 1:1 now, so anyone
+  // else's number is a drag away; this is a good place to start, not a claim
+  // about everyone's room.
+  micFloor: 0.12 };
 
 let prefs = { ...DEFAULTS };
 try {
@@ -123,3 +133,57 @@ function defaultAsk() {
     'Voice chat itself does NOT require this — you can talk without it.',
   ));
 }
+
+/** How many times the measured room noise a sound must be, to count as speech.
+ *
+ *  🔴 THE ONE DEFINITION. This formula lived in FOUR places (the gate, the gate's
+ *  own info dump, and two panel readouts) and had already drifted once — the
+ *  panel kept an old additive version after the gate went multiplicative, so the
+ *  two reported different thresholds (2026-08-09). Anything that needs it
+ *  imports it from here.
+ *
+ *  Range 1.5x…20x, widened after R found the old 5x ceiling too low: "even
+ *  someone talking in another room here is hitting 100% from time to time."
+ *  She was right — distant speech lands around 3-4x a quiet room's floor, so a
+ *  5x maximum left almost no rejection headroom, while her own voice clears the
+ *  floor by more than 30x. The top of the range is now genuinely strict and the
+ *  bottom still catches a whisper.
+ */
+// THE THRESHOLD IS A dB POSITION, not a multiplier over the room.
+//
+// R, after three rounds of the marker and the colour disagreeing: "maybe it's
+// time to search online for how other people have programmed mic sensitivity
+// sliders". Discord's model, and it is better than what I built:
+//
+//   • one widget, two jobs — the live level bar and the draggable threshold
+//     share one track, on a dB scale (roughly -60..0 dBFS)
+//   • the marker DOES NOT MOVE. The level moves past it.
+//   • colour by GATE STATE, not by level: below the marker is muted, above is
+//     live
+//
+// My room-relative version (level >= noise x k) meant the threshold moved as the
+// room changed — so drawing the marker where the gate opens made it slide away
+// from the cursor, and drawing it where the cursor was made the colour flip
+// somewhere else. There is no way to draw two coordinate systems as one mark.
+// A fixed dB threshold removes the conflict at the root rather than papering it.
+//
+// dB also fixes the crushed scale: on a linear RMS meter a quiet room and speech
+// are both jammed into the left edge, which is why the useful part of the slider
+// kept feeling like a sliver. In dB they are 25 points apart.
+
+/** The gate threshold in dBFS. 0% = -60 dB (everything), 100% = 0 dB (nothing).
+ *  Linear in dB, which is already logarithmic in amplitude — the standard shape
+ *  for this control, and the reason Discord's slider feels even end to end. */
+export const gateThresholdDb = () => -60 + Math.min(1, Math.max(0, prefs.micFloor / 0.2)) * 60;
+
+/** Same threshold as a linear amplitude, for comparing against an RMS reading. */
+export const gateThreshold = () => Math.pow(10, gateThresholdDb() / 20);
+
+/** dBFS of a linear amplitude, floored so silence does not become -Infinity. */
+export const toDb = (amp) => 20 * Math.log10(Math.max(amp, 1e-6));
+
+/** Where a level sits on the meter, 0..1 across the same -60..0 dB span the
+ *  threshold uses. ONE function for both, so the bar and the marker cannot
+ *  land in different places — that mismatch is this control's whole history. */
+export const meterPos = (amp) => Math.max(0, Math.min(1, (toDb(amp) + 60) / 60));
+

--- a/client/lib/voiceconsent.js
+++ b/client/lib/voiceconsent.js
@@ -186,4 +186,3 @@ export const toDb = (amp) => 20 * Math.log10(Math.max(amp, 1e-6));
  *  threshold uses. ONE function for both, so the bar and the marker cannot
  *  land in different places — that mismatch is this control's whole history. */
 export const meterPos = (amp) => Math.max(0, Math.min(1, (toDb(amp) + 60) / 60));
-

--- a/client/lib/voicesource.js
+++ b/client/lib/voicesource.js
@@ -20,6 +20,7 @@
 // with clients rather than with the room (R, 2026-08-08).
 
 import { report } from './core.js';
+import { audioContext } from './audioctx.js';
 
 // The registered TTS source. null = ordinary microphone.
 //   fn: (text: string) => Promise<{pcm: Int16Array, sampleRate: number}>
@@ -260,7 +261,10 @@ let pacer = null;
  *  round trip. Off for renderers/spectators, which have no business making
  *  noise.
  */
-let monitorCtx = null;
+// The sidetone plays through the PAGE's one AudioContext (audioctx.js), not a
+// private one. A second context here is exactly the disease #86 exists to cure:
+// it counts against Chrome's ~six-context cap and its output cannot compose with
+// the shared gain graph (distance, category sliders, ambient bed).
 let monitorOn = (() => {
   try { return localStorage.getItem('eido.ttsSidetone') !== 'off'; } catch { return true; }
 })();
@@ -275,7 +279,7 @@ export const sidetone = (on) => {
 function monitor(pcm, sampleRate) {
   if (!monitorOn || !pcm?.length) return;
   try {
-    monitorCtx ??= new (window.AudioContext || window.webkitAudioContext)();
+    const monitorCtx = audioContext();
     // A context created before a user gesture starts suspended; a resume() that
     // never lands must not throw away the sample.
     if (monitorCtx.state === 'suspended') void monitorCtx.resume();

--- a/client/lib/voicesource.js
+++ b/client/lib/voicesource.js
@@ -452,7 +452,13 @@ export async function voiceSource() {
     if (isTtsEnabled() && canSynthesize()) {
       const track = ensureGenerator();
       startPacer();
-      return new MediaStream([track]);
+      const ms = new MediaStream([track]);
+      // Mark it: this is a SYNTHETIC source, not a device. The caller must not
+      // wrap it in the WebAudio gate — a synth has no room noise to gate, and
+      // the gate graph hangs off an AudioContext whose clock is DEAD in every
+      // headless body (field-measured 2026-08-10: 'running', +0.000s/2s).
+      ms.synthetic = true;
+      return ms;
     }
     throw e;
   }

--- a/client/lib/voicesource.js
+++ b/client/lib/voicesource.js
@@ -1,0 +1,576 @@
+// voicesource — WHERE YOUR VOICE COMES FROM.
+//
+// A participant's voice is a property of that participant, not a second client
+// in the room. Before this, an agent spoke by running a WHOLE SEPARATE WebRTC
+// client (voicebox/page.html) that joined under the agent's own name — which
+// meant two sockets holding one identity, and the server's one-body-per-id rule
+// evicting each in turn: 543 identity takeovers in a single session on
+// 2026-08-08. Renaming that client is not the fix; not being a client is.
+//
+// So: voice.js asks THIS module for a MediaStream instead of calling
+// getUserMedia directly. Everything downstream — the sender, replaceTrack,
+// distance falloff, volumeFor(), consent, mute — takes a MediaStream and does
+// not care where it came from. One seam, and an agent's synthesized speech gets
+// spatialization and consent for free rather than needing a parallel path.
+//
+//   humans → getUserMedia (unchanged; the browser/OS default device)
+//   agents → a local TTS function, registered by whatever is driving the body
+//
+// LOCAL, always. Synthesis on the client costs the server nothing and scales
+// with clients rather than with the room (R, 2026-08-08).
+
+import { report } from './core.js';
+
+// The registered TTS source. null = ordinary microphone.
+//   fn: (text: string) => Promise<{pcm: Int16Array, sampleRate: number}>
+// A *function pointer*, deliberately: an agent points at its own synthesizer
+// and nothing here needs to know what produces the samples.
+let ttsFn = null;
+let ttsName = '';        // shown in the audio panel so it is never ambiguous
+let ttsEnabled = false;  // OFF by default — speaking is opt-in, like a mic
+
+let genTrack = null;     // the live MediaStreamTrackGenerator, if any
+let writer = null;
+
+export const ttsAvailable = () => !!ttsFn;
+export const ttsVoiceName = () => ttsName;
+export const isTtsEnabled = () => ttsEnabled && !!ttsFn;
+
+/** Point this body's mouth at a synthesizer. Called by an agent harness, never
+ *  by the UI. Passing null reverts to the microphone. */
+export function setTtsSource(fn, name = 'TTS') {
+  ttsFn = fn || null;
+  ttsName = fn ? name : '';
+  if (!fn) ttsEnabled = false;
+}
+
+// ── the human path to the SAME seam ─────────────────────────────────────────
+// A human picking a voice and an agent registering one MUST be the same call,
+// or the two drift and "how is that one speaking?" stops having one answer.
+// setTtsSource is that call for both; a UI is only ever a wrapper over it.
+//
+// 🔴 The browser's own speechSynthesis CANNOT be that source, and this is a
+// hard platform limit rather than something to work around. The Web Speech API
+// offers no route from speak() to an AudioNode, MediaStream or Blob — on Linux
+// synthesis does not even occur in the browser (speech-dispatcher over a
+// socket), so there is nothing to capture. The spec request to allow
+// SpeechSynthesis → MediaStreamTrack (WICG/speech-api#69) is still open and
+// unimplemented. A first draft here routed speak() through a
+// MediaStreamDestination + MediaRecorder; that records SILENCE, because
+// nothing is ever connected to the destination. It cannot be.
+//
+// So a human who wants a synthesized voice needs a source that RETURNS SAMPLES:
+//   • a local synthesizer over the same ws protocol piperbridge.js uses
+//   • an in-browser WASM TTS (Piper via onnxruntime-web, kokoro-js, sherpa-onnx)
+//   • a cloud TTS returning wav/mp3, decoded with decodeAudioData
+// All three are ordinary `(text) => {pcm, sampleRate}` functions and all three
+// go through setTtsSource unchanged. The seam is already symmetric; what a
+// human lacks is a bundled source, not a different API.
+//
+// The in-browser option is REAL and close: kokoro-js runs an 82M TTS entirely
+// client-side (WASM, or WebGPU where available) and tts.generate(text) hands
+// back samples — ~82MB cached after first load, 21 voices, no server and no
+// install. Piper-via-onnxruntime-web is the same shape (~75MB, VITS, ~0.03
+// realtime factor, first audio ~40ms). Either is a drop-in `(text) =>
+// {pcm, sampleRate}`; neither needs one line of this file to change.
+//
+// So the honest statement is narrow: the browser's BUILT-IN speechSynthesis
+// cannot feed the mic lane. Every other synthesizer can, including ones that
+// run in the same page. Do not read the paragraph above as "browsers cannot do
+// TTS into WebRTC" — they can, and this codebase already does it with Piper
+// over a socket (2.70s of audio in 0.08s, measured 2026-08-08).
+//
+// Until a source is bundled the UI row stays honest: toggle disabled, field
+// reads "system default (microphone)". No pretend voice picker.
+
+/** The audio panel's toggle. Humans leave this off and use a mic; an agent
+ *  turns it on once its source is registered. */
+export function setTtsEnabled(on) {
+  const was = ttsEnabled;
+  ttsEnabled = !!on && !!ttsFn;
+  // 🔴 EITHER ORDER MUST WORK. voiceSource() mixes the synth in when the mic
+  // opens — but enabling TTS AFTER the mic is already live used to just set a
+  // flag, so nothing was ever connected and speech went nowhere. That is the
+  // mirror of the bug this fixes, and shipping only one direction would be the
+  // asymmetric repair this codebase keeps producing. Wire (or unwire) it here
+  // too, so mic-then-TTS and TTS-then-mic reach the same place.
+  if (ttsEnabled !== was && typeof window !== 'undefined') {
+    import('./micgate.js').then(async (m) => {
+      if (!m.isGated?.()) return;              // no lane yet; voiceSource will do it
+        // MIC BEATS TTS: while a real microphone is live, synthesized speech does
+        // not join the lane at all (R, 2026-08-09). Ticking TTS with the mic on
+        // therefore arms it for LATER — the moment the mic goes off, voiceSource
+        // falls back to the generator with nothing to re-enable. Both directions
+        // handled here; fixing only one is the asymmetric repair the comment
+        // above warns about.
+        const micLive = (await import('./voice.js')).micOn?.();
+        if (ttsEnabled && canSynthesize() && !micLive) {
+          startPacer(); m.mixSynthTrack(ensureGenerator());
+        } else m.unmixSynth();
+    }).catch(() => {});
+  }
+  return ttsEnabled;
+}
+
+// ── the generator ───────────────────────────────────────────────────────────
+// MediaStreamTrackGenerator fed timestamped PCM at WALL-CLOCK pace. The pacing
+// is the load-bearing part and it is not ours: voicebox/page.html found that a
+// realtime AudioContext in a headless browser runs its clock at ~1% and stalls
+// mid-run. Frames as DATA, paced by the wall clock, is what fixed it there.
+//
+// Chromium-only today. Firefox has no MediaStreamTrackGenerator, so an agent
+// there falls back to the microphone path (i.e. stays silent) rather than
+// throwing — a missing voice must never take the body down with it.
+const CHUNK_MS = 20;
+
+export const canSynthesize = () => typeof MediaStreamTrackGenerator !== 'undefined';
+
+// Fired when a DEAD generator is replaced by a live one. The new track is a
+// different object, so every sender still holding the old one transmits silence
+// forever — ICE healthy, direction sendonly, nothing to see. voice.js listens
+// and replaceTrack()s it onto the existing senders (no renegotiation).
+// sourceIsDead() was written for exactly this and had ZERO callers, the same
+// way toggleMute did while the HUD called the destructive path.
+let onRebuild = null;
+export const setGeneratorRebuildHook = (fn) => { onRebuild = fn; };
+/** Test seam: fire the installed hook without having to kill a real generator
+ *  (MediaStreamTrackGenerator does not exist under happy-dom). */
+export const __fireRebuild = (track) => onRebuild?.(track);
+
+// Exported so the mic-off handover can wire the synth in (voice.js). Internal
+// to the module otherwise — nothing else should be minting generators.
+export function ensureGenerator() {
+  if (genTrack && genTrack.readyState === 'live') return genTrack;
+  const replacing = !!genTrack;
+  // An ENDED generator is not a dead end: make a new one and hand it back. The
+  // caller replaceTrack()s it onto the existing sender — no device, no
+  // permission prompt, no renegotiation. This is the recovery a microphone
+  // cannot offer, and the reason a TTS source is easier to keep alive than a
+  // mic (R, 2026-08-08).
+  genTrack = new MediaStreamTrackGenerator({ kind: 'audio' });
+  writer = genTrack.writable.getWriter();
+  if (replacing) {
+    console.warn('[voice] generator was dead — rebuilt; re-binding senders');
+    try { onRebuild?.(genTrack); } catch (e) { report('generator rebind', e); }
+  }
+  return genTrack;
+}
+
+/** Speak text through the registered synthesizer. Silent no-op when TTS is off
+ *  or unavailable — callers should not have to branch. */
+export async function speak(text) {
+  // EVERY REFUSAL SAYS WHY. This function had five silent `return false`
+  // paths, so "nothing came out" looked identical whether TTS was off, the
+  // sender was missing, or the synthesizer returned empty. A whole evening was
+  // spent unable to tell those apart (2026-08-08).
+  if (!isTtsEnabled()) { console.warn(`[voice] speak refused: tts off (enabled=${ttsEnabled} fn=${!!ttsFn})`); return false; }
+  // NO SINK IS NOT NO REASON TO SPEAK. This used to refuse outright, which meant
+  // a human who picked a voice and typed heard nothing until they also opened
+  // their mic — an unrelated control, and not one anybody would guess at. With
+  // sidetone we can still play it locally; only TRANSMISSION needs the lane.
+  // Say which of the two happened rather than silently doing half.
+  if (!canSynthesize() && !sidetone()) {
+    console.warn('[voice] speak refused: no generator sink and sidetone off');
+    return false;
+  }
+  console.log(`[voice] synthesizing ${text.length} chars…`);
+  let out;
+  try {
+    out = await ttsFn(text);
+  } catch (e) { report('tts synthesize', e); return false; }
+  if (!out?.pcm?.length) { console.warn('[voice] synthesizer returned no pcm'); return false; }
+    // 🔴 IS THE PCM ITSELF CLEAN? R, 2026-08-09: short utterances sound "badly
+    // compressed or staticy", long ones are perfect. That is NOT a prosody
+    // complaint — static means the SAMPLES are wrong, so measure them before the
+    // pacer can be blamed. Clipping and DC offset both sound like distortion and
+    // both show up in one pass; if these are clean, the fault is downstream.
+    {
+      const pcm = out.pcm;
+      let peak = 0, sum = 0, clipped = 0;
+      for (let i = 0; i < pcm.length; i++) {
+        const v = pcm[i]; const a = v < 0 ? -v : v;
+        if (a > peak) peak = a;
+        if (a >= 32767) clipped++;
+        sum += v;
+      }
+      const dc = sum / pcm.length;
+      console.log(`[voice] pcm: ${pcm.length} samples @${out.sampleRate}Hz `
+        + `peak ${(peak / 32768).toFixed(3)} (${(20 * Math.log10(peak / 32768 || 1e-9)).toFixed(1)} dBFS) `
+        + `dc ${(dc / 32768).toFixed(4)} clipped ${clipped}`
+        + (clipped > pcm.length * 0.001 ? '  ⚠️ CLIPPING' : '')
+        + (Math.abs(dc / 32768) > 0.01 ? '  ⚠️ DC OFFSET' : ''));
+    }
+  // QUEUE IT — DO NOT PUSH IT. The frames are handed to a wall-clock pacer that
+  // is already running; see the pacer below for why the track must never starve.
+  enqueue(out.pcm, out.sampleRate);
+  return true;
+}
+
+// ── the pacer: A MOUTH IS ALWAYS OPEN ──────────────────────────────────────
+// THE BUG THIS FIXES (2026-08-08): speak() used to write its frames in a tight
+// await loop and then stop. Between utterances the generator got NOTHING, so
+// the track was starved — and a starved MediaStreamTrackGenerator is not a
+// quiet microphone, it is a track with no media to encode. Every local check
+// passed (samples written, speak() returned true, sender bound, ICE connected)
+// and the room heard silence.
+//
+// The workbench rig got this right and I dropped it in the port: it runs a
+// 10ms pacer that writes exactly as many frames as wall time OWES, filling
+// them with speech when there is speech and with SILENCE when there is not, so
+// the track never starves. Speech is what fills the frames; the frames happen
+// regardless. That is what makes this behave like a microphone, which is the
+// entire point of the source design — a mic keeps producing silence when you
+// are not talking, and the mesh keeps carrying it.
+// 🔴 RESAMPLE TO 48k OURSELVES, ONCE, WITH A REAL FILTER.
+//
+// R, 2026-08-09: short utterances sound "badly compressed or staticy"; long ones
+// are fine. The pcm arriving from the model is CLEAN (measured: peak -3.4 dBFS,
+// dc -0.0009, 0 clipped), so the distortion is downstream — and the one lossy
+// step downstream is rate conversion. Piper emits 22050 Hz; WebRTC/Opus encodes
+// at 48000. 48000/22050 = 2.1768…, not an integer ratio, so a cheap linear
+// resampler aliases — worst on short bursts, where there is no steady signal for
+// it to settle into. Exactly the reported symptom.
+//
+// The monitor path does NOT have this problem because WebAudio resamples with a
+// proper filter. Same samples, two routes, one sounds right: that is the tell.
+//
+// So we hand WebRTC audio already at its native rate and skip its converter.
+const OUT_RATE = 48000;
+// (RATE_HINT is gone: the pacer now speaks ONE rate, OUT_RATE. Keeping a second
+// rate around was how 22050-sized frames got declared as 48k in my first pass.)
+const FRAME = Math.round(OUT_RATE / 50);   // 20ms at the OUTPUT rate
+let queue = [];            // pending {pcm, sampleRate}
+let qOff = 0;              // read offset into queue[0]
+let playhead = 0;          // samples emitted since the pacer started
+let t0 = 0;
+let pacer = null;
+
+/** SIDETONE — hearing your own synthesized voice.
+ *
+ *  R, 2026-08-09: "I don't hear anything when I type into the chat box. Hearing
+ *  yourself as a human using TTS is half the fun."
+ *
+ *  She is right, and the omission was structural: speak() feeds the SENDER, so
+ *  the samples go to the room and never to your own speakers. Everyone else
+ *  hears you; you are the one person who cannot. (Telephony calls this
+ *  sidetone, and leaves it in deliberately — a line with none sounds dead.)
+ *
+ *  A separate AudioContext path, not a loopback of the peer connection: we own
+ *  the PCM before it is paced onto the track, so this stays exact and adds no
+ *  round trip. Off for renderers/spectators, which have no business making
+ *  noise.
+ */
+let monitorCtx = null;
+let monitorOn = (() => {
+  try { return localStorage.getItem('eido.ttsSidetone') !== 'off'; } catch { return true; }
+})();
+export const sidetone = (on) => {
+  if (on !== undefined) {
+    monitorOn = !!on;
+    try { localStorage.setItem('eido.ttsSidetone', on ? 'on' : 'off'); } catch { /* private mode */ }
+  }
+  return monitorOn;
+};
+
+function monitor(pcm, sampleRate) {
+  if (!monitorOn || !pcm?.length) return;
+  try {
+    monitorCtx ??= new (window.AudioContext || window.webkitAudioContext)();
+    // A context created before a user gesture starts suspended; a resume() that
+    // never lands must not throw away the sample.
+    if (monitorCtx.state === 'suspended') void monitorCtx.resume();
+    const buf = monitorCtx.createBuffer(1, pcm.length, sampleRate);
+    const ch = buf.getChannelData(0);
+    for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
+    const src = monitorCtx.createBufferSource();
+    const g = monitorCtx.createGain();
+    // Slightly under unity: your own voice should sit behind the room, the way
+    // sidetone always does, rather than competing with it.
+    g.gain.value = 0.8;
+    src.buffer = buf;
+    src.connect(g).connect(monitorCtx.destination);
+    src.start();
+  } catch (e) { console.warn('[voice] sidetone failed (still transmitting):', e?.message || e); }
+}
+
+/** Resample to OUT_RATE with WebAudio's own (good) resampler, so the browser's
+ *  WebRTC path never has to do it with a cheap one.
+ *
+ *  OfflineAudioContext resamples on render — the same filter the monitor path
+ *  gets for free, which is why the monitor sounds right and the sent audio does
+ *  not. Async, so callers queue the RESULT rather than the raw pcm. */
+async function toOutRate(pcm, inRate) {
+  // 🔴 SWITCHABLE, because I added this stage on a theory that later turned out
+  // to be the WRONG explanation for the symptom it was meant to fix (the real
+  // cause of bad short utterances was missing terminal punctuation —
+  // rhasspy/piper#252). Resampling myself may be a genuine improvement, a no-op,
+  // or a SECOND resample on top of the browser's own — I never verified which,
+  // which is exactly the mistake this file keeps recording.
+  //   localStorage.eidoTtsResample = 'off'   → hand WebRTC the native rate
+  // A/B it by ear; the probe below prints what each path produces.
+  try {
+    if (localStorage.getItem('eidoTtsResample') === 'off') {
+      const f = new Float32Array(pcm.length);
+      for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
+      return f;
+    }
+  } catch { /* private mode */ }
+  if (inRate === OUT_RATE) {
+    const f = new Float32Array(pcm.length);
+    for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
+    return f;
+  }
+  const Ctx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+  if (!Ctx) {                                  // no offline context: send as-is
+    const f = new Float32Array(pcm.length);
+    for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
+    return f;
+  }
+  const outLen = Math.ceil((pcm.length * OUT_RATE) / inRate);
+  const ctx = new Ctx(1, outLen, OUT_RATE);
+  const buf = ctx.createBuffer(1, pcm.length, inRate);
+  const ch = buf.getChannelData(0);
+  for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.connect(ctx.destination);
+  src.start();
+  const rendered = await ctx.startRendering();
+  const outCh = rendered.getChannelData(0);
+  // Same measurement the pcm probe makes, one stage later. Clean in + dirty out
+  // here would be conclusive; matching stats mean the resampler is exonerated
+  // and the fault is further down (pacer, generator, or Opus).
+  {
+    let peak = 0, sum = 0;
+    for (let i = 0; i < outCh.length; i++) { const a = Math.abs(outCh[i]); if (a > peak) peak = a; sum += a * a; }
+    console.log(`[voice] resampled ${pcm.length}@${inRate} → ${outCh.length}@${OUT_RATE} `
+      + `peak ${peak.toFixed(3)} rms ${Math.sqrt(sum / (outCh.length || 1)).toFixed(4)}`
+      + (peak > 0.999 ? '  ⚠️ CLIPPING INTRODUCED' : ''));
+  }
+  return outCh;
+}
+
+
+function enqueue(pcm, sampleRate) {
+  monitor(pcm, sampleRate);          // hear yourself, then send
+  // Deliberately NOT gated on having a sender. Two traps I walked into here:
+  // canSynthesize() tests browser SUPPORT for MediaStreamTrackGenerator (not an
+  // open lane), and `genTrack` is CREATED by ensureGenerator() inside
+  // startPacer() — so gating on either would block the first utterance and stop
+  // the generator from ever being built. The pacer's own `if (!writer) return`
+  // already makes a senderless queue harmless; it drains once a lane exists.
+  if (!canSynthesize()) return;
+  // Resample BEFORE queueing so the pacer only ever handles OUT_RATE floats and
+  // the frame math has exactly one rate in it.
+  void toOutRate(pcm, sampleRate).then((f) => { queue.push(f); }).catch((e) => report('resample', e));
+  return;
+  queue.push({ pcm, sampleRate });
+  startPacer();
+}
+
+/** Drain the queue into one frame; zeros when there is nothing to say. */
+function fillSpeech(out) {
+  let i = 0;
+  while (i < out.length) {
+    const head = queue[0];
+    if (!head) break;                       // nothing queued → leave silence
+    const src = head;                       // already Float32 at OUT_RATE
+    const n = Math.min(out.length - i, src.length - qOff);
+    for (let k = 0; k < n; k++) out[i + k] = src[qOff + k];
+    i += n; qOff += n;
+    if (qOff >= src.length) { queue.shift(); qOff = 0; }
+  }
+}
+
+export function startPacer() {
+  if (pacer) return;
+  ensureGenerator();
+  t0 = performance.now();
+  playhead = 0;
+  pacer = setInterval(() => {
+    if (!writer) return;
+    const owed = Math.floor(((performance.now() - t0) / 1000) * OUT_RATE) - playhead;
+    for (let n = 0; n + FRAME <= owed; n += FRAME) {
+      const data = new Float32Array(FRAME);
+      fillSpeech(data);
+      try {
+        writer.write(new AudioData({
+          format: 'f32', sampleRate: OUT_RATE, numberOfFrames: FRAME,
+          numberOfChannels: 1, timestamp: Math.round((playhead / OUT_RATE) * 1e6), data,
+        }));
+      } catch (e) { report('tts write', e); }
+      playhead += FRAME;
+    }
+  }, 10);
+}
+
+/** Stop pacing (releases the interval). The track stays live. */
+export function stopPacer() {
+  if (pacer) { clearInterval(pacer); pacer = null; }
+  queue = []; qOff = 0;
+}
+
+/** Probe seam: is the mouth open, and how much is waiting to be said? */
+export const mouthInfo = () => ({ pacing: !!pacer, queued: queue.length, playhead });
+
+/** What voice.js calls instead of getUserMedia. Returns a MediaStream from
+ *  whichever source this body uses. */
+export async function voiceSource() {
+  // 🔴 NOT AN EITHER/OR ANY MORE. This used to return the synthesizer INSTEAD of
+  // the microphone whenever TTS was on — an agent-shaped assumption (a synth
+  // replaces a mouth) that silently broke every human who enabled TTS before
+  // opening their mic: the mesh got a generator, forever, and every check
+  // reported healthy (R, 2026-08-09).
+  //
+  // A body has ONE mic. If this machine has no microphone at all — an agent —
+  // the generator IS the source. Otherwise the mic is the source and synthesized
+  // speech is MIXED into the same lane past the gate (see micgate.mixSynthTrack),
+  // because a synth is not a replacement for a mouth; it is another thing making
+  // sound in the same room.
+  try {
+    const mic = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true },
+    });
+      // 🔴 A LIVE MIC WINS OUTRIGHT — it does not share the lane (R, 2026-08-09).
+      // This used to MIX synthesized speech into the mic's lane, on the theory
+      // that a synth is "another thing making sound in the same room". But
+      // nobody wants both: a human with a working mic just talks. Mic on means
+      // your own voice, full stop; mic off drops straight back to TTS with
+      // nothing to re-enable, because the TTS setting is left STANDING rather
+      // than cleared — that is what makes this a priority, not a toggle.
+      // The generator is deliberately not started: an idle pacer feeding a lane
+      // that will not carry it is pure cost.
+    return mic;
+  } catch (e) {
+    // No microphone, or permission refused. If we can synthesize, that is the
+    // whole voice — this is the agent path, and the path a human takes when they
+    // have no mic but still want to be heard.
+    if (isTtsEnabled() && canSynthesize()) {
+      const track = ensureGenerator();
+      startPacer();
+      return new MediaStream([track]);
+    }
+    throw e;
+  }
+}
+
+/** True when the current source's track has died and needs re-making. The
+ *  liveness check nothing was doing — an `audio:ended` sender transmits
+ *  silence forever while ICE and direction both look perfectly healthy. */
+export function sourceIsDead(stream) {
+  const t = stream?.getAudioTracks?.()[0];
+  return !!t && t.readyState === 'ended';
+}
+
+// ── speak your own says ─────────────────────────────────────────────────────
+// world.js already emits 'speech' for every say that was not already performed
+// (args.spoken marks the ones a voice paced itself, so this cannot
+// double-speak). A body with a synthesizer listens for its OWN and voices it:
+// that is the entire bridge from "posted text" to "made a sound", and it runs
+// through the ordinary sender, so distance, the category slider and consent all
+// apply exactly as they do to a microphone.
+export function speakOwnSays(bus, myId) {
+  bus.on('speech', ({ actor, text }) => {
+    const mine = actor === myId();
+    if (!mine) return;                       // someone else's say: not ours to voice
+    if (!isTtsEnabled()) { console.warn(`[voice] own say NOT spoken — tts disabled`); return; }
+    console.log(`[voice] own say → speaking: "${String(text).slice(0, 60)}"`);
+    void speak(text);
+  });
+}
+
+/** THE ONE QUESTION A SILENT VOICE CANNOT ANSWER FROM INSIDE: is the track we
+ *  are feeding the same object the peer connection is sending? speak() can
+ *  return true — synthesized, written, no errors — while the samples pour into
+ *  an orphan generator because the mic lane opened from a different source.
+ *  Every local check still passes and the room hears nothing. This exposes the
+ *  identity so a probe can compare it against the sender's track. */
+export const genTrackInfo = () => (genTrack
+  ? { id: genTrack.id, kind: genTrack.kind, readyState: genTrack.readyState, enabled: genTrack.enabled }
+  : null);
+
+
+
+/** Benchmark the current voice: N runs of the same text, reporting the spread.
+ *
+ *  Exists because every latency claim today has been settled by measurement and
+ *  none by argument. Run it, switch backend, run it again:
+ *
+ *      await ttsBench('hello')                     // current backend
+ *      localStorage.eidoTtsBackend = 'wasm'        // then reload and re-run
+ *
+ *  Reports P50 and best rather than a mean: a mean over 5 runs hides the one
+ *  slow first call that the user actually feels.
+ */
+export async function ttsTTFS(text = 'hello there, this is a test', runs = 3) {
+  // 🔴 TIME TO FIRST SOUND — the number a LISTENER experiences, which is not the
+  // same as `infer`. R, 2026-08-09: "as long as you can load your own models from
+  // your end you ought to be able to poll time to first sound, since TTS is wired
+  // to be able to hear yourself." Exactly: self-monitoring makes an agent its own
+  // measurement instrument, no human in the loop.
+  //
+  // TTFS = phonemize + infer + everything between the call and audio existing.
+  // Optimising `infer` alone can move that number not at all, which is precisely
+  // the mistake this whole evening kept making at a different layer.
+  if (!isTtsEnabled() || !ttsFn) { console.warn('[ttfs] no voice loaded'); return null; }
+  const out = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    const r = await ttsFn(text);
+    const ttfs = performance.now() - t0;
+    const secs = (r?.pcm?.length || 0) / (r?.sampleRate || 22050);
+    out.push({ ttfs, secs });
+  }
+  out.sort((a, b) => a.ttfs - b.ttfs);
+  const p50 = out[Math.floor(out.length / 2)];
+  console.log(`[ttfs] ${JSON.stringify(text)} ×${runs}: `
+    + `best ${Math.round(out[0].ttfs)}ms · P50 ${Math.round(p50.ttfs)}ms `
+    + `→ ${p50.secs.toFixed(2)}s audio · RTF ${(p50.ttfs / 1000 / Math.max(p50.secs, 1e-6)).toFixed(3)}`);
+  return { best: out[0].ttfs, p50: p50.ttfs, secs: p50.secs };
+}
+if (typeof window !== 'undefined') window.ttsTTFS = ttsTTFS;
+
+export async function ttsBench(text = 'hello', runs = 5) {
+  if (!isTtsEnabled() || !ttsFn) { console.warn('[bench] no voice loaded'); return null; }
+  const ms = [];
+  let secs = 0;
+  for (let i = 0; i < runs; i++) {
+    const t = performance.now();
+    const out = await ttsFn(text);
+    ms.push(performance.now() - t);
+    secs = (out?.pcm?.length || 0) / (out?.sampleRate || 22050);
+  }
+  ms.sort((a, b) => a - b);
+  const p50 = ms[Math.floor(ms.length / 2)];
+  console.log(`[bench] ${JSON.stringify(text)} ×${runs}: `
+    + `best ${Math.round(ms[0])}ms · P50 ${Math.round(p50)}ms · worst ${Math.round(ms.at(-1))}ms `
+    + `→ ${secs.toFixed(2)}s audio · RTF ${(p50 / 1000 / Math.max(secs, 1e-6)).toFixed(3)}`);
+  return { best: ms[0], p50, worst: ms.at(-1), secs };
+}
+if (typeof window !== 'undefined') window.ttsBench = ttsBench;
+
+
+/** Speak the same text N times so you can hear the SPREAD, not one sample.
+ *
+ *  R, 2026-08-09, found the need for this with a one-character test: two strings
+ *  that phonemize identically sounded different, because VITS samples noise on
+ *  every call. Judging a voice from one utterance is judging one draw.
+ */
+export async function ttsSpread(text = 'hello there', runs = 5) {
+  if (!isTtsEnabled() || !ttsFn) { console.warn('[spread] no voice loaded'); return null; }
+  const rows = [];
+  for (let i = 0; i < runs; i++) {
+    const r = await ttsFn(text);
+    const pcm = r?.pcm || [];
+    let peak = 0, sum = 0;
+    for (let k = 0; k < pcm.length; k++) { const a = Math.abs(pcm[k]); if (a > peak) peak = a; sum += a * a; }
+    rows.push({ n: pcm.length, peak: peak / 32768, rms: Math.sqrt(sum / (pcm.length || 1)) / 32768 });
+  }
+  const lens = rows.map((r) => r.n);
+  const spread = (Math.max(...lens) - Math.min(...lens)) / Math.max(...lens) * 100;
+  console.log(`[spread] ${JSON.stringify(text)} ×${runs}: `
+    + `${Math.min(...lens)}-${Math.max(...lens)} samples (${spread.toFixed(1)}% length spread)`);
+  rows.forEach((r, i) => console.log(`  run ${i + 1}: ${r.n} samples  peak ${r.peak.toFixed(3)}  rms ${r.rms.toFixed(4)}`));
+  return { spread, rows };
+}
+if (typeof window !== 'undefined') window.ttsSpread = ttsSpread;

--- a/client/lib/voicesource.js
+++ b/client/lib/voicesource.js
@@ -14,444 +14,59 @@
 // spatialization and consent for free rather than needing a parallel path.
 //
 //   humans → getUserMedia (unchanged; the browser/OS default device)
-//   agents → a local TTS function, registered by whatever is driving the body
+//   agents → a SYNTH PROVIDER, registered by whatever is driving the body
 //
-// LOCAL, always. Synthesis on the client costs the server nothing and scales
-// with clients rather than with the room (R, 2026-08-08).
+// This module deliberately contains NO synthesizer (#90 review, 2026-08-11):
+// it is the seam, not the mouth. A provider hands over a finished
+// MediaStreamTrack — how the samples are made (generator, pacer, TTS engine,
+// test stub) is entirely the provider's business, and lives in its own module.
 
 import { report } from './core.js';
-import { audioContext } from './audioctx.js';
 
-// The registered TTS source. null = ordinary microphone.
-//   fn: (text: string) => Promise<{pcm: Int16Array, sampleRate: number}>
-// A *function pointer*, deliberately: an agent points at its own synthesizer
-// and nothing here needs to know what produces the samples.
-let ttsFn = null;
-let ttsName = '';        // shown in the audio panel so it is never ambiguous
-let ttsEnabled = false;  // OFF by default — speaking is opt-in, like a mic
+// ── the synth-provider contract ──────────────────────────────────────────────
+// {
+//   available(): boolean            — can this provider produce a track NOW
+//   start(): MediaStreamTrack       — begin producing; returns the live track
+//   stop(): void                    — cease producing (track may end)
+//   label?: string                  — shown in the audio panel
+// }
+// One provider, replaceable. null = this body has no synthetic voice.
+let provider = null;
 
-let genTrack = null;     // the live MediaStreamTrackGenerator, if any
-let writer = null;
-
-export const ttsAvailable = () => !!ttsFn;
-export const ttsVoiceName = () => ttsName;
-export const isTtsEnabled = () => ttsEnabled && !!ttsFn;
-
-/** Point this body's mouth at a synthesizer. Called by an agent harness, never
- *  by the UI. Passing null reverts to the microphone. */
-export function setTtsSource(fn, name = 'TTS') {
-  ttsFn = fn || null;
-  ttsName = fn ? name : '';
-  if (!fn) ttsEnabled = false;
+export function setSynthProvider(p) {
+  provider = p || null;
+  return provider;
 }
+export const synthProvider = () => provider;
 
-// ── the human path to the SAME seam ─────────────────────────────────────────
-// A human picking a voice and an agent registering one MUST be the same call,
-// or the two drift and "how is that one speaking?" stops having one answer.
-// setTtsSource is that call for both; a UI is only ever a wrapper over it.
-//
-// 🔴 The browser's own speechSynthesis CANNOT be that source, and this is a
-// hard platform limit rather than something to work around. The Web Speech API
-// offers no route from speak() to an AudioNode, MediaStream or Blob — on Linux
-// synthesis does not even occur in the browser (speech-dispatcher over a
-// socket), so there is nothing to capture. The spec request to allow
-// SpeechSynthesis → MediaStreamTrack (WICG/speech-api#69) is still open and
-// unimplemented. A first draft here routed speak() through a
-// MediaStreamDestination + MediaRecorder; that records SILENCE, because
-// nothing is ever connected to the destination. It cannot be.
-//
-// So a human who wants a synthesized voice needs a source that RETURNS SAMPLES:
-//   • a local synthesizer over the same ws protocol piperbridge.js uses
-//   • an in-browser WASM TTS (Piper via onnxruntime-web, kokoro-js, sherpa-onnx)
-//   • a cloud TTS returning wav/mp3, decoded with decodeAudioData
-// All three are ordinary `(text) => {pcm, sampleRate}` functions and all three
-// go through setTtsSource unchanged. The seam is already symmetric; what a
-// human lacks is a bundled source, not a different API.
-//
-// The in-browser option is REAL and close: kokoro-js runs an 82M TTS entirely
-// client-side (WASM, or WebGPU where available) and tts.generate(text) hands
-// back samples — ~82MB cached after first load, 21 voices, no server and no
-// install. Piper-via-onnxruntime-web is the same shape (~75MB, VITS, ~0.03
-// realtime factor, first audio ~40ms). Either is a drop-in `(text) =>
-// {pcm, sampleRate}`; neither needs one line of this file to change.
-//
-// So the honest statement is narrow: the browser's BUILT-IN speechSynthesis
-// cannot feed the mic lane. Every other synthesizer can, including ones that
-// run in the same page. Do not read the paragraph above as "browsers cannot do
-// TTS into WebRTC" — they can, and this codebase already does it with Piper
-// over a socket (2.70s of audio in 0.08s, measured 2026-08-08).
-//
-// Until a source is bundled the UI row stays honest: toggle disabled, field
-// reads "system default (microphone)". No pretend voice picker.
-
-/** The audio panel's toggle. Humans leave this off and use a mic; an agent
- *  turns it on once its source is registered. */
-export function setTtsEnabled(on) {
-  const was = ttsEnabled;
-  ttsEnabled = !!on && !!ttsFn;
-  // 🔴 EITHER ORDER MUST WORK. voiceSource() mixes the synth in when the mic
-  // opens — but enabling TTS AFTER the mic is already live used to just set a
-  // flag, so nothing was ever connected and speech went nowhere. That is the
-  // mirror of the bug this fixes, and shipping only one direction would be the
-  // asymmetric repair this codebase keeps producing. Wire (or unwire) it here
-  // too, so mic-then-TTS and TTS-then-mic reach the same place.
-  if (ttsEnabled !== was && typeof window !== 'undefined') {
-    import('./micgate.js').then(async (m) => {
-      if (!m.isGated?.()) return;              // no lane yet; voiceSource will do it
-        // MIC BEATS TTS: while a real microphone is live, synthesized speech does
-        // not join the lane at all (R, 2026-08-09). Ticking TTS with the mic on
-        // therefore arms it for LATER — the moment the mic goes off, voiceSource
-        // falls back to the generator with nothing to re-enable. Both directions
-        // handled here; fixing only one is the asymmetric repair the comment
-        // above warns about.
-        const micLive = (await import('./voice.js')).micOn?.();
-        if (ttsEnabled && canSynthesize() && !micLive) {
-          startPacer(); m.mixSynthTrack(ensureGenerator());
-        } else m.unmixSynth();
-    }).catch(() => {});
-  }
-  return ttsEnabled;
-}
-
-// ── the generator ───────────────────────────────────────────────────────────
-// MediaStreamTrackGenerator fed timestamped PCM at WALL-CLOCK pace. The pacing
-// is the load-bearing part and it is not ours: voicebox/page.html found that a
-// realtime AudioContext in a headless browser runs its clock at ~1% and stalls
-// mid-run. Frames as DATA, paced by the wall clock, is what fixed it there.
-//
-// Chromium-only today. Firefox has no MediaStreamTrackGenerator, so an agent
-// there falls back to the microphone path (i.e. stays silent) rather than
-// throwing — a missing voice must never take the body down with it.
-const CHUNK_MS = 20;
-
-export const canSynthesize = () => typeof MediaStreamTrackGenerator !== 'undefined';
-
-// Fired when a DEAD generator is replaced by a live one. The new track is a
-// different object, so every sender still holding the old one transmits silence
-// forever — ICE healthy, direction sendonly, nothing to see. voice.js listens
-// and replaceTrack()s it onto the existing senders (no renegotiation).
-// sourceIsDead() was written for exactly this and had ZERO callers, the same
-// way toggleMute did while the HUD called the destructive path.
+// ── track-change notification ────────────────────────────────────────────────
+// If a provider must rebuild its track (its generator died, its engine
+// restarted), it calls notifySynthTrackChanged(newTrack); voice.js re-binds
+// every sender. The hook survives from the pre-split module under its old
+// name so the call site's diff stays honest.
 let onRebuild = null;
 export const setGeneratorRebuildHook = (fn) => { onRebuild = fn; };
-/** Test seam: fire the installed hook without having to kill a real generator
- *  (MediaStreamTrackGenerator does not exist under happy-dom). */
-export const __fireRebuild = (track) => onRebuild?.(track);
-
-// Exported so the mic-off handover can wire the synth in (voice.js). Internal
-// to the module otherwise — nothing else should be minting generators.
-export function ensureGenerator() {
-  if (genTrack && genTrack.readyState === 'live') return genTrack;
-  const replacing = !!genTrack;
-  // An ENDED generator is not a dead end: make a new one and hand it back. The
-  // caller replaceTrack()s it onto the existing sender — no device, no
-  // permission prompt, no renegotiation. This is the recovery a microphone
-  // cannot offer, and the reason a TTS source is easier to keep alive than a
-  // mic (R, 2026-08-08).
-  genTrack = new MediaStreamTrackGenerator({ kind: 'audio' });
-  writer = genTrack.writable.getWriter();
-  if (replacing) {
-    console.warn('[voice] generator was dead — rebuilt; re-binding senders');
-    try { onRebuild?.(genTrack); } catch (e) { report('generator rebind', e); }
-  }
-  return genTrack;
-}
-
-/** Speak text through the registered synthesizer. Silent no-op when TTS is off
- *  or unavailable — callers should not have to branch. */
-export async function speak(text) {
-  // EVERY REFUSAL SAYS WHY. This function had five silent `return false`
-  // paths, so "nothing came out" looked identical whether TTS was off, the
-  // sender was missing, or the synthesizer returned empty. A whole evening was
-  // spent unable to tell those apart (2026-08-08).
-  if (!isTtsEnabled()) { console.warn(`[voice] speak refused: tts off (enabled=${ttsEnabled} fn=${!!ttsFn})`); return false; }
-  // NO SINK IS NOT NO REASON TO SPEAK. This used to refuse outright, which meant
-  // a human who picked a voice and typed heard nothing until they also opened
-  // their mic — an unrelated control, and not one anybody would guess at. With
-  // sidetone we can still play it locally; only TRANSMISSION needs the lane.
-  // Say which of the two happened rather than silently doing half.
-  if (!canSynthesize() && !sidetone()) {
-    console.warn('[voice] speak refused: no generator sink and sidetone off');
-    return false;
-  }
-  console.log(`[voice] synthesizing ${text.length} chars…`);
-  let out;
-  try {
-    out = await ttsFn(text);
-  } catch (e) { report('tts synthesize', e); return false; }
-  if (!out?.pcm?.length) { console.warn('[voice] synthesizer returned no pcm'); return false; }
-    // 🔴 IS THE PCM ITSELF CLEAN? R, 2026-08-09: short utterances sound "badly
-    // compressed or staticy", long ones are perfect. That is NOT a prosody
-    // complaint — static means the SAMPLES are wrong, so measure them before the
-    // pacer can be blamed. Clipping and DC offset both sound like distortion and
-    // both show up in one pass; if these are clean, the fault is downstream.
-    {
-      const pcm = out.pcm;
-      let peak = 0, sum = 0, clipped = 0;
-      for (let i = 0; i < pcm.length; i++) {
-        const v = pcm[i]; const a = v < 0 ? -v : v;
-        if (a > peak) peak = a;
-        if (a >= 32767) clipped++;
-        sum += v;
-      }
-      const dc = sum / pcm.length;
-      console.log(`[voice] pcm: ${pcm.length} samples @${out.sampleRate}Hz `
-        + `peak ${(peak / 32768).toFixed(3)} (${(20 * Math.log10(peak / 32768 || 1e-9)).toFixed(1)} dBFS) `
-        + `dc ${(dc / 32768).toFixed(4)} clipped ${clipped}`
-        + (clipped > pcm.length * 0.001 ? '  ⚠️ CLIPPING' : '')
-        + (Math.abs(dc / 32768) > 0.01 ? '  ⚠️ DC OFFSET' : ''));
-    }
-  // QUEUE IT — DO NOT PUSH IT. The frames are handed to a wall-clock pacer that
-  // is already running; see the pacer below for why the track must never starve.
-  enqueue(out.pcm, out.sampleRate);
-  return true;
-}
-
-// ── the pacer: A MOUTH IS ALWAYS OPEN ──────────────────────────────────────
-// THE BUG THIS FIXES (2026-08-08): speak() used to write its frames in a tight
-// await loop and then stop. Between utterances the generator got NOTHING, so
-// the track was starved — and a starved MediaStreamTrackGenerator is not a
-// quiet microphone, it is a track with no media to encode. Every local check
-// passed (samples written, speak() returned true, sender bound, ICE connected)
-// and the room heard silence.
-//
-// The workbench rig got this right and I dropped it in the port: it runs a
-// 10ms pacer that writes exactly as many frames as wall time OWES, filling
-// them with speech when there is speech and with SILENCE when there is not, so
-// the track never starves. Speech is what fills the frames; the frames happen
-// regardless. That is what makes this behave like a microphone, which is the
-// entire point of the source design — a mic keeps producing silence when you
-// are not talking, and the mesh keeps carrying it.
-// 🔴 RESAMPLE TO 48k OURSELVES, ONCE, WITH A REAL FILTER.
-//
-// R, 2026-08-09: short utterances sound "badly compressed or staticy"; long ones
-// are fine. The pcm arriving from the model is CLEAN (measured: peak -3.4 dBFS,
-// dc -0.0009, 0 clipped), so the distortion is downstream — and the one lossy
-// step downstream is rate conversion. Piper emits 22050 Hz; WebRTC/Opus encodes
-// at 48000. 48000/22050 = 2.1768…, not an integer ratio, so a cheap linear
-// resampler aliases — worst on short bursts, where there is no steady signal for
-// it to settle into. Exactly the reported symptom.
-//
-// The monitor path does NOT have this problem because WebAudio resamples with a
-// proper filter. Same samples, two routes, one sounds right: that is the tell.
-//
-// So we hand WebRTC audio already at its native rate and skip its converter.
-const OUT_RATE = 48000;
-// (RATE_HINT is gone: the pacer now speaks ONE rate, OUT_RATE. Keeping a second
-// rate around was how 22050-sized frames got declared as 48k in my first pass.)
-const FRAME = Math.round(OUT_RATE / 50);   // 20ms at the OUTPUT rate
-let queue = [];            // pending {pcm, sampleRate}
-let qOff = 0;              // read offset into queue[0]
-let playhead = 0;          // samples emitted since the pacer started
-let t0 = 0;
-let pacer = null;
-
-/** SIDETONE — hearing your own synthesized voice.
- *
- *  R, 2026-08-09: "I don't hear anything when I type into the chat box. Hearing
- *  yourself as a human using TTS is half the fun."
- *
- *  She is right, and the omission was structural: speak() feeds the SENDER, so
- *  the samples go to the room and never to your own speakers. Everyone else
- *  hears you; you are the one person who cannot. (Telephony calls this
- *  sidetone, and leaves it in deliberately — a line with none sounds dead.)
- *
- *  A separate AudioContext path, not a loopback of the peer connection: we own
- *  the PCM before it is paced onto the track, so this stays exact and adds no
- *  round trip. Off for renderers/spectators, which have no business making
- *  noise.
- */
-// The sidetone plays through the PAGE's one AudioContext (audioctx.js), not a
-// private one. A second context here is exactly the disease #86 exists to cure:
-// it counts against Chrome's ~six-context cap and its output cannot compose with
-// the shared gain graph (distance, category sliders, ambient bed).
-let monitorOn = (() => {
-  try { return localStorage.getItem('eido.ttsSidetone') !== 'off'; } catch { return true; }
-})();
-export const sidetone = (on) => {
-  if (on !== undefined) {
-    monitorOn = !!on;
-    try { localStorage.setItem('eido.ttsSidetone', on ? 'on' : 'off'); } catch { /* private mode */ }
-  }
-  return monitorOn;
+export const notifySynthTrackChanged = (track) => {
+  try { onRebuild?.(track); } catch (e) { report('synth track-change hook', e); }
 };
 
-function monitor(pcm, sampleRate) {
-  if (!monitorOn || !pcm?.length) return;
-  try {
-    const monitorCtx = audioContext();
-    // A context created before a user gesture starts suspended; a resume() that
-    // never lands must not throw away the sample.
-    if (monitorCtx.state === 'suspended') void monitorCtx.resume();
-    const buf = monitorCtx.createBuffer(1, pcm.length, sampleRate);
-    const ch = buf.getChannelData(0);
-    for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
-    const src = monitorCtx.createBufferSource();
-    const g = monitorCtx.createGain();
-    // Slightly under unity: your own voice should sit behind the room, the way
-    // sidetone always does, rather than competing with it.
-    g.gain.value = 0.8;
-    src.buffer = buf;
-    src.connect(g).connect(monitorCtx.destination);
-    src.start();
-  } catch (e) { console.warn('[voice] sidetone failed (still transmitting):', e?.message || e); }
-}
-
-/** Resample to OUT_RATE with WebAudio's own (good) resampler, so the browser's
- *  WebRTC path never has to do it with a cheap one.
- *
- *  OfflineAudioContext resamples on render — the same filter the monitor path
- *  gets for free, which is why the monitor sounds right and the sent audio does
- *  not. Async, so callers queue the RESULT rather than the raw pcm. */
-async function toOutRate(pcm, inRate) {
-  // 🔴 SWITCHABLE, because I added this stage on a theory that later turned out
-  // to be the WRONG explanation for the symptom it was meant to fix (the real
-  // cause of bad short utterances was missing terminal punctuation —
-  // rhasspy/piper#252). Resampling myself may be a genuine improvement, a no-op,
-  // or a SECOND resample on top of the browser's own — I never verified which,
-  // which is exactly the mistake this file keeps recording.
-  //   localStorage.eidoTtsResample = 'off'   → hand WebRTC the native rate
-  // A/B it by ear; the probe below prints what each path produces.
-  try {
-    if (localStorage.getItem('eidoTtsResample') === 'off') {
-      const f = new Float32Array(pcm.length);
-      for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
-      return f;
-    }
-  } catch { /* private mode */ }
-  if (inRate === OUT_RATE) {
-    const f = new Float32Array(pcm.length);
-    for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
-    return f;
-  }
-  const Ctx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
-  if (!Ctx) {                                  // no offline context: send as-is
-    const f = new Float32Array(pcm.length);
-    for (let i = 0; i < pcm.length; i++) f[i] = pcm[i] / 32768;
-    return f;
-  }
-  const outLen = Math.ceil((pcm.length * OUT_RATE) / inRate);
-  const ctx = new Ctx(1, outLen, OUT_RATE);
-  const buf = ctx.createBuffer(1, pcm.length, inRate);
-  const ch = buf.getChannelData(0);
-  for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
-  const src = ctx.createBufferSource();
-  src.buffer = buf;
-  src.connect(ctx.destination);
-  src.start();
-  const rendered = await ctx.startRendering();
-  const outCh = rendered.getChannelData(0);
-  // Same measurement the pcm probe makes, one stage later. Clean in + dirty out
-  // here would be conclusive; matching stats mean the resampler is exonerated
-  // and the fault is further down (pacer, generator, or Opus).
-  {
-    let peak = 0, sum = 0;
-    for (let i = 0; i < outCh.length; i++) { const a = Math.abs(outCh[i]); if (a > peak) peak = a; sum += a * a; }
-    console.log(`[voice] resampled ${pcm.length}@${inRate} → ${outCh.length}@${OUT_RATE} `
-      + `peak ${peak.toFixed(3)} rms ${Math.sqrt(sum / (outCh.length || 1)).toFixed(4)}`
-      + (peak > 0.999 ? '  ⚠️ CLIPPING INTRODUCED' : ''));
-  }
-  return outCh;
-}
-
-
-function enqueue(pcm, sampleRate) {
-  monitor(pcm, sampleRate);          // hear yourself, then send
-  // Deliberately NOT gated on having a sender. Two traps I walked into here:
-  // canSynthesize() tests browser SUPPORT for MediaStreamTrackGenerator (not an
-  // open lane), and `genTrack` is CREATED by ensureGenerator() inside
-  // startPacer() — so gating on either would block the first utterance and stop
-  // the generator from ever being built. The pacer's own `if (!writer) return`
-  // already makes a senderless queue harmless; it drains once a lane exists.
-  if (!canSynthesize()) return;
-  // Resample BEFORE queueing so the pacer only ever handles OUT_RATE floats and
-  // the frame math has exactly one rate in it.
-  void toOutRate(pcm, sampleRate).then((f) => { queue.push(f); }).catch((e) => report('resample', e));
-  return;
-  queue.push({ pcm, sampleRate });
-  startPacer();
-}
-
-/** Drain the queue into one frame; zeros when there is nothing to say. */
-function fillSpeech(out) {
-  let i = 0;
-  while (i < out.length) {
-    const head = queue[0];
-    if (!head) break;                       // nothing queued → leave silence
-    const src = head;                       // already Float32 at OUT_RATE
-    const n = Math.min(out.length - i, src.length - qOff);
-    for (let k = 0; k < n; k++) out[i + k] = src[qOff + k];
-    i += n; qOff += n;
-    if (qOff >= src.length) { queue.shift(); qOff = 0; }
-  }
-}
-
-export function startPacer() {
-  if (pacer) return;
-  ensureGenerator();
-  t0 = performance.now();
-  playhead = 0;
-  pacer = setInterval(() => {
-    if (!writer) return;
-    const owed = Math.floor(((performance.now() - t0) / 1000) * OUT_RATE) - playhead;
-    for (let n = 0; n + FRAME <= owed; n += FRAME) {
-      const data = new Float32Array(FRAME);
-      fillSpeech(data);
-      try {
-        writer.write(new AudioData({
-          format: 'f32', sampleRate: OUT_RATE, numberOfFrames: FRAME,
-          numberOfChannels: 1, timestamp: Math.round((playhead / OUT_RATE) * 1e6), data,
-        }));
-      } catch (e) { report('tts write', e); }
-      playhead += FRAME;
-    }
-  }, 10);
-}
-
-/** Stop pacing (releases the interval). The track stays live. */
-export function stopPacer() {
-  if (pacer) { clearInterval(pacer); pacer = null; }
-  queue = []; qOff = 0;
-}
-
-/** Probe seam: is the mouth open, and how much is waiting to be said? */
-export const mouthInfo = () => ({ pacing: !!pacer, queued: queue.length, playhead });
-
-/** What voice.js calls instead of getUserMedia. Returns a MediaStream from
- *  whichever source this body uses. */
+// ── the source ───────────────────────────────────────────────────────────────
 export async function voiceSource() {
-  // 🔴 NOT AN EITHER/OR ANY MORE. This used to return the synthesizer INSTEAD of
-  // the microphone whenever TTS was on — an agent-shaped assumption (a synth
-  // replaces a mouth) that silently broke every human who enabled TTS before
-  // opening their mic: the mesh got a generator, forever, and every check
-  // reported healthy (R, 2026-08-09).
-  //
-  // A body has ONE mic. If this machine has no microphone at all — an agent —
-  // the generator IS the source. Otherwise the mic is the source and synthesized
-  // speech is MIXED into the same lane past the gate (see micgate.mixSynthTrack),
-  // because a synth is not a replacement for a mouth; it is another thing making
-  // sound in the same room.
+  // A body has ONE mic, and a LIVE MIC WINS OUTRIGHT (R, 2026-08-09): mic on
+  // means your own voice, full stop; mic off drops back to the synth provider
+  // with nothing to re-enable, because the provider's enablement is left
+  // STANDING rather than cleared — a priority, not a toggle.
   try {
     const mic = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: true, noiseSuppression: true },
     });
-      // 🔴 A LIVE MIC WINS OUTRIGHT — it does not share the lane (R, 2026-08-09).
-      // This used to MIX synthesized speech into the mic's lane, on the theory
-      // that a synth is "another thing making sound in the same room". But
-      // nobody wants both: a human with a working mic just talks. Mic on means
-      // your own voice, full stop; mic off drops straight back to TTS with
-      // nothing to re-enable, because the TTS setting is left STANDING rather
-      // than cleared — that is what makes this a priority, not a toggle.
-      // The generator is deliberately not started: an idle pacer feeding a lane
-      // that will not carry it is pure cost.
     return mic;
   } catch (e) {
-    // No microphone, or permission refused. If we can synthesize, that is the
-    // whole voice — this is the agent path, and the path a human takes when they
-    // have no mic but still want to be heard.
-    if (isTtsEnabled() && canSynthesize()) {
-      const track = ensureGenerator();
-      startPacer();
+    // No microphone, or permission refused. If a synth provider is registered
+    // and willing, that is the whole voice — the agent path, and the path a
+    // human with no mic takes to still be heard.
+    if (provider?.available?.()) {
+      const track = provider.start();
       const ms = new MediaStream([track]);
       // Mark it: this is a SYNTHETIC source, not a device. The caller must not
       // wrap it in the WebAudio gate — a synth has no room noise to gate, and
@@ -471,116 +86,3 @@ export function sourceIsDead(stream) {
   const t = stream?.getAudioTracks?.()[0];
   return !!t && t.readyState === 'ended';
 }
-
-// ── speak your own says ─────────────────────────────────────────────────────
-// world.js already emits 'speech' for every say that was not already performed
-// (args.spoken marks the ones a voice paced itself, so this cannot
-// double-speak). A body with a synthesizer listens for its OWN and voices it:
-// that is the entire bridge from "posted text" to "made a sound", and it runs
-// through the ordinary sender, so distance, the category slider and consent all
-// apply exactly as they do to a microphone.
-export function speakOwnSays(bus, myId) {
-  bus.on('speech', ({ actor, text }) => {
-    const mine = actor === myId();
-    if (!mine) return;                       // someone else's say: not ours to voice
-    if (!isTtsEnabled()) { console.warn(`[voice] own say NOT spoken — tts disabled`); return; }
-    console.log(`[voice] own say → speaking: "${String(text).slice(0, 60)}"`);
-    void speak(text);
-  });
-}
-
-/** THE ONE QUESTION A SILENT VOICE CANNOT ANSWER FROM INSIDE: is the track we
- *  are feeding the same object the peer connection is sending? speak() can
- *  return true — synthesized, written, no errors — while the samples pour into
- *  an orphan generator because the mic lane opened from a different source.
- *  Every local check still passes and the room hears nothing. This exposes the
- *  identity so a probe can compare it against the sender's track. */
-export const genTrackInfo = () => (genTrack
-  ? { id: genTrack.id, kind: genTrack.kind, readyState: genTrack.readyState, enabled: genTrack.enabled }
-  : null);
-
-
-
-/** Benchmark the current voice: N runs of the same text, reporting the spread.
- *
- *  Exists because every latency claim today has been settled by measurement and
- *  none by argument. Run it, switch backend, run it again:
- *
- *      await ttsBench('hello')                     // current backend
- *      localStorage.eidoTtsBackend = 'wasm'        // then reload and re-run
- *
- *  Reports P50 and best rather than a mean: a mean over 5 runs hides the one
- *  slow first call that the user actually feels.
- */
-export async function ttsTTFS(text = 'hello there, this is a test', runs = 3) {
-  // 🔴 TIME TO FIRST SOUND — the number a LISTENER experiences, which is not the
-  // same as `infer`. R, 2026-08-09: "as long as you can load your own models from
-  // your end you ought to be able to poll time to first sound, since TTS is wired
-  // to be able to hear yourself." Exactly: self-monitoring makes an agent its own
-  // measurement instrument, no human in the loop.
-  //
-  // TTFS = phonemize + infer + everything between the call and audio existing.
-  // Optimising `infer` alone can move that number not at all, which is precisely
-  // the mistake this whole evening kept making at a different layer.
-  if (!isTtsEnabled() || !ttsFn) { console.warn('[ttfs] no voice loaded'); return null; }
-  const out = [];
-  for (let i = 0; i < runs; i++) {
-    const t0 = performance.now();
-    const r = await ttsFn(text);
-    const ttfs = performance.now() - t0;
-    const secs = (r?.pcm?.length || 0) / (r?.sampleRate || 22050);
-    out.push({ ttfs, secs });
-  }
-  out.sort((a, b) => a.ttfs - b.ttfs);
-  const p50 = out[Math.floor(out.length / 2)];
-  console.log(`[ttfs] ${JSON.stringify(text)} ×${runs}: `
-    + `best ${Math.round(out[0].ttfs)}ms · P50 ${Math.round(p50.ttfs)}ms `
-    + `→ ${p50.secs.toFixed(2)}s audio · RTF ${(p50.ttfs / 1000 / Math.max(p50.secs, 1e-6)).toFixed(3)}`);
-  return { best: out[0].ttfs, p50: p50.ttfs, secs: p50.secs };
-}
-if (typeof window !== 'undefined') window.ttsTTFS = ttsTTFS;
-
-export async function ttsBench(text = 'hello', runs = 5) {
-  if (!isTtsEnabled() || !ttsFn) { console.warn('[bench] no voice loaded'); return null; }
-  const ms = [];
-  let secs = 0;
-  for (let i = 0; i < runs; i++) {
-    const t = performance.now();
-    const out = await ttsFn(text);
-    ms.push(performance.now() - t);
-    secs = (out?.pcm?.length || 0) / (out?.sampleRate || 22050);
-  }
-  ms.sort((a, b) => a - b);
-  const p50 = ms[Math.floor(ms.length / 2)];
-  console.log(`[bench] ${JSON.stringify(text)} ×${runs}: `
-    + `best ${Math.round(ms[0])}ms · P50 ${Math.round(p50)}ms · worst ${Math.round(ms.at(-1))}ms `
-    + `→ ${secs.toFixed(2)}s audio · RTF ${(p50 / 1000 / Math.max(secs, 1e-6)).toFixed(3)}`);
-  return { best: ms[0], p50, worst: ms.at(-1), secs };
-}
-if (typeof window !== 'undefined') window.ttsBench = ttsBench;
-
-
-/** Speak the same text N times so you can hear the SPREAD, not one sample.
- *
- *  R, 2026-08-09, found the need for this with a one-character test: two strings
- *  that phonemize identically sounded different, because VITS samples noise on
- *  every call. Judging a voice from one utterance is judging one draw.
- */
-export async function ttsSpread(text = 'hello there', runs = 5) {
-  if (!isTtsEnabled() || !ttsFn) { console.warn('[spread] no voice loaded'); return null; }
-  const rows = [];
-  for (let i = 0; i < runs; i++) {
-    const r = await ttsFn(text);
-    const pcm = r?.pcm || [];
-    let peak = 0, sum = 0;
-    for (let k = 0; k < pcm.length; k++) { const a = Math.abs(pcm[k]); if (a > peak) peak = a; sum += a * a; }
-    rows.push({ n: pcm.length, peak: peak / 32768, rms: Math.sqrt(sum / (pcm.length || 1)) / 32768 });
-  }
-  const lens = rows.map((r) => r.n);
-  const spread = (Math.max(...lens) - Math.min(...lens)) / Math.max(...lens) * 100;
-  console.log(`[spread] ${JSON.stringify(text)} ×${runs}: `
-    + `${Math.min(...lens)}-${Math.max(...lens)} samples (${spread.toFixed(1)}% length spread)`);
-  rows.forEach((r, i) => console.log(`  run ${i + 1}: ${r.n} samples  peak ${r.peak.toFixed(3)}  rms ${r.rms.toFixed(4)}`));
-  return { spread, rows };
-}
-if (typeof window !== 'undefined') window.ttsSpread = ttsSpread;

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1218,5 +1218,30 @@ check("unhush rejoins the SAME peer at full volume",
         `openness=${gateOpenness()} (old lane open=${wasOpen})`);
 }
 
+// ── B2 (#90 review): the gate fails CLOSED, and says so ─────────────────────
+// A gate graph that cannot be built must NOT hand back the raw device stream:
+// that is a privacy control silently reporting "on" while transmitting "off".
+// Deterministic breakage: a destination-less AudioContext.
+{
+  const m = await import("../client/lib/micgate.js");
+  const Real = (globalThis as Record<string, unknown>).AudioContext;
+  class BrokenCtx { state = "running"; resume() { return Promise.resolve(); } }  // no createMediaStreamDestination
+  (globalThis as Record<string, unknown>).AudioContext = BrokenCtx;
+  const ax = await import("../client/lib/audioctx.js");
+  ax.__resetForTest();          // next audioContext() constructs the BROKEN one
+  m.release();
+  const out = m.gateStream(new FakeStream() as never, () => 0.5);
+  check("B2 broken graph → gateStream REFUSES (null), no raw fallback", out === null, String(out));
+  check("B2 gateUnavailable() reports the true state", m.gateUnavailable?.() === true);
+  m.allowUngated?.(true);
+  const raw = new FakeStream();
+  const out2 = m.gateStream(raw as never, () => 0.5);
+  check("B2 explicit allowUngated(true) → raw stream, by choice", out2 === (raw as never));
+  check("B2 gateUnavailable stays visible under the override", m.gateUnavailable?.() === true);
+  m.allowUngated?.(false);
+  (globalThis as Record<string, unknown>).AudioContext = Real;
+  ax.__resetForTest();          // later blocks get a working context again
+}
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -71,7 +71,8 @@ class FakePC {
     this.transceivers.push({ direction: "sendrecv", sender, receiver: { track: { kind: "audio" } } });
     return sender;
   }
-  removeTrack(s: { track: FakeTrack | null }) { s.track = null; }
+  removeTrackCalls = 0;      // B3 pins releaseMicrophone to ZERO of these
+  removeTrack(s: { track: FakeTrack | null }) { this.removeTrackCalls++; s.track = null; }
   getSenders() { return this.senders; }
   getTransceivers() { return this.transceivers; }
   /** the direction actually offered to the far end */
@@ -1216,6 +1217,40 @@ check("unhush rejoins the SAME peer at full volume",
   check("fresh lane reports closed even though the old one was open",
         gateOpenness() === 0,
         `openness=${gateOpenness()} (old lane open=${wasOpen})`);
+}
+
+// ── B3 (#90 review): the standing-lane release contract, pinned ─────────────
+// releaseMicrophone's comments promise: device stops, but every sender keeps
+// the live (silent) destination track — so reacquiring needs no removeTrack
+// and no renegotiation. The implementation contradicted this with an
+// untrack+renegotiate loop for months and no test noticed. This one does.
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const peer = created.at(-1);
+  if (peer) {
+    const beforeTracks = peer.getSenders().map((s) => s.track?.id).join(",");
+    const beforeOffers = peer.offers;
+    const beforeRemove = peer.removeTrackCalls;
+    voice.releaseMicrophone();
+    await new Promise((r) => setTimeout(r, 30));
+    check("B3 release: zero removeTrack on any sender", peer.removeTrackCalls === beforeRemove,
+      `${peer.removeTrackCalls - beforeRemove} calls`);
+    check("B3 release: zero negotiation cycles", peer.offers === beforeOffers,
+      `${peer.offers - beforeOffers} offers`);
+    check("B3 release: senders keep the SAME track identity",
+      peer.getSenders().map((s) => s.track?.id).join(",") === beforeTracks,
+      peer.getSenders().map((s) => s.track?.id).join(","));
+    check("B3 release: micOn reports no device", voice.micOn() === false);
+
+    // reacquire: same graph, same track, still no sender surgery
+    await voice.toggleMic("me");
+    await new Promise((r) => setTimeout(r, 30));
+    check("B3 reacquire: still zero removeTrack", peer.removeTrackCalls === beforeRemove);
+    check("B3 reacquire: senders STILL hold the same track identity",
+      peer.getSenders().map((s) => s.track?.id).join(",") === beforeTracks,
+      peer.getSenders().map((s) => s.track?.id).join(","));
+    check("B3 reacquire: mic is live again", voice.micOn() === true);
+  }
 }
 
 // ── B2 (#90 review): the gate fails CLOSED, and says so ─────────────────────

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -269,10 +269,25 @@ const liveTrack = (await import("../client/lib/voice.js")).micOn();
 await voice.toggleMic("me");
 check("mic off stops the local track", liveTrack === true && voice.micOn() === false);
 check("mic off does NOT close a consented inbound peer (send ≠ receive)", !inbound.closed);
-check("mic off leaves no outbound track on the peer",
-  inbound.getSenders().every((s) => s.track === null));
+// THE CONTRACT CHANGED (2026-08-08). Mic-off used to stop() the track and
+// removeTrack() it from every peer, then renegotiate — three destructive acts
+// to express "don't transmit", and the source of four of the six voice bugs
+// fixed this week. It now disables the track instead, so the sender KEEPS it
+// and the SDP never changes. Asserting track === null here would be asserting
+// the bug. What matters is that nothing audible leaves:
+check("mic off keeps the sender bound but silences it (no renegotiation)",
+  inbound.getSenders().every((s) => !s.track || s.track.enabled === false));
+check("mic off does not stop() the track — an ended track cannot be revived",
+  inbound.getSenders().every((s) => !s.track || s.track.readyState !== "ended"));
 
 // ---- refusal must not loop ------------------------------------------------
+// Refusal is only reachable from a body that holds NO stream. Since mic-off
+// keeps the stream (and re-enabling needs no permission — correctly: a mic you
+// were already granted is not re-asked for), the honest way to reach the
+// permission path is to RELEASE the device first. That is what
+// releaseMicrophone() is for, and it is the only caller that stops tracks.
+voice.releaseMicrophone();
+await settle();
 denyMic = true;
 const before = micDenies;
 const r1 = await voice.toggleMic("me");
@@ -306,6 +321,13 @@ consent.setReceiveVoice(false);
 created.length = 0;
 stubs.remotes.set("peer1", { agent: false });
 denyMic = false;
+// Drive to the state, never assume a call reaches it (the discipline this file
+// states at the bottom). Mic-off now KEEPS the stream and only disables the
+// track, so a bare toggleMic() means "flip", not "on".
+// A real off->on cycle, so the courting path runs for THIS test's peer rather
+// than relying on one a previous test happened to leave behind.
+if (voice.micOn()) { await voice.toggleMic("me"); await settle(); }
+created.length = 0;
 await voice.toggleMic("me");            // mic ON, receive OFF
 await settle();
 const outbound = created.at(-1)!;
@@ -1117,5 +1139,35 @@ check("unhush rejoins the SAME peer at full volume",
 // stay at 0 inbound pkts; RTC_MODE=relay-turn must exceed 0. External harness
 // by design — fake RTC cannot prove media.
 
+// ---- a rebuilt generator must reach the senders --------------------------
+// THE SILENT-FOREVER FAILURE. The synthesizer's generator dies; speak() quietly
+// makes a NEW track and every sender keeps the dead one. ICE stays connected,
+// direction stays sendonly, speak() returns true — and the room hears nothing.
+// Indistinguishable from the audio:ended blocker seen in the field.
+// sourceIsDead() was written for exactly this and had ZERO callers, the same
+// way toggleMute did while the HUD button called the destructive path.
+{
+  const vs = await import("../client/lib/voicesource.js");
+  check("voicesource exposes a rebuild hook", typeof vs.setGeneratorRebuildHook === "function");
+  check("sourceIsDead recognises an ended track",
+    vs.sourceIsDead({ getAudioTracks: () => [{ readyState: "ended" }] }) === true);
+  check("sourceIsDead does NOT flag a live one",
+    vs.sourceIsDead({ getAudioTracks: () => [{ readyState: "live" }] }) === false);
+
+  // voice.js installs the real hook at import time; prove it re-binds senders.
+  const peer = created.at(-1);
+  if (peer) {
+    const dead = { id: "dead", kind: "audio", readyState: "ended", enabled: true, stop() {} };
+    for (const s of peer.getSenders()) s.track = dead;
+    check("precondition: a sender is holding an ENDED track",
+      peer.getSenders().some((s) => s.track?.readyState === "ended"));
+
+    const fresh = { id: "fresh", kind: "audio", readyState: "live", enabled: true, stop() {} };
+    vs.__fireRebuild?.(fresh);
+    check("after a rebuild no sender is left holding the dead track",
+      peer.getSenders().every((s) => s.track?.id !== "dead"),
+      peer.getSenders().map((s) => s.track?.id).join(","));
+  }
+}
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -196,6 +196,10 @@ class FakeAudioCtx {
     getByteTimeDomainData() {},
     getFloatTimeDomainData(buf: Float32Array) { buf.fill(FakeAudioCtx.level); },
     connect() {}, disconnect() {} }; }
+  // A real destination stream CARRIES one audio track — the gated lane the
+  // senders attach. An empty one here silently reroutes every sender test onto
+  // the ungated fallback path.
+  createMediaStreamDestination() { const t = [new FakeTrack()]; return { stream: { getTracks: () => t, getAudioTracks: () => t } }; }
   async resume() {}
 }
 (globalThis as Record<string, unknown>).AudioContext = FakeAudioCtx;
@@ -275,8 +279,16 @@ check("mic off does NOT close a consented inbound peer (send ≠ receive)", !inb
 // fixed this week. It now disables the track instead, so the sender KEEPS it
 // and the SDP never changes. Asserting track === null here would be asserting
 // the bug. What matters is that nothing audible leaves:
-check("mic off keeps the sender bound but silences it (no renegotiation)",
-  inbound.getSenders().every((s) => !s.track || s.track.enabled === false));
+// With the gate in the chain the sender holds the GATED track, which stays
+// enabled — silence is enforced UPSTREAM: the raw source track is disabled and
+// the gate is driven closed. Asserting sender.track.enabled===false here would
+// be asserting the pre-gate wiring.
+const { rawStream } = await import("../client/lib/micgate.js");
+const rawOff = (rawStream()?.getTracks() ?? []).length > 0 &&
+  rawStream().getTracks().every((t: { enabled: boolean }) => !t.enabled);
+check("mic off silences the RAW source and closes the gate (sender stays bound)",
+  inbound.getSenders().some((s) => s.track) && rawOff,
+  `rawOff=${rawOff} senders=${inbound.getSenders().length}`);
 check("mic off does not stop() the track — an ended track cannot be revived",
   inbound.getSenders().every((s) => !s.track || s.track.readyState !== "ended"));
 
@@ -1169,5 +1181,42 @@ check("unhush rejoins the SAME peer at full volume",
       peer.getSenders().map((s) => s.track?.id).join(","));
   }
 }
+
+// ── mute × mic-button: the wedge (review of #90) ─────────────────────────────
+// A muted user pressing the mic button used to re-enter the ON path forever:
+// micOn() requires !muted, the on-path set _micLive but never cleared muted, so
+// the off-path was unreachable — with the raw tracks re-enabled while
+// micOn/isMuted/micTransmitting all said silent.
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  voice.toggleMute();
+  check("mute while live: isMuted true, micOn false", voice.isMuted() && !voice.micOn());
+  await voice.toggleMic("me");           // muted user presses the mic button
+  check("mic button while muted UNMUTES (on-path clears muted)",
+        !voice.isMuted() && voice.micOn(),
+        `isMuted=${voice.isMuted()} micOn=${voice.micOn()}`);
+  await voice.toggleMic("me");           // and the off-path is reachable again
+  check("second press now reaches the OFF path", !voice.micOn());
+}
+
+// ── a fresh gate lane reports CLOSED (review of #90) ─────────────────────────
+// gateStream builds the graph with gain 0; _wanted must not outlive the old
+// lane, or gateOpenness() claims "audible" before any driveGate tick.
+{
+  const { gateStream, driveGate, gateOpenness } = await import("../client/lib/micgate.js");
+  gateStream(new FakeStream() as never, () => 0.5);
+  driveGate(true);                       // force the gate open on the old lane
+  const { isGated } = await import("../client/lib/micgate.js");
+  check("F2 precondition: the gate graph actually built under the fakes", isGated(),
+        "gateStream returned the raw stream — this case would be vacuous");
+  const wasOpen = gateOpenness() > 0.5;
+  check("F2 precondition: the old lane was genuinely OPEN", wasOpen,
+        `openness=${gateOpenness()} — driveGate(true) did not take`);
+  gateStream(new FakeStream() as never, () => 0.5);  // reacquire: a NEW lane
+  check("fresh lane reports closed even though the old one was open",
+        gateOpenness() === 0,
+        `openness=${gateOpenness()} (old lane open=${wasOpen})`);
+}
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1175,7 +1175,7 @@ check("unhush rejoins the SAME peer at full volume",
       peer.getSenders().some((s) => s.track?.readyState === "ended"));
 
     const fresh = { id: "fresh", kind: "audio", readyState: "live", enabled: true, stop() {} };
-    vs.__fireRebuild?.(fresh);
+    vs.notifySynthTrackChanged?.(fresh);
     check("after a rebuild no sender is left holding the dead track",
       peer.getSenders().every((s) => s.track?.id !== "dead"),
       peer.getSenders().map((s) => s.track?.id).join(","));


### PR DESCRIPTION
Three related repairs to the microphone lane, all of which land as the same
principle: **mute the lane, never tear it down.** Recovering a torn-down audio
path costs a renegotiation and seconds of silence, and every one of the bugs
below was an instance of paying that cost by accident.

**1. The gate is a GAIN, not a switch.** `track.enabled` is binary: full to
digital silence between one 40ms tick and the next, which is an audible click at
both ends — and the opening click lands on your first consonant, the worst
possible place. micgate.js puts a real WebAudio graph in front of WebRTC and
lerps the gain with attack/release, the shape BasisVR uses
(`BasisLocalMicrophoneDriver._noiseGateGain`). Per-sample access is what we did
not have while handing the raw device track straight to the peer connection.

**2. Going quiet is a data change, not a connection change.** `toggleMic`'s off
path used to stop() the track, removeTrack() it from every peer, and
renegotiate — three destructive operations to express "don't transmit". The
identical intent was already implemented correctly ten lines below in
`toggleMute` (track.enabled = false, zero renegotiation) and had NO CALLERS,
while the HUD button called the destructive one. stop() also manufactures
exactly the `audio:ended` sender state seen on the failing leg in the field.

**3. A released device now actually comes back.** releaseMicrophone() stops the
DEVICE and deliberately keeps the lane standing — correct, that is what avoids
the renegotiation. But two other things then lied about it: `micOn()` never
cleared `_micLive`, so it reported an open mic with no device behind it; and the
acquire path branched on `if (micStream)`, which survives a release, so it
re-enabled STOPPED tracks instead of calling getUserMedia. User-visible effect:
after any release, the mic button did nothing, forever.

Also includes `voicesource.js` — the seam `micStream` is produced through
(88 lines, and this time the claim is checked against the file: an earlier
head of this branch carried the whole synthesizer in here, caller-less, and
review caught it). It exposes a track-level synth-provider contract —
`setSynthProvider({available, start, stop})` — and nothing that makes
samples. A TTS engine (#91) registers a provider without touching this file.

Review hardening on top (B1–B3, separate commits for re-reviewability):
the gate now **fails closed** — a broken WebAudio graph refuses to transmit
(machine-visible `gateUnavailable()`, amber explicit-override row in the
audio panel) instead of silently going raw; and `releaseMicrophone` now
actually keeps the standing-lane contract its comments promised — the
untrack+renegotiate loop is gone, and the suite pins zero removeTrack,
zero negotiation cycles, and identical sender track identity across
release→reacquire.

Lifecycle suite 124/124 (70/70 before this branch; +54 covering the gate,
the toggle rewrite, the release contract, and the fail-closed path).
Wiring 29/29, bundle green, `git diff --check` clean.

Stacks on #86 (one AudioContext) — audioctx.js is shared and must land first.

---

**Merge order:** stacks on #86 (one AudioContext) — `audioctx.js` is shared and must land first. Verified to merge clean onto current `main`.

**Receipts:** lifecycle suite 101/101 (70/70 before this branch; +31 new cases covering the gate, the toggle rewrite, and the release path).

Discord has been asking for functional audio for humans — this is that half, and it is independently reviewable.
