### PR TITLE
agent: mounted cargo perceives from its carrier's frame, or says why it can't (#82)

### DIFF
--- a/client/lib/motion.js
+++ b/client/lib/motion.js
@@ -34,94 +34,18 @@ import { THREE } from './core.js';
 import { entities, comps, findPart } from './world.js';
 import { reindexCollider } from './colliders.js';
 import { serverNow } from './remotes.js';
+// The closed forms themselves live in motioneval.js — a dependency-free
+// module shared verbatim with the agent's text-tier perception (#82), the
+// same arrangement forecast.js has. The generous reader (axis synonyms,
+// `amplitude`, missing t0) lives there too; this file is what remains:
+// applying evaluated transforms to THREE objects, and the part-frame
+// machinery only a renderer with a loaded model can have.
+import { evalWholeMotion, evalPath, axisOf, ampOf, since, pendulumTheta } from './motioneval.js';
 
-const UP = new THREE.Vector3(0, 1, 0);
 const _q = new THREE.Quaternion();
-const _qy = new THREE.Quaternion();
 const _ax = new THREE.Vector3();
 const _pv = new THREE.Vector3();
 const _rp = new THREE.Vector3();
-
-// ---- the generous reader ----------------------------------------------------
-// Text-tier authors improvise dialect: `amplitude` for amp, `axis: "x"` for
-// [1,0,0], no t0 at all. The fold is blind by doctrine, so nothing upstream
-// corrects them — and a strict evaluator turns every synonym into a world
-// that silently refuses to move. (Fable's first line of world-script — a
-// pendulum on the commons swing — stood perfectly still THREE separate ways:
-// `amplitude` read as amp 0, axis "x" spread into NaN, missing t0 frozen at
-// phase 0. No error anywhere, because every layer was being strict and
-// nothing was wrong enough to say so.) The closed form stays exact; the
-// PARSING is where generosity lives.
-const AXES = { x: [1, 0, 0], y: [0, 1, 0], z: [0, 0, 1],
-  '-x': [-1, 0, 0], '-y': [0, -1, 0], '-z': [0, 0, -1] };
-const axisOf = (m, def) => {
-  const a = m.axis;
-  if (Array.isArray(a) && a.length === 3) return a;
-  if (typeof a === 'string' && AXES[a.toLowerCase()]) return AXES[a.toLowerCase()];
-  return def;
-};
-const ampOf = (m, def = 0) => {
-  const v = Number(m.amp ?? m.amplitude ?? def);
-  return Number.isFinite(v) ? v : def;
-};
-
-/** Seconds since the motion's epoch. Log timestamps are sequencer clock, so
- *  all clients agree on phase to within their own clock skew. A motion with
- *  NO t0 anchors to when this client first evaluated it — clients disagree
- *  on phase, but the thing MOVES, which beats frozen honesty. (New entries
- *  get a real t0 stamped at fold; this is the fallback for old logs.) */
-const since = (m, nowMs) => Math.max(0, (nowMs - (m.t0 ?? (m._t0 ??= nowMs))) / 1000);
-
-/** ⚠ MIRRORS pendulumImpulse math in server/server.ts — keep in sync, or a
- *  joiner's swing disagrees with the one being pushed.
- *  Missing damp = 0 = swings FOREVER. Friction is opt-in: a declared
- *  pendulum is ambient decoration, and a default 0.06 meant every
- *  undamped swing quietly died within a minute or two of being cast —
- *  working exactly long enough for its author to walk away happy. */
-function pendulumTheta(m, t) {
-  const w0 = (2 * Math.PI) / (m.period ?? 3.5);
-  return ampOf(m) * Math.exp(-(m.damp ?? 0) * t) * Math.cos(w0 * t + (m.phase ?? 0));
-}
-
-/** Rotate obj by `theta` about local `axis` at local point `pivot`, composed
- *  on the base pose. The pendulum/spin workhorse. */
-function rotateAtPivot(obj, base, axis, pivot, theta) {
-  _ax.set(...(axis ?? [0, 1, 0])).normalize();
-  _q.setFromAxisAngle(_ax, theta);
-  _qy.setFromAxisAngle(UP, base.yaw ?? 0);
-  obj.quaternion.copy(_qy).multiply(_q);
-  _pv.set(...(pivot ?? [0, 0, 0]));
-  _rp.copy(_pv).applyQuaternion(_q);          // pivot after rotation
-  _pv.sub(_rp).applyQuaternion(_qy);          // shift that keeps the pivot fixed
-  obj.position.set(...base.pos).add(_pv);
-}
-
-function evalPath(m, t, obj, base) {
-  const pts = m.points;
-  if (!Array.isArray(pts) || pts.length < 2) return;
-  // cumulative arc lengths, cached on the component object itself
-  if (!m._len) {
-    m._len = [0];
-    for (let i = 1; i < pts.length; i++) {
-      const [ax, ay, az] = pts[i - 1]; const [bx, by, bz] = pts[i];
-      m._len.push(m._len[i - 1] + Math.hypot(bx - ax, by - ay, bz - az));
-    }
-  }
-  const total = m._len[m._len.length - 1] || 1;
-  const speed = m.speed ?? (m.duration ? total / m.duration : 1);
-  let s = speed * t;
-  const loop = m.loop ?? 'loop';
-  if (loop === 'loop') s %= total;
-  else if (loop === 'pingpong') { s %= 2 * total; if (s > total) s = 2 * total - s; }
-  else s = Math.min(s, total);                 // 'once': arrive and stay
-  let i = 1;
-  while (i < m._len.length - 1 && m._len[i] < s) i++;
-  const seg = m._len[i] - m._len[i - 1] || 1;
-  const f = (s - m._len[i - 1]) / seg;
-  const [ax, ay, az] = pts[i - 1]; const [bx, by, bz] = pts[i];
-  obj.position.set(ax + (bx - ax) * f, ay + (by - ay) * f, az + (bz - az) * f);
-  if (m.face !== false) obj.rotation.set(0, Math.atan2(bx - ax, bz - az), 0);
-}
 
 // Colliders re-index at a walk, not at frame rate — a moving thing's collider
 // trails it by up to half a second, which is invisible next to the cost of
@@ -175,9 +99,13 @@ function evalPart(m, t, obj, pbase) {
       if (m.face !== false) obj.rotation.set(0, a + Math.PI / 2, 0);
       return true;
     }
-    case 'path':
-      evalPath(m, t, obj, { pos: pbase.pos });
+    case 'path': {
+      const r = evalPath(m, t, { pos: pbase.pos, yaw: 0 });
+      if (!r.ok) return false;   // malformed path: the part rests, like an unknown type
+      obj.position.set(...r.pos);
+      if (r.rot) obj.rotation.set(0, r.yaw, 0);
       return true;
+    }
     default:
       return false;   // unknown type: the part rests here, moves for newer clients
   }
@@ -226,39 +154,20 @@ export function tickMotion() {
       } else {
         const base = obj.userData.base
           ?? (obj.userData.base = { pos: obj.position.toArray(), yaw: obj.rotation.y });
-        switch (m.type) {
-          case 'pendulum':
-            rotateAtPivot(obj, base, axisOf(m, [1, 0, 0]), m.pivot ?? [0, 2, 0], pendulumTheta(m, t));
-            break;
-          case 'spin': {
-            const rate = m.degPerSec != null ? m.degPerSec : (m.rpm ?? 6) * 6;   // rpm → deg/s
-            rotateAtPivot(obj, base, axisOf(m, [0, 1, 0]), m.pivot ?? [0, 0, 0],
-              (m.phase ?? 0) + (rate * Math.PI / 180) * t);
-            break;
-          }
-          case 'orbit': {
-            const c = m.center ?? base.pos;
-            const r = m.radius ?? 3;
-            const a = (m.phase ?? 0) + ((m.degPerSec ?? 12) * Math.PI / 180) * t;
-            obj.position.set(c[0] + r * Math.sin(a), (c[1] ?? base.pos[1]), c[2] + r * Math.cos(a));
-            if (m.face !== false) obj.rotation.set(0, a + Math.PI / 2, 0);
-            break;
-          }
-          case 'bob': {
-            const off = Math.sin((2 * Math.PI / (m.period ?? 4)) * t + (m.phase ?? 0)) * ampOf(m, 0.3);
-            _ax.set(...axisOf(m, [0, 1, 0])).normalize();
-            obj.position.set(...base.pos).addScaledVector(_ax, off);
-            break;
-          }
-          case 'path':
-            evalPath(m, t, obj, base);
-            break;
-          default:
-            // A motion type this client doesn't know: the thing stands still
-            // here and moves for newer clients. Forward-compatible, never an
-            // error.
-            continue;
+        // The shared evaluator (motioneval.js) is the single source of the
+        // closed forms — the agent's look() runs the SAME call, which is the
+        // whole point (#82). This side just applies the result to the object.
+        const r = evalWholeMotion(base, m, nowMs);
+        if (!r.ok) {
+          // A motion this evaluator won't vouch for (unknown type, malformed
+          // path): the thing stands still here and moves for newer clients.
+          // Forward-compatible, never an error.
+          continue;
         }
+        obj.position.set(...r.pos);
+        // rot:false = this motion leaves authored rotation alone (bob;
+        // face:false orbit/path) — matching the old per-case behavior.
+        if (r.rot) obj.quaternion.set(...r.quat);
       }
       const li = lastIndexed.get(id) ?? 0;
       if (nowMs - li > 500) { lastIndexed.set(id, nowMs); reindexCollider(id); }

--- a/client/lib/motioneval.js
+++ b/client/lib/motioneval.js
@@ -1,0 +1,219 @@
+// motioneval — the whole-entity motion closed forms, as pure math.
+//
+// Extracted from motion.js (#82 review): the browser render loop and the
+// agent's text-tier perception must agree on where a moving thing IS, and
+// the only way two runtimes agree forever is to evaluate the same file.
+// This module is deliberately dependency-free — no THREE, no DOM, no scene,
+// no clock: callers pass {base, motion, nowMs} in and get a transform out.
+// motion.js consumes it per frame; mcpl/agent.ts consumes it at read time.
+//
+// Contract: evalWholeMotion returns a FINITE transform or an explicit
+// refusal ({ok:false, why}) — never a partially-composed number. Unknown
+// motion types are a refusal here even though the renderer quietly shows
+// such things at rest: a renderer that draws stillness is visibly guessing,
+// but a printed coordinate claims to be truth (#82's whole disease).
+//
+// Part-frame motion (`motion:<part>` keys, or a `motion` carrying `part`)
+// does not displace the entity's ROOT transform at all — those stay in
+// motion.js, THREE-side, and this module reports the root as unmoved.
+
+// ---- quaternions, the four lines of them we need ---------------------------
+// [x, y, z, w], same layout THREE uses. Right-handed, Y-up, radians.
+
+export const qAxisAngle = (axis, angle) => {
+  const [x, y, z] = axis;
+  const n = Math.hypot(x, y, z) || 1;
+  const s = Math.sin(angle / 2);
+  return [(x / n) * s, (y / n) * s, (z / n) * s, Math.cos(angle / 2)];
+};
+
+export const qMul = (a, b) => {
+  const [ax, ay, az, aw] = a, [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+};
+
+export const qApply = (q, v) => {
+  // v' = v + 2 * cross(q.xyz, cross(q.xyz, v) + w*v)
+  const [qx, qy, qz, qw] = q, [vx, vy, vz] = v;
+  const cx = qy * vz - qz * vy + qw * vx;
+  const cy = qz * vx - qx * vz + qw * vy;
+  const cz = qx * vy - qy * vx + qw * vz;
+  return [
+    vx + 2 * (qy * cz - qz * cy),
+    vy + 2 * (qz * cx - qx * cz),
+    vz + 2 * (qx * cy - qy * cx),
+  ];
+};
+
+/** Yaw of a quaternion, by the house convention: the yaw whose +Z-forward
+ *  matches the quaternion's, `atan2(x, z)` of the rotated forward vector. */
+export const yawOfQuat = (q) => {
+  const [fx, , fz] = qApply(q, [0, 0, 1]);
+  return Math.atan2(fx, fz);
+};
+
+const yawQuat = (yaw) => qAxisAngle([0, 1, 0], yaw ?? 0);
+
+// ---- the generous reader (verbatim from motion.js — see its history) -------
+// Text-tier authors improvise dialect: `amplitude` for amp, `axis: "x"` for
+// [1,0,0], no t0 at all. Parsing is where generosity lives; the closed form
+// stays exact.
+
+const AXES = { x: [1, 0, 0], y: [0, 1, 0], z: [0, 0, 1],
+  '-x': [-1, 0, 0], '-y': [0, -1, 0], '-z': [0, 0, -1] };
+
+export const axisOf = (m, def) => {
+  const a = m.axis;
+  if (Array.isArray(a) && a.length === 3) return a;
+  if (typeof a === 'string' && AXES[a.toLowerCase()]) return AXES[a.toLowerCase()];
+  return def;
+};
+
+export const ampOf = (m, def = 0) => {
+  const v = Number(m.amp ?? m.amplitude ?? def);
+  return Number.isFinite(v) ? v : def;
+};
+
+/** Seconds since the motion's epoch. A motion with NO t0 anchors to when
+ *  this process first evaluated it — same per-client fallback motion.js has
+ *  always had, held here in a WeakMap instead of a stowaway `_t0` property
+ *  so evaluation never mutates a component bag it does not own. */
+const t0Fallback = new WeakMap();
+export const since = (m, nowMs) => {
+  let t0 = m.t0;
+  if (t0 == null) {
+    t0 = t0Fallback.get(m);
+    if (t0 == null) t0Fallback.set(m, (t0 = nowMs));
+  }
+  return Math.max(0, (nowMs - t0) / 1000);
+};
+
+/** ⚠ MIRRORS pendulumImpulse math in server/server.ts — keep in sync, or a
+ *  joiner's swing disagrees with the one being pushed.
+ *  Missing damp = 0 = swings FOREVER (friction is opt-in; see motion.js). */
+export function pendulumTheta(m, t) {
+  const w0 = (2 * Math.PI) / (m.period ?? 3.5);
+  return ampOf(m) * Math.exp(-(m.damp ?? 0) * t) * Math.cos(w0 * t + (m.phase ?? 0));
+}
+
+/** rotateAtPivot, pure: rotate by `theta` about local `axis` at local point
+ *  `pivot`, composed on the base pose. Returns {pos, quat}. */
+function rotateAtPivot(base, axis, pivot, theta) {
+  const q = qAxisAngle(axis ?? [0, 1, 0], theta);
+  const qy = yawQuat(base.yaw);
+  const quat = qMul(qy, q);
+  const pv = pivot ?? [0, 0, 0];
+  const rp = qApply(q, pv);                                  // pivot after rotation
+  const shift = qApply(qy, [pv[0] - rp[0], pv[1] - rp[1], pv[2] - rp[2]]);
+  return { pos: [base.pos[0] + shift[0], base.pos[1] + shift[1], base.pos[2] + shift[2]], quat };
+}
+
+// Path arc-length tables, cached per component object. A re-folded comp is a
+// new object, so the cache invalidates exactly when the points can change —
+// the same lifetime the old `m._len` stowaway had, without the mutation.
+const pathLen = new WeakMap();
+
+export function evalPath(m, t, base) {
+  const pts = m.points;
+  if (!Array.isArray(pts) || pts.length < 2) return { ok: false, why: "path needs ≥ 2 points" };
+  let len = pathLen.get(m);
+  if (!len) {
+    len = [0];
+    for (let i = 1; i < pts.length; i++) {
+      const [ax, ay, az] = pts[i - 1]; const [bx, by, bz] = pts[i];
+      len.push(len[i - 1] + Math.hypot(bx - ax, by - ay, bz - az));
+    }
+    pathLen.set(m, len);
+  }
+  const total = len[len.length - 1] || 1;
+  const speed = m.speed ?? (m.duration ? total / m.duration : 1);
+  let s = speed * t;
+  const loop = m.loop ?? 'loop';
+  if (loop === 'loop') s %= total;
+  else if (loop === 'pingpong') { s %= 2 * total; if (s > total) s = 2 * total - s; }
+  else s = Math.min(s, total);                               // 'once': arrive and stay
+  let i = 1;
+  while (i < len.length - 1 && len[i] < s) i++;
+  const seg = len[i] - len[i - 1] || 1;
+  const f = (s - len[i - 1]) / seg;
+  const [ax, ay, az] = pts[i - 1]; const [bx, by, bz] = pts[i];
+  const pos = [ax + (bx - ax) * f, ay + (by - ay) * f, az + (bz - az) * f];
+  if (m.face !== false) {
+    const yaw = Math.atan2(bx - ax, bz - az);
+    return { ok: true, pos, yaw, quat: yawQuat(yaw), rot: true };
+  }
+  return { ok: true, pos, yaw: base.yaw ?? 0, quat: yawQuat(base.yaw), rot: false };
+}
+
+/**
+ * Evaluate a WHOLE-ENTITY motion component at `nowMs`, composed on the
+ * entity's logged base pose.
+ *
+ *   base:  {pos: [x,y,z], yaw}    — the spawn/place rest transform
+ *   m:     the motion component's data ({type, ...params, t0?})
+ *   nowMs: epoch ms on the sequencer's clock (caller's responsibility —
+ *          motion.js passes serverNow(), the agent passes its own estimate)
+ *
+ * Returns {ok:true, pos, yaw, quat, rot} — `rot: false` means this motion
+ * type leaves the entity's authored rotation alone (bob; face:false orbit
+ * and path), which the renderer honors by not touching obj.rotation —
+ * or {ok:false, why} for anything it will not vouch for: unknown types,
+ * malformed paths, non-finite params. Part-frame motion (`m.part`) returns
+ * the base pose unchanged with rot:false — parts swing, roots stand still.
+ */
+export function evalWholeMotion(base, m, nowMs) {
+  if (!m || typeof m.type !== "string") return { ok: false, why: "no motion type" };
+  if (typeof m.part === "string") {
+    // animates ONE NAMED NODE of the model; the root transform is untouched
+    return { ok: true, pos: [...base.pos], yaw: base.yaw ?? 0, quat: yawQuat(base.yaw), rot: false };
+  }
+  const t = since(m, nowMs);
+  let r;
+  switch (m.type) {
+    case 'pendulum':
+      r = { ok: true, rot: true, yaw: null,
+        ...rotateAtPivot(base, axisOf(m, [1, 0, 0]), m.pivot ?? [0, 2, 0], pendulumTheta(m, t)) };
+      break;
+    case 'spin': {
+      const rate = m.degPerSec != null ? m.degPerSec : (m.rpm ?? 6) * 6;   // rpm → deg/s
+      r = { ok: true, rot: true, yaw: null,
+        ...rotateAtPivot(base, axisOf(m, [0, 1, 0]), m.pivot ?? [0, 0, 0],
+          (m.phase ?? 0) + (rate * Math.PI / 180) * t) };
+      break;
+    }
+    case 'orbit': {
+      const c = m.center ?? base.pos;
+      const rad = m.radius ?? 3;
+      const a = (m.phase ?? 0) + ((m.degPerSec ?? 12) * Math.PI / 180) * t;
+      const pos = [c[0] + rad * Math.sin(a), (c[1] ?? base.pos[1]), c[2] + rad * Math.cos(a)];
+      r = m.face !== false
+        ? { ok: true, pos, yaw: a + Math.PI / 2, quat: yawQuat(a + Math.PI / 2), rot: true }
+        : { ok: true, pos, yaw: base.yaw ?? 0, quat: yawQuat(base.yaw), rot: false };
+      break;
+    }
+    case 'bob': {
+      const off = Math.sin((2 * Math.PI / (m.period ?? 4)) * t + (m.phase ?? 0)) * ampOf(m, 0.3);
+      const ax = axisOf(m, [0, 1, 0]);
+      const n = Math.hypot(...ax) || 1;
+      r = { ok: true, rot: false, yaw: base.yaw ?? 0, quat: yawQuat(base.yaw),
+        pos: [base.pos[0] + (ax[0] / n) * off, base.pos[1] + (ax[1] / n) * off, base.pos[2] + (ax[2] / n) * off] };
+      break;
+    }
+    case 'path':
+      r = evalPath(m, t, base);
+      break;
+    default:
+      return { ok: false, why: `motion type "${m.type}" not supported here` };
+  }
+  if (!r.ok) return r;
+  if (r.yaw == null) r.yaw = yawOfQuat(r.quat);
+  if (!r.pos.every(Number.isFinite) || !Number.isFinite(r.yaw) || !r.quat.every(Number.isFinite)) {
+    return { ok: false, why: `motion "${m.type}" produced a non-finite transform` };
+  }
+  return r;
+}

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -18,6 +18,7 @@ import { foldSkyEntry, describeSky, effectiveSky, effectiveClock, dayPhase, hour
 // a renderer client and a resident who perceives by reading must agree about
 // what is burning (#25's shared-facts boundary).
 import { describeParticles, emitterTransition, transitionLine } from "../client/lib/particles.js";
+import { effectiveWorldTransform, type Effective } from "./effective.ts";
 
 (globalThis as any).THREE = Object.assign({}, THREE_W, TSL);
 
@@ -96,7 +97,10 @@ function stateToEntries(state: any, skipChatFromSeq = Infinity): any[] {
   // princess stood, her session had no idea she was mounted, antra kept
   // seeing her seated on the crate)
   for (const [rid, m] of Object.entries<any>(state.mounts ?? {})) {
-    add("mount", { id: rid, to: m.to, ...(m.slot ? { slot: m.slot } : {}) }, rid);
+    // full wire shape, like entity parents above — a folded mount that loses
+    // its offset/yaw overrides composes to the wrong seat (#82)
+    add("mount", { id: rid, to: m.to, ...(m.slot ? { slot: m.slot } : {}),
+      ...(m.offset ? { offset: m.offset } : {}), ...(m.yaw != null ? { yaw: m.yaw } : {}) }, rid);
   }
   for (const m of state.recentChat ?? []) {
     if ((m.seq ?? -1) >= skipChatFromSeq) continue;   // the tail will bring these
@@ -176,7 +180,10 @@ export class WorldAgent {
   private walkDone: ((arrived: boolean) => void) | null = null;
   entities = new Map<string, Entity>();
   /** who/what rides what: mount verbs, keyed by the rider (body or thing) */
-  mounts = new Map<string, { to: string; slot?: string }>();
+  /** Every mount's full wire shape — offset/yaw OVERRIDE socket defaults in
+   *  the world transform (#82), so dropping them here made the composed
+   *  position disagree with every renderer. */
+  mounts = new Map<string, { to: string; slot?: string; offset?: number[]; yaw?: number }>();
   people = new Map<string, Person>();
   inbox: InboxItem[] = [];
   private inboxCursor = 0;
@@ -729,7 +736,12 @@ export class WorldAgent {
         // Replay reconstructs the state above and stops there: a fire that was
         // lit last week is in look(), not in your ears (#25).
         if (args.type === "particles" && live) {
-          this.noteEmitter(actor, String(args.id), before, args.data ?? null, e.pos, ts);
+          // proximity-gate on where the emitter's owner ACTUALLY is — a
+          // carried lantern is judged at the carrier, not at its pre-mount
+          // spot (#82); stale pos stays as the fallback when the chain
+          // cannot compose, which matches the old behavior exactly
+          const fx = this.eff(String(args.id), Date.now());
+          this.noteEmitter(actor, String(args.id), before, args.data ?? null, fx.ok ? fx.pos : e.pos, ts);
         }
         // a motion arriving or leaving changes whether this thing may hold a
         // body up (see hasActiveMotion)
@@ -744,7 +756,12 @@ export class WorldAgent {
         this.trackSupport(this.syncSupport(args.id));   // starts moving = stops supporting, and back
       }
     } else if (verb === "mount") {
-      this.mounts.set(args.id, { to: args.to, slot: args.slot });
+      // offset/yaw are kept RAW: effective.ts refuses non-finite values with
+      // a named link rather than silently substituting the socket default —
+      // a substitution would disagree with what the browser renders.
+      this.mounts.set(args.id, { to: args.to, slot: args.slot,
+        ...(args.offset != null ? { offset: args.offset } : {}),
+        ...(args.yaw != null ? { yaw: args.yaw } : {}) });
       // Cargo rides its parent, so its own support goes stale the instant the
       // parent moves — world.js drops the collider here for exactly that
       // reason and lets the pair collide as the parent. Entities only: a
@@ -1517,10 +1534,29 @@ export class WorldAgent {
     return dirs[Math.round(((a + Math.PI * 2) % (Math.PI * 2)) / (Math.PI / 4)) % 8];
   }
 
-  look(): string {
+  /** Where a thing ACTUALLY is right now: the mount chain and any whole-
+   *  entity motion, composed at read time by effective.ts with the same
+   *  closed forms the renderer runs. Every numeric spatial claim in
+   *  perception goes through this — reading `e.pos` directly is how mounted
+   *  cargo was reported 11m from its carrier (#82). */
+  private eff(id: string, nowMs: number): Effective {
+    return effectiveWorldTransform(id, {
+      entity: (eid) => this.entities.get(eid),
+      mount: (eid) => this.mounts.get(eid),
+    }, nowMs);
+  }
+
+  look(nowMs = Date.now()): string {
     const L: string[] = [];
-    const me = this.pos;
-    L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}.`);
+    // The agent's own seat rides its parent too: seated on a moving ferry,
+    // every distance below is measured from where the body actually is.
+    // this.pos itself stays the controller's (dismount restores it) — the
+    // composition is a READ, here and nowhere else.
+    const selfRide = this.mounts.get(this.name);
+    const selfEff = selfRide ? this.eff(this.name, nowMs) : null;
+    const me = selfEff?.ok ? { x: selfEff.pos[0], y: selfEff.pos[1], z: selfEff.pos[2] } : this.pos;
+    const seated = selfRide ? `, seated on ${selfRide.to}${selfEff?.ok && selfEff.moving ? ` (riding its ${selfEff.moving})` : ""}` : "";
+    L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}${seated}.`);
     // Structured object, NEVER a bare string: consumers of look() were
     // reading {hours, azimuth, clouds, ts, …} long before the forecast
     // existed, and a type change here silently breaks them (Sill, postdeploy
@@ -1560,11 +1596,16 @@ export class WorldAgent {
 
     const ents = [...this.entities.values()];
     L.push(ents.length ? `\nThings (${ents.length}):` : "\nNo placed things yet.");
+    // one composition per entity per look, shared by the sort and the line
+    const fx = new Map<string, Effective>();
+    for (const e of ents) fx.set(e.id, this.eff(e.id, nowMs));
+    const sortPos = (e: Entity) => { const f = fx.get(e.id)!; return f.ok ? f.pos : e.pos; };
     for (const e of ents.sort((a, b) => {
-      const da = Math.hypot(a.pos[0] - me.x, a.pos[2] - me.z), db = Math.hypot(b.pos[0] - me.x, b.pos[2] - me.z);
+      const pa = sortPos(a), pb = sortPos(b);
+      const da = Math.hypot(pa[0] - me.x, pa[2] - me.z), db = Math.hypot(pb[0] - me.x, pb[2] - me.z);
       return da - db;
     })) {
-      const dx = e.pos[0] - me.x, dz = e.pos[2] - me.z;
+      const f = fx.get(e.id)!;
       const short = (e.lib ?? "(light)").split("/").pop()!.replace(".glb", "").split("_").slice(0, 5).join(" ");
       // Affordances read out loud: a thing that can be sat on, used, or is
       // moving SAYS SO in text-tier perception — this is how the capability
@@ -1587,10 +1628,22 @@ export class WorldAgent {
       const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles", "lock"].includes(k));
       if (extra.length) aff.push(`components: ${extra.join(", ")}`);
       const ride = this.mounts.get(e.id);
-      if (ride) aff.push(`mounted on ${ride.to}`);
+      if (ride) aff.push(`mounted on ${ride.to}${f.ok && f.moving ? ` (riding its ${f.moving})` : ""}`);
       const riders = [...this.mounts.entries()].filter(([, m]) => m.to === e.id).map(([rid, m]) => `${rid}${m.slot ? ` (${m.slot})` : ""}`);
       if (riders.length) aff.push(`carrying: ${riders.join(", ")}`);
-      L.push(`  - [${e.id}] ${short}: ${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} at (${e.pos[0].toFixed(1)}, ${e.pos[1].toFixed(1)}, ${e.pos[2].toFixed(1)})${e.pos[1] > 0.05 ? " (elevated)" : ""}${aff.length ? ` — ${aff.join(" · ")}` : ""}`);
+      if (f.ok) {
+        // the EFFECTIVE position — mount chain and motion composed at nowMs.
+        // For an unmounted, unmoving thing this is exactly the folded pos.
+        const dx = f.pos[0] - me.x, dz = f.pos[2] - me.z;
+        L.push(`  - [${e.id}] ${short}: ${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} at (${f.pos[0].toFixed(1)}, ${f.pos[1].toFixed(1)}, ${f.pos[2].toFixed(1)})${f.pos[1] > 0.05 ? " (elevated)" : ""}${aff.length ? ` — ${aff.join(" · ")}` : ""}`);
+      } else {
+        // No number is better than a wrong number: when the chain cannot be
+        // composed (a part socket, an unknown motion type, a malformed link),
+        // perception says whose frame the thing rides and why the coordinate
+        // is withheld — never the stale pre-mount pos next to "mounted on".
+        const where = ride ? `position rides ${ride.to}` : `position unavailable`;
+        L.push(`  - [${e.id}] ${short}: ${where} — ${f.why}${aff.length ? ` — ${aff.join(" · ")}` : ""}`);
+      }
     }
     if (ents.some((e) => e.comp?.sockets || e.comp?.reactions)) {
       L.push(`  (interact via world_verb: use {id, action} · sit/ride via mount {id: "${this.name}", to, slot} — both open to everyone; dismount {id: "${this.name}"} to get off)`);

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -369,6 +369,31 @@ export class WorldAgent {
     console.error(`[agent ${this.name}] malformed ${verb} entry — position kept: ${JSON.stringify(args)?.slice(0, 160)}`);
   }
 
+  /** Server-to-local clock offset, smoothed — the headless serverNow()
+   *  (mirrors client/lib/remotes.js: same source, same 0.92/0.08 EMA).
+   *  Motion is a function of SEQUENCER time; evaluating it on a skewed host
+   *  clock makes this body report a different pendulum phase than every
+   *  browser looking at the same swing, while both run the same closed form
+   *  (#92 review, B1). Fed from the embodied plane's frame stamps. */
+  private clockOffset: number | null = null;
+  noteServerTime(t: unknown) {
+    if (typeof t !== "number" || !Number.isFinite(t)) return;
+    const sample = t - Date.now();
+    this.clockOffset = this.clockOffset === null ? sample : this.clockOffset * 0.92 + sample * 0.08;
+  }
+  /** Epoch ms on the sequencer's clock, best estimate. Before the first
+   *  frame lands this is local time — the browser's exact fallback. */
+  serverNow(): number { return Date.now() + (this.clockOffset ?? 0); }
+
+  /** A composition gap is a perception limit, not a world error: say so a
+   *  few times (the noteMalformed bound), then stay quiet. Callers that hit
+   *  one must ABSTAIN, never fall back to a stale coordinate (#92, B2). */
+  effGaps = 0;
+  private noteEffGap(id: string, why: string) {
+    if (this.effGaps++ >= 5) return;
+    console.error(`[agent ${this.name}] effective transform unavailable for ${id} — ${why}`);
+  }
+
   /** A build act (spawn/place/light/remove) near this body counts as activity. */
   private noteBuild(actor: string | undefined, pos: number[] | undefined | null) {
     if (!actor || actor === this.name || actor === "world") return;
@@ -584,7 +609,10 @@ export class WorldAgent {
             this.notePose(msg.id, msg.pose);
             break;
           case "frame":
-            // batched embodied plane: latest pose per id, one message per tick
+            // batched embodied plane: latest pose per id, one message per tick.
+            // The frame's server stamp also feeds the clock estimate — the
+            // same source the browser smooths into serverNow() (#92, B1).
+            this.noteServerTime((msg as { t?: unknown }).t);
             for (const [id, pose] of Object.entries(msg.poses as Record<string, Pose>)) {
               if (id !== this.name) this.notePose(id, pose);
             }
@@ -738,10 +766,13 @@ export class WorldAgent {
         if (args.type === "particles" && live) {
           // proximity-gate on where the emitter's owner ACTUALLY is — a
           // carried lantern is judged at the carrier, not at its pre-mount
-          // spot (#82); stale pos stays as the fallback when the chain
-          // cannot compose, which matches the old behavior exactly
-          const fx = this.eff(String(args.id), Date.now());
-          this.noteEmitter(actor, String(args.id), before, args.data ?? null, fx.ok ? fx.pos : e.pos, ts);
+          // spot (#82). When the chain cannot compose, ABSTAIN: gating on
+          // the stale pos would deliver a live sensory event to people near
+          // an abandoned address and miss those beside the actual carrier
+          // (#92, B2). The gap is logged, bounded, not performed.
+          const fx = this.eff(String(args.id), this.serverNow());
+          if (fx.ok) this.noteEmitter(actor, String(args.id), before, args.data ?? null, fx.pos, ts);
+          else this.noteEffGap(String(args.id), fx.why);
         }
         // a motion arriving or leaving changes whether this thing may hold a
         // body up (see hasActiveMotion)
@@ -1546,17 +1577,26 @@ export class WorldAgent {
     }, nowMs);
   }
 
-  look(nowMs = Date.now()): string {
+  look(nowMs = this.serverNow()): string {
     const L: string[] = [];
     // The agent's own seat rides its parent too: seated on a moving ferry,
     // every distance below is measured from where the body actually is.
     // this.pos itself stays the controller's (dismount restores it) — the
-    // composition is a READ, here and nowhere else.
+    // composition is a READ, here and nowhere else. When the OWN chain
+    // cannot compose (a part-socket seat), the position is UNKNOWN: the
+    // header says so and every dependent distance/bearing below is
+    // suppressed — never measured from the stale controller pos while the
+    // same line claims "seated on" (#92, B2).
     const selfRide = this.mounts.get(this.name);
     const selfEff = selfRide ? this.eff(this.name, nowMs) : null;
+    const meKnown = !selfRide || selfEff?.ok === true;
     const me = selfEff?.ok ? { x: selfEff.pos[0], y: selfEff.pos[1], z: selfEff.pos[2] } : this.pos;
     const seated = selfRide ? `, seated on ${selfRide.to}${selfEff?.ok && selfEff.moving ? ` (riding its ${selfEff.moving})` : ""}` : "";
-    L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}${seated}.`);
+    if (meKnown) {
+      L.push(`You are "${this.name}" in world "${this.world}" at (${me.x.toFixed(1)}, ${me.z.toFixed(1)}), ground height ${me.y.toFixed(2)}m, facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}${seated}.`);
+    } else {
+      L.push(`You are "${this.name}" in world "${this.world}", position unknown (${selfEff && !selfEff.ok ? selfEff.why : "seat unresolved"}), facing ${this.bearing(Math.sin(this.yaw), Math.cos(this.yaw))}${seated}. Distances are withheld until your seat resolves — dismount {id: "${this.name}"} restores a stamped position.`);
+    }
     // Structured object, NEVER a bare string: consumers of look() were
     // reading {hours, azimuth, clouds, ts, …} long before the forecast
     // existed, and a type change here silently breaks them (Sill, postdeploy
@@ -1591,20 +1631,22 @@ export class WorldAgent {
       const posed = held ? `, holding a pose (${Object.keys(held).length} bones)` : "";
       const ride = this.mounts.get(p.id);
       const riding = ride ? ` — on ${ride.to}${ride.slot ? ` (${ride.slot})` : ""}` : "";
-      L.push(`  - ${p.id}: ${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} at (${x.toFixed(1)}, ${z.toFixed(1)}), ${doing}${posed}${riding}`);
+      L.push(`  - ${p.id}: ${meKnown ? `${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} ` : ""}at (${x.toFixed(1)}, ${z.toFixed(1)}), ${doing}${posed}${riding}`);
     }
 
     const ents = [...this.entities.values()];
     L.push(ents.length ? `\nThings (${ents.length}):` : "\nNo placed things yet.");
-    // one composition per entity per look, shared by the sort and the line
+    // one composition per entity per look, shared by the sort and the line.
+    // Resolved things sort by their EFFECTIVE distance; unresolved ones make
+    // no spatial claim at all, so they list last in stable fold order —
+    // never placed by their abandoned pre-mount address (#92, B2). And with
+    // the agent's own position unknown, distance itself means nothing:
+    // fold order for everything.
     const fx = new Map<string, Effective>();
     for (const e of ents) fx.set(e.id, this.eff(e.id, nowMs));
-    const sortPos = (e: Entity) => { const f = fx.get(e.id)!; return f.ok ? f.pos : e.pos; };
-    for (const e of ents.sort((a, b) => {
-      const pa = sortPos(a), pb = sortPos(b);
-      const da = Math.hypot(pa[0] - me.x, pa[2] - me.z), db = Math.hypot(pb[0] - me.x, pb[2] - me.z);
-      return da - db;
-    })) {
+    const sortKey = (e: Entity) => { const f = fx.get(e.id)!; return f.ok ? Math.hypot(f.pos[0] - me.x, f.pos[2] - me.z) : Infinity; };
+    const ordered = meKnown ? [...ents].sort((a, b) => sortKey(a) - sortKey(b)) : ents;
+    for (const e of ordered) {
       const f = fx.get(e.id)!;
       const short = (e.lib ?? "(light)").split("/").pop()!.replace(".glb", "").split("_").slice(0, 5).join(" ");
       // Affordances read out loud: a thing that can be sat on, used, or is
@@ -1634,8 +1676,9 @@ export class WorldAgent {
       if (f.ok) {
         // the EFFECTIVE position — mount chain and motion composed at nowMs.
         // For an unmounted, unmoving thing this is exactly the folded pos.
+        // Distance/bearing only exist relative to a KNOWN self (#92, B2).
         const dx = f.pos[0] - me.x, dz = f.pos[2] - me.z;
-        L.push(`  - [${e.id}] ${short}: ${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} at (${f.pos[0].toFixed(1)}, ${f.pos[1].toFixed(1)}, ${f.pos[2].toFixed(1)})${f.pos[1] > 0.05 ? " (elevated)" : ""}${aff.length ? ` — ${aff.join(" · ")}` : ""}`);
+        L.push(`  - [${e.id}] ${short}: ${meKnown ? `${Math.hypot(dx, dz).toFixed(1)}m ${this.bearing(dx, dz)} ` : ""}at (${f.pos[0].toFixed(1)}, ${f.pos[1].toFixed(1)}, ${f.pos[2].toFixed(1)})${f.pos[1] > 0.05 ? " (elevated)" : ""}${aff.length ? ` — ${aff.join(" · ")}` : ""}`);
       } else {
         // No number is better than a wrong number: when the chain cannot be
         // composed (a part socket, an unknown motion type, a malformed link),

--- a/mcpl/effective-test.ts
+++ b/mcpl/effective-test.ts
@@ -1,0 +1,283 @@
+/**
+ * Effective-transform test — #82: agent perception must report mounted cargo
+ * (and moving things) where they ACTUALLY are, or refuse to give a number.
+ * No servers needed; time is injected everywhere.
+ *
+ * Run: cd mcpl && bun run effective-test.ts
+ *
+ * Fail-on-main controls: the look()-level checks below use only surface that
+ * exists on main (WorldAgent, applyEntry, look), so running this file on a
+ * pre-#82 checkout demonstrates the stale-coordinate contradiction failing
+ * on its own receipts (the pure-module checks report the module as absent).
+ *
+ * Expected values are HAND-COMPUTED from the closed forms — never from the
+ * code under test. Worked math is inline at each case.
+ */
+
+import { WorldAgent } from "./agent.ts";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const near = (a: number, b: number, eps = 1e-4) => Math.abs(a - b) < eps;
+const near3 = (a: number[], b: number[], eps = 1e-4) => a.length === 3 && a.every((v, i) => near(v, b[i], eps));
+
+// effective.ts does not exist on main — load it dynamically so the
+// look()-level receipts still run there.
+let EFF: typeof import("./effective.ts") | null = null;
+try { EFF = await import("./effective.ts"); } catch { /* pre-#82 checkout */ }
+
+const T0 = 1_700_000_000_000;                       // fixed epoch; all time injected
+
+/** An agent that never connects: entries are folded straight through
+ *  applyEntry (live=false = replay semantics), the same door join uses. */
+function offlineAgent(): WorldAgent {
+  return new WorldAgent({ url: "ws://127.0.0.1:9/ws", name: "tester", world: "efftest" });
+}
+const fold = (a: WorldAgent, entry: { verb: string; args: any; actor?: string }, live = false) =>
+  (a as any).applyEntry({ seq: 0, ts: T0, actor: entry.actor ?? "t", ...entry }, live);
+
+// A fake view for the pure module — plain data, no agent.
+const view = (ents: Record<string, any>, mounts: Record<string, any>) => ({
+  entity: (id: string) => ents[id],
+  mount: (id: string) => mounts[id],
+});
+
+// ---- pure module: composition contract -------------------------------------
+console.log("\n━━ effective.ts: the composition contract ━━");
+if (!EFF) {
+  check("effective.ts present", false, "module absent (pre-#82 checkout)");
+} else {
+  const { effectiveWorldTransform: eff } = EFF;
+
+  // static parent + mount offset (no socket)
+  {
+    const r = eff("crate", view(
+      { swing: { pos: [10, 0, 10], yaw: 0 }, crate: { pos: [3, 0, 3], yaw: 0 } },
+      { crate: { to: "swing", offset: [0, 0.55, 0] } }), T0);
+    check("static parent + offset: composed, not stale", r.ok && near3(r.pos, [10, 0.55, 10]), JSON.stringify(r));
+  }
+
+  // socket default; then mount offset/yaw OVERRIDING socket defaults
+  {
+    const ents = { swing: { pos: [0, 0, 0], yaw: 0, comp: { sockets: { seat: { pos: [0, 1, 0], yaw: 1 } } } }, crate: { pos: [9, 9, 9], yaw: 0 } };
+    const bySock = eff("crate", view(ents, { crate: { to: "swing", slot: "seat" } }), T0);
+    check("socket supplies the local frame", bySock.ok && near3(bySock.pos, [0, 1, 0]) && near(bySock.yaw, 1), JSON.stringify(bySock));
+    const byMount = eff("crate", view(ents, { crate: { to: "swing", slot: "seat", offset: [0, 2, 0], yaw: 0.5 } }), T0);
+    check("mount offset/yaw override socket defaults", byMount.ok && near3(byMount.pos, [0, 2, 0]) && near(byMount.yaw, 0.5), JSON.stringify(byMount));
+  }
+
+  // parent yaw + non-1 scalar scale: offset [1,0,0] under yaw π/2, scale 2
+  // rotY(π/2): [x,z] → [x·cosθ + z·sinθ, −x·sinθ + z·cosθ]; [2,0] → [0,−2]
+  {
+    const r = eff("crate", view(
+      { boat: { pos: [10, 0, 10], yaw: Math.PI / 2, scale: 2 }, crate: { pos: [0, 0, 0], scale: 3 } },
+      { crate: { to: "boat", offset: [1, 0, 0] } }), T0);
+    check("parent yaw rotates the offset", r.ok && near3(r.pos, [10, 0, 8]), JSON.stringify(r));
+    check("parent scale scales the offset, scales multiply down", r.ok && near(r.yaw, Math.PI / 2) && near(r.scale, 6), JSON.stringify(r));
+  }
+
+  // moving parent (pendulum) at two explicit nowMs.
+  // θ(t) = amp·e^{-damp·t}·cos(2π t/period + phase); axis x, pivot p, socket s.
+  // Swing shift = p − q·p (yaw 0); crate = swingPos + q·s.
+  //   t=0: θ=0.5 → y = 2.4 − 1.85·cos(0.5), z = 10 − 1.85·sin(0.5)
+  //   t=1s (¼ period of 4s): θ = 0.5·cos(π/2) ≈ 0 → crate at rest point (10, 0.55, 10)
+  {
+    const ents = {
+      swing: { pos: [10, 0, 10], yaw: 0, comp: {
+        sockets: { seat: { pos: [0, 0.55, 0] } },
+        motion: { type: "pendulum", axis: "x", pivot: [0, 2.4, 0], amp: 0.5, period: 4, damp: 0, t0: T0 } } },
+      crate: { pos: [3, 0, 3], yaw: 0 },
+    };
+    const v = view(ents, { crate: { to: "swing", slot: "seat" } });
+    const r1 = eff("crate", v, T0);
+    const r2 = eff("crate", v, T0 + 1000);
+    const y1 = 2.4 - 1.85 * Math.cos(0.5), z1 = 10 - 1.85 * Math.sin(0.5);
+    check("pendulum parent, phase 1: hand-computed", r1.ok && near3(r1.pos, [10, y1, z1]), JSON.stringify(r1));
+    check("pendulum parent, phase 2: back through rest", r2.ok && near3(r2.pos, [10, 0.55, 10], 1e-3), JSON.stringify(r2));
+    check("two nowMs, two positions", r1.ok && r2.ok && !near3(r1.pos, r2.pos, 1e-3));
+    check("the moving link is named", r1.ok && r1.moving === "pendulum", JSON.stringify(r1.ok && r1.moving));
+  }
+
+  // nested root mounts on a path-motion grandparent.
+  // path [[0,0,0]→[10,0,0]], speed 1, 'once', t=5s → ferry (5,0,0), yaw atan2(10,0)=π/2.
+  // Offsets [0,1,0] are yaw-invariant → pallet (5,1,0), crate (5,2,0).
+  {
+    const ents = {
+      ferry: { pos: [0, 0, 0], yaw: 0, comp: { motion: { type: "path", points: [[0, 0, 0], [10, 0, 0]], speed: 1, loop: "once", t0: T0 } } },
+      pallet: { pos: [90, 0, 90], yaw: 0 }, crate: { pos: [80, 0, 80], yaw: 0 },
+    };
+    const v = view(ents, { pallet: { to: "ferry", offset: [0, 1, 0] }, crate: { to: "pallet", offset: [0, 1, 0] } });
+    const r = eff("crate", v, T0 + 5000);
+    check("nested mounts compose recursively", r.ok && near3(r.pos, [5, 2, 0]) && near(r.yaw, Math.PI / 2), JSON.stringify(r));
+  }
+
+  // a body seat: no entity record → the browser's [0, 0.5, 0] body default
+  {
+    const r = eff("rider", view({ bench: { pos: [4, 0, 4], yaw: 0 } }, { rider: { to: "bench" } }), T0);
+    check("a mounted body defaults to the seat offset", r.ok && near3(r.pos, [4, 0.5, 4]), JSON.stringify(r));
+  }
+
+  // refusals: every bad link is named, no number escapes
+  {
+    const cyc = eff("a", view({ a: { pos: [0, 0, 0] }, b: { pos: [1, 1, 1] } }, { a: { to: "b" }, b: { to: "a" } }), T0);
+    check("cycle: refused and named", !cyc.ok && /cycle/.test((cyc as any).why), JSON.stringify(cyc));
+
+    const deepEnts: any = {}, deepMounts: any = {};
+    for (let i = 0; i <= 10; i++) { deepEnts[`c${i}`] = { pos: [i, 0, 0] }; if (i > 0) deepMounts[`c${i}`] = { to: `c${i - 1}` }; }
+    const deep = eff("c10", view(deepEnts, deepMounts), T0);
+    check("over-deep chain: refused", !deep.ok && /deeper/.test((deep as any).why), JSON.stringify(deep));
+
+    const orphan = eff("crate", view({ crate: { pos: [0, 0, 0] } }, { crate: { to: "ghost" } }), T0);
+    check("missing parent: refused, link names the parent", !orphan.ok && (orphan as any).link === "ghost", JSON.stringify(orphan));
+
+    const nan = eff("crate", view({ boat: { pos: [0, 0, 0] }, crate: { pos: [0, 0, 0] } }, { crate: { to: "boat", offset: [1, NaN, 0] } }), T0);
+    check("non-finite offset: refused, never substituted", !nan.ok && /non-finite/.test((nan as any).why), JSON.stringify(nan));
+
+    const part = eff("crate", view(
+      { swing: { pos: [0, 0, 0], comp: { sockets: { seat: { pos: [0, -0.83, 0], part: "plank" } } } }, crate: { pos: [0, 0, 0] } },
+      { crate: { to: "swing", slot: "seat" } }), T0);
+    check("part socket: honestly unsupported in slice one", !part.ok && /part "plank"/.test((part as any).why), JSON.stringify(part));
+
+    const wig = eff("crate", view(
+      { ufo: { pos: [0, 0, 0], comp: { motion: { type: "wiggle", t0: T0 } } }, crate: { pos: [0, 0, 0] } },
+      { crate: { to: "ufo" } }), T0);
+    check("unknown motion type on a link: refused and named", !wig.ok && /wiggle/.test((wig as any).why), JSON.stringify(wig));
+  }
+
+  // part-frame motion does not displace the root (and reports the chain still)
+  {
+    const r = eff("mill", view({ mill: { pos: [7, 0, 7], yaw: 0.3, comp: { motion: { type: "spin", part: "blades", t0: T0 } } } }, {}), T0 + 9000);
+    check("part motion leaves the root at base", r.ok && near3(r.pos, [7, 0, 7]) && r.moving === null, JSON.stringify(r));
+  }
+}
+
+// ---- look(): the sense organ itself ----------------------------------------
+console.log("\n━━ look(): stale coordinates are gone from perception ━━");
+
+const crateLine = (txt: string) => txt.split("\n").find((l) => l.includes("[crate1]")) ?? "";
+const distOf = (line: string) => { const m = line.match(/:\s*([\d.]+)m\s+(\w+)\s+at\s+\(/); return m ? { d: Number(m[1]), b: m[2] } : null; };
+
+// the founding contradiction: mounted cargo printed at its pre-mount spot
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing1", slot: "seat" } });
+  const line = crateLine(a.look(T0));
+  check("mounted cargo reports the carrier's frame", line.includes("at (10.0, 0.6, 10.0)"), line);
+  check("the stale pre-mount coordinate is GONE", !line.includes("(3.0, 0.0, 3.0)"), line);
+  check("still says what it rides", line.includes("mounted on swing1"), line);
+
+  // dismount stamps an authoritative absolute — perception returns to it
+  await fold(a, { verb: "dismount", args: { id: "crate1", pos: [1, 2, 3], yaw: 0.7 } });
+  const after = crateLine(a.look(T0));
+  check("dismount restores the stamped absolute", after.includes("at (1.0, 2.0, 3.0)") && !after.includes("mounted on"), after);
+  a.close();
+}
+
+// distance and bearing move with the effective position, not just the tuple
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "wheel", lib: "models/wheel.glb", pos: [0, 0, 0], yaw: 0 } });
+  await fold(a, { verb: "motion", args: { id: "wheel", type: "orbit", center: [0, 0, 0], radius: 5, degPerSec: 90, face: false, t0: T0 } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [50, 0, 50], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "wheel", offset: [0, 1, 0] } });
+  // orbit: pos = center + r·(sin a, ·, cos a); a = 90°/s. t=0 → (0,·,5) = S of
+  // the origin-standing agent; t=2s → a=π → (0,·,−5) = N. Same distance.
+  const p1 = distOf(crateLine(a.look(T0)));
+  const p2 = distOf(crateLine(a.look(T0 + 2000)));
+  check("bearing follows the ride (S → N)", p1?.b === "S" && p2?.b === "N", JSON.stringify({ p1, p2 }));
+  check("distance is measured to the effective position", p1 != null && near(p1.d, 5, 0.15) && p2 != null && near(p2.d, 5, 0.15), JSON.stringify({ p1, p2 }));
+  a.close();
+}
+
+// the sort walks the composed world too: cargo on a far carrier lists far
+{
+  const a = offlineAgent();
+  // near1 sits at 5m — FARTHER than the crate's stale 4.2m, so a sort on
+  // stale positions lists the crate first and this check fails on main
+  await fold(a, { verb: "spawn", args: { id: "near1", lib: "models/rock.glb", pos: [5, 0, 0], yaw: 0 } });
+  await fold(a, { verb: "spawn", args: { id: "far1", lib: "models/bench.glb", pos: [30, 0, 30], yaw: 0 } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "far1", offset: [0, 1, 0] } });
+  const txt = a.look(T0);
+  check("distance sort uses the effective position", txt.indexOf("[near1]") < txt.indexOf("[crate1]"), txt.split("\n").filter((l) => l.includes("[")).join(" | "));
+  a.close();
+}
+
+// suppression in the sense organ: part sockets and unknown motion say WHY
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "swing2", lib: "models/swing.glb", pos: [5, 0, 5], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing2", type: "sockets", data: { seat: { pos: [0, -0.83, 0], part: "plank" } } } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing2", slot: "seat" } });
+  const line = crateLine(a.look(T0));
+  check("part socket: coordinate withheld, frame named", line.includes("position rides swing2") && !/at \(/.test(line), line);
+  check("part socket: the reason is spoken", /part "plank"/.test(line), line);
+
+  await fold(a, { verb: "spawn", args: { id: "ufo1", lib: "models/ufo.glb", pos: [8, 0, 8], yaw: 0 } });
+  await fold(a, { verb: "motion", args: { id: "ufo1", type: "wiggle", t0: T0 } });
+  const uline = a.look(T0).split("\n").find((l) => l.includes("[ufo1]")) ?? "";
+  check("unknown motion: no guessed coordinate", uline.includes("position unavailable") && /wiggle/.test(uline), uline);
+  a.close();
+}
+
+// the agent's own seat: distances measured from where the body actually is
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } });
+  await fold(a, { verb: "mount", args: { id: "tester", to: "swing1", slot: "seat" } });
+  const head = a.look(T0).split("\n")[0];
+  check("self position rides the seat", head.includes("at (10.0, 10.0)"), head);
+  check("the seat is named", head.includes("seated on swing1"), head);
+  a.close();
+}
+
+// folded replay is EVENT-SILENT: state reconstructs, nothing performs
+{
+  const a = offlineAgent();
+  let events = 0;
+  a.onEvent = () => { events++; };
+  await fold(a, { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 }, actor: "digi" });
+  await fold(a, { verb: "comp", args: { id: "swing1", type: "particles", data: { preset: "fire" } }, actor: "digi" });
+  await fold(a, { verb: "motion", args: { id: "swing1", type: "pendulum", amp: 0.3, t0: T0 }, actor: "digi" });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3] }, actor: "digi" });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing1" }, actor: "digi" });
+  a.look(T0);
+  check("no invented event during folded replay", events === 0 && a.pings.length === 0, `events=${events} pings=${a.pings.length}`);
+  a.close();
+}
+
+// live and folded-join shapes agree: one composition path, byte-identical line
+{
+  const live = offlineAgent();
+  for (const e of [
+    { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } },
+    { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } },
+    { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } },
+  ]) await fold(live, e, true);
+  await fold(live, { verb: "mount", args: { id: "crate1", to: "swing1", slot: "seat" } }, true);
+
+  const folded = offlineAgent();
+  // the synthetic order a folded join produces (stateToEntries): spawns,
+  // then comps, then the mount recovered from entities[].parent — live=false
+  for (const e of [
+    { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } },
+    { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } },
+    { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } },
+    { verb: "mount", args: { id: "crate1", to: "swing1", slot: "seat" } },
+  ]) await fold(folded, e, false);
+
+  const a = crateLine(live.look(T0)), b = crateLine(folded.look(T0));
+  check("live mount and folded late join agree exactly", a === b && a.length > 0, `live: ${a}\n      fold: ${b}`);
+  live.close(); folded.close();
+}
+
+console.log("");
+process.exit(failures ? 1 : 0);

--- a/mcpl/effective-test.ts
+++ b/mcpl/effective-test.ts
@@ -279,5 +279,100 @@ const distOf = (line: string) => { const m = line.match(/:\s*([\d.]+)m\s+(\w+)\s
   live.close(); folded.close();
 }
 
+// ---- #92 review: B1 — motion runs on SEQUENCER time, not the host clock ----
+console.log("\n━━ B1: sequencer-relative clock ━━");
+{
+  const a = offlineAgent();
+  // the embodied plane's frame stamps say the sequencer is 7s AHEAD of this
+  // host; the motion's t0 is in the host's present — so the true phase is
+  // t ≈ 7s, and a host-clock evaluation reads t ≈ 0 instead
+  const skew = 7000;
+  // optional-called so a pre-revision head FAILS the checks below by phase
+  // rather than crashing the file — the control stays a control
+  for (let i = 0; i < 3; i++) (a as any).noteServerTime?.(Date.now() + skew);
+  const t0 = Date.now();
+  await fold(a, { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } });
+  await fold(a, { verb: "motion", args: { id: "swing1", type: "pendulum", axis: "x", pivot: [0, 2, 0], amp: 1, period: 20, damp: 0, t0 } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing1", slot: "seat" } });
+  // crate = base + [0, 2 − 1.45·cosθ, −1.45·sinθ];  θ(7s) = cos(2π·7/20) ≈ −0.5885
+  // → (10.0, 0.8, 10.8).  A host-clock evaluation gives θ(0) = 1 → (10.0, 1.2, 8.8).
+  const def = crateLine(a.look());
+  check("default look() evaluates on sequencer time", def.includes("at (10.0, 0.8, 10.8)"), def);
+  const explicit = crateLine(a.look(Date.now()));
+  check("explicit nowMs is still honored verbatim", explicit.includes("at (10.0, 1.2, 8.8)"), explicit);
+  a.close();
+}
+
+// ---- #92 review: B2 — refusals never fall back to stale coordinates --------
+console.log("\n━━ B2: no stale fallbacks ━━");
+
+// (1) the sort: an unresolved thing makes no spatial claim — it lists last
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "far1", lib: "models/bench.glb", pos: [30, 0, 30], yaw: 0 } });
+  await fold(a, { verb: "spawn", args: { id: "swing2", lib: "models/swing.glb", pos: [5, 0, 5], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing2", type: "sockets", data: { seat: { pos: [0, 0.5, 0], part: "plank" } } } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [1, 0, 1], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing2", slot: "seat" } });
+  const txt = a.look(T0);
+  check("unresolved cargo lists after resolved things, not by its stale 1.4m", txt.indexOf("[far1]") < txt.indexOf("[crate1]"),
+    txt.split("\n").filter((l) => l.includes("[")).join(" | "));
+  a.close();
+}
+
+// (2) the emitter gate: unknown position → abstain + bounded diagnostic
+{
+  const a = offlineAgent();
+  let events = 0;
+  a.onEvent = () => { events++; };
+  await fold(a, { verb: "spawn", args: { id: "swing2", lib: "models/swing.glb", pos: [5, 0, 5], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing2", type: "sockets", data: { seat: { pos: [0, 0.5, 0], part: "plank" } } } });
+  await fold(a, { verb: "spawn", args: { id: "lantern", lib: "models/lantern.glb", pos: [1, 0, 1], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "lantern", to: "swing2", slot: "seat" } });
+  await fold(a, { verb: "comp", args: { id: "lantern", type: "particles", data: { preset: "fire" } }, actor: "digi" }, true);
+  check("unresolvable emitter abstains from proximity delivery", events === 0 && a.effGaps > 0, `events=${events} gaps=${a.effGaps}`);
+  await fold(a, { verb: "spawn", args: { id: "hearth", lib: "models/hearth.glb", pos: [10, 0, 10], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "hearth", type: "particles", data: { preset: "fire" } }, actor: "digi" }, true);
+  check("a resolvable emitter still delivers", events === 1, `events=${events}`);
+  a.close();
+}
+
+// (3) the mounted self: unknown is SAID, and dependent distances are withheld
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "swing2", lib: "models/swing.glb", pos: [5, 0, 5], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing2", type: "sockets", data: { seat: { pos: [0, 0.5, 0], part: "plank" } } } });
+  await fold(a, { verb: "spawn", args: { id: "rock1", lib: "models/rock.glb", pos: [2, 0, 2], yaw: 0 } });
+  await fold(a, { verb: "mount", args: { id: "tester", to: "swing2", slot: "seat" } });
+  const txt = a.look(T0);
+  const head = txt.split("\n")[0];
+  check("own unresolved seat: position unknown, said out loud", head.includes("position unknown") && /part "plank"/.test(head) && head.includes("seated on swing2"), head);
+  check("no distance/bearing is measured from a ghost", !/\d+\.\d+m /.test(txt), txt.split("\n").find((l) => /\d+\.\d+m /.test(l)));
+  check("resolved coordinates still print (facts survive)", txt.includes("[rock1]") && /\[rock1\][^\n]*at \(2\.0, 0\.0, 2\.0\)/.test(txt), txt);
+  a.close();
+}
+
+// ---- #92 review, precision: cargo's own root motion is inert while mounted -
+console.log("\n━━ precision: mount chain wins over own motion ━━");
+{
+  const a = offlineAgent();
+  await fold(a, { verb: "spawn", args: { id: "swing1", lib: "models/bench.glb", pos: [10, 0, 10], yaw: 0 } });
+  await fold(a, { verb: "comp", args: { id: "swing1", type: "sockets", data: { seat: { pos: [0, 0.55, 0] } } } });
+  await fold(a, { verb: "spawn", args: { id: "crate1", lib: "models/crate.glb", pos: [3, 0, 3], yaw: 0 } });
+  await fold(a, { verb: "motion", args: { id: "crate1", type: "orbit", center: [3, 0, 3], radius: 4, degPerSec: 90, t0: T0 - 60_000 } });
+  await fold(a, { verb: "mount", args: { id: "crate1", to: "swing1", slot: "seat" } });
+  // the renderer skips a mounted entity's own motion (motion.js tickMotion:
+  // `obj.userData.mountedTo` guard) — the seat, not the orbit, is the truth
+  const line = crateLine(a.look(T0));
+  check("own root motion is inert while mounted (matches the renderer)", line.includes("at (10.0, 0.6, 10.0)"), line);
+  await fold(a, { verb: "dismount", args: { id: "crate1", pos: [3, 0, 3], yaw: 0 } });
+  const after = crateLine(a.look(T0 + 1000));
+  // dismounted, the orbit resumes: a = 90°/s · 61s = 5490° ≡ 90° → (3+4, 0, 3+0)
+  check("own motion resumes on dismount", after.includes("at (7.0, 0.0, 3.0)"), after);
+  a.close();
+}
+
 console.log("");
 process.exit(failures ? 1 : 0);

--- a/mcpl/effective.ts
+++ b/mcpl/effective.ts
@@ -1,0 +1,114 @@
+// effective — where a thing ACTUALLY is, composed at read time (#82).
+//
+// The fold keeps a mounted entity's pre-mount `pos` untouched — that is
+// correct log-truth (dismount stamps a fresh absolute; nothing here changes
+// that invariant). But perception must never present that stale coordinate
+// as current while also saying "mounted on". This module walks the mount
+// chain the way the browser's scene graph does — parent base pose, the
+// parent's whole-entity motion at `nowMs` (via the SAME evaluator the
+// renderer runs, client/lib/motioneval.js), mount offset/yaw overrides
+// before socket defaults, socket local frame, recursively mounted parents —
+// and returns either a finite world transform or an explicit refusal naming
+// the first link it will not vouch for. No partially composed number is
+// ever returned as truth.
+//
+// Pure by construction: state comes in through a caller-supplied view,
+// time comes in as an argument. agent.ts wraps it; tests drive it bare.
+
+import { evalWholeMotion, qMul, qApply, qAxisAngle, yawOfQuat } from "../client/lib/motioneval.js";
+
+export type EffectiveView = {
+  /** The folded entity, or undefined when `id` is not a thing (a body, or unknown). */
+  entity(id: string): { pos: number[]; yaw?: number; scale?: number; comp?: Record<string, any> } | undefined;
+  /** The live mount record for `id` (thing OR body), or undefined when unmounted. */
+  mount(id: string): { to: string; slot?: string; offset?: number[]; yaw?: number } | undefined;
+};
+
+export type Effective =
+  | { ok: true; pos: [number, number, number]; yaw: number;
+      quat: [number, number, number, number]; scale: number;
+      /** the motion type of the nearest moving link, or null when the chain stands still */
+      moving: string | null }
+  | { ok: false; why: string; link: string };
+
+const fin3 = (v: unknown): v is [number, number, number] =>
+  Array.isArray(v) && v.length === 3 && v.every(Number.isFinite);
+
+/** Default local offset when neither the mount nor a socket provides one.
+ *  Mirrors the browser exactly: world.js applyMount uses [0,0,0] for cargo,
+ *  mountTransform uses [0,0.5,0] for a seated body. */
+const defaultOffset = (isBody: boolean): [number, number, number] => (isBody ? [0, 0.5, 0] : [0, 0, 0]);
+
+export function effectiveWorldTransform(
+  id: string, view: EffectiveView, nowMs: number, maxDepth = 8,
+): Effective {
+  return resolve(id, view, nowMs, maxDepth, new Set());
+}
+
+function resolve(id: string, view: EffectiveView, nowMs: number, depth: number, seen: Set<string>): Effective {
+  if (seen.has(id)) return { ok: false, why: `mount cycle (${[...seen, id].join(" → ")})`, link: id };
+  if (depth <= 0) return { ok: false, why: "mount chain deeper than supported", link: id };
+  seen.add(id);
+
+  const e = view.entity(id);
+  const m = view.mount(id);
+
+  // ---- mounted: the parent's frame is the truth, recursively -----------------
+  if (m) {
+    if (!m.to || m.to === id) return { ok: false, why: "malformed mount (no parent)", link: id };
+    const parent = resolve(m.to, view, nowMs, depth - 1, seen);
+    if (!parent.ok) return parent;                     // the FIRST unsupported link names itself
+
+    const sock = m.slot ? view.entity(m.to)?.comp?.sockets?.[m.slot] : undefined;
+    if (sock && typeof sock.part === "string") {
+      // The seat rides a model part the browser animates from loaded geometry
+      // (part rest transforms) this side does not possess. Refusing is the
+      // honest option — slice one of #82; part support follows when the
+      // geometry does.
+      return { ok: false, why: `socket "${m.slot}" rides part "${sock.part}" of ${m.to} — part geometry unavailable here`, link: m.to };
+    }
+
+    // mount overrides beat socket defaults beat the kind's default — the
+    // browser's exact precedence (world.js applyMount / mountTransform)
+    const isBody = !e;
+    const rawOff = m.offset ?? sock?.pos ?? defaultOffset(isBody);
+    if (!fin3(rawOff)) return { ok: false, why: "non-finite mount/socket offset", link: id };
+    const rawYaw = m.yaw ?? sock?.yaw ?? 0;
+    if (!Number.isFinite(rawYaw)) return { ok: false, why: "non-finite mount/socket yaw", link: id };
+    const ownScale = e?.scale ?? 1;
+    if (!Number.isFinite(ownScale)) return { ok: false, why: "non-finite scale", link: id };
+
+    // child world = parent world ∘ (scaled local offset, then local yaw) —
+    // socket coords are model-frame, so the parent's world scale applies to
+    // them (world.js runs the offset through matrixWorld for the same reason)
+    const local: [number, number, number] = [rawOff[0] * parent.scale, rawOff[1] * parent.scale, rawOff[2] * parent.scale];
+    const d = qApply(parent.quat, local);
+    const pos: [number, number, number] = [parent.pos[0] + d[0], parent.pos[1] + d[1], parent.pos[2] + d[2]];
+    const quat = qMul(parent.quat, qAxisAngle([0, 1, 0], rawYaw)) as [number, number, number, number];
+    const yaw = yawOfQuat(quat);
+    if (!fin3(pos) || !Number.isFinite(yaw)) return { ok: false, why: "composed transform is non-finite", link: id };
+    return { ok: true, pos, yaw, quat, scale: parent.scale * ownScale, moving: parent.moving };
+  }
+
+  // ---- unmounted: the folded base, plus the thing's own whole-entity motion --
+  if (!e) return { ok: false, why: "unknown id (not a thing, and not mounted)", link: id };
+  if (!fin3(e.pos)) return { ok: false, why: "non-finite folded position", link: id };
+  const yaw0 = e.yaw ?? 0;
+  const scale = e.scale ?? 1;
+  if (!Number.isFinite(yaw0) || !Number.isFinite(scale)) return { ok: false, why: "non-finite folded transform", link: id };
+
+  const motion = e.comp?.motion;
+  if (motion && motion.type != null) {
+    const r = evalWholeMotion({ pos: e.pos, yaw: yaw0 }, motion, nowMs);
+    if (!r.ok) return { ok: false, why: r.why, link: id };
+    // part-carrying motion returns the base unmoved (parts swing, roots
+    // stand still) — report the chain as still in that case
+    const rootMoved = typeof motion.part !== "string";
+    return { ok: true, pos: r.pos as [number, number, number], yaw: r.yaw,
+      quat: r.quat as [number, number, number, number], scale,
+      moving: rootMoved ? String(motion.type) : null };
+  }
+
+  return { ok: true, pos: [e.pos[0], e.pos[1], e.pos[2]], yaw: yaw0,
+    quat: qAxisAngle([0, 1, 0], yaw0) as [number, number, number, number], scale, moving: null };
+}

--- a/mcpl/effective.ts
+++ b/mcpl/effective.ts
@@ -54,6 +54,11 @@ function resolve(id: string, view: EffectiveView, nowMs: number, depth: number, 
   const m = view.mount(id);
 
   // ---- mounted: the parent's frame is the truth, recursively -----------------
+  // A mounted entity's OWN root motion is deliberately inert here — the
+  // renderer does exactly this (motion.js tickMotion: `if (!obj ||
+  // obj.userData.mountedTo) continue` — mounted things ride their parent),
+  // so the defined composition order is: mount chain wins, own root motion
+  // resumes on dismount. Pinned by test (#92 review, "additional precision").
   if (m) {
     if (!m.to || m.to === id) return { ok: false, why: "malformed mount (no parent)", link: id };
     const parent = resolve(m.to, view, nowMs, depth - 1, seen);

--- a/tools/motioneval-test.ts
+++ b/tools/motioneval-test.ts
@@ -1,0 +1,187 @@
+/**
+ * motioneval parity fixture — #92 review B3: the motion.js refactor moved
+ * every whole-entity closed form into motioneval.js, so this file pins the
+ * evaluator against an INDEPENDENT reference implementation (Rodrigues
+ * rotation matrices — a different formulation than the module's
+ * quaternions, carried only in this test) plus scalar hand-math, across
+ * every extracted root type and rotation policy. #82 must not repair text
+ * perception by silently changing existing browser motion.
+ *
+ * Run: bun run tools/motioneval-test.ts   (no servers, all time injected)
+ */
+
+import { evalWholeMotion, qApply } from "../client/lib/motioneval.js";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const near = (a: number, b: number, eps = 1e-9) => Math.abs(a - b) < eps;
+const near3 = (a: number[], b: number[], eps = 1e-9) => a.length === 3 && a.every((v, i) => near(v, b[i], eps));
+
+const T0 = 1_700_000_000_000;
+
+// ---- the independent reference: axis-angle as a 3×3 matrix (Rodrigues) -----
+type M3 = number[][];
+const norm3 = (v: number[]) => { const n = Math.hypot(v[0], v[1], v[2]) || 1; return [v[0] / n, v[1] / n, v[2] / n]; };
+const rodrigues = (axis: number[], th: number): M3 => {
+  const [x, y, z] = norm3(axis); const c = Math.cos(th), s = Math.sin(th), C = 1 - c;
+  return [
+    [c + x * x * C, x * y * C - z * s, x * z * C + y * s],
+    [y * x * C + z * s, c + y * y * C, y * z * C - x * s],
+    [z * x * C - y * s, z * y * C + x * s, c + z * z * C],
+  ];
+};
+const mApply = (M: M3, v: number[]) => [
+  M[0][0] * v[0] + M[0][1] * v[1] + M[0][2] * v[2],
+  M[1][0] * v[0] + M[1][1] * v[1] + M[1][2] * v[2],
+  M[2][0] * v[0] + M[2][1] * v[1] + M[2][2] * v[2],
+];
+const mMul = (A: M3, B: M3): M3 => A.map((row, i) => [0, 1, 2].map((j) => row[0] * B[0][j] + row[1] * B[1][j] + row[2] * B[2][j]));
+const sub3 = (a: number[], b: number[]) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const add3 = (a: number[], b: number[]) => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+
+/** Reference rotate-at-pivot: pos = base + Ry·(pivot − R·pivot); Rtot = Ry·R. */
+const refPivot = (base: { pos: number[]; yaw?: number }, axis: number[], pivot: number[], th: number) => {
+  const R = rodrigues(axis, th), Ry = rodrigues([0, 1, 0], base.yaw ?? 0);
+  return { pos: add3(base.pos, mApply(Ry, sub3(pivot, mApply(R, pivot)))), Rtot: mMul(Ry, R) };
+};
+/** A quaternion and a matrix agree iff they act identically on a basis. */
+const quatMatchesM = (q: number[], M: M3, eps = 1e-9) =>
+  [[1, 0, 0], [0, 1, 0], [0, 0, 1]].every((e) => near3(qApply(q, e), mApply(M, e), eps));
+
+// ---- foundation: the module's quaternion action vs Rodrigues ----------------
+console.log("\n━━ foundation: quaternion action ≡ rotation matrix ━━");
+{
+  const cases = [
+    { axis: [1, 0, 0], th: 0.5, v: [0, 2.4, 0] },
+    { axis: [0, 1, 0], th: -1.2, v: [1, 0, 3] },
+    { axis: [1, 1, 0], th: 2.7, v: [0.3, -0.4, 0.5] },
+    { axis: [0.2, -0.5, 0.9], th: 3.9, v: [-2, 1, 0.7] },
+  ];
+  const { qAxisAngle } = await import("../client/lib/motioneval.js");
+  check("qApply agrees with Rodrigues on a mixed grid", cases.every(({ axis, th, v }) =>
+    near3(qApply(qAxisAngle(axis, th), v), mApply(rodrigues(axis, th), v))));
+}
+
+// ---- pendulum: nontrivial yaw, off-axis, off-origin pivot, damping ---------
+console.log("\n━━ pendulum ━━");
+{
+  const base = { pos: [3, 1, -2], yaw: 0.7 };
+  const m = { type: "pendulum", axis: [0, 0, 1], pivot: [0.3, 2, 0.1], amp: 0.6, period: 2.7, phase: 0.4, damp: 0.15, t0: T0 };
+  const t = 1.234;
+  const th = 0.6 * Math.exp(-0.15 * t) * Math.cos((2 * Math.PI / 2.7) * t + 0.4);
+  const ref = refPivot(base, [0, 0, 1], [0.3, 2, 0.1], th);
+  const r = evalWholeMotion(base, m, T0 + 1234);
+  check("position matches the matrix reference", r.ok && near3(r.pos, ref.pos), JSON.stringify(r));
+  check("rotation matches the matrix reference", r.ok && r.rot === true && quatMatchesM(r.quat, ref.Rtot));
+  const r2 = evalWholeMotion(base, { ...m, damp: undefined }, T0 + 1234);
+  const th2 = 0.6 * Math.cos((2 * Math.PI / 2.7) * t + 0.4);
+  check("missing damp = 0 (swings forever)", r2.ok && near3(r2.pos, refPivot(base, [0, 0, 1], [0.3, 2, 0.1], th2).pos));
+  const r3 = evalWholeMotion(base, { type: "pendulum", amplitude: 0.6, axis: "z", pivot: [0.3, 2, 0.1], period: 2.7, phase: 0.4, damp: 0.15, t0: T0 }, T0 + 1234);
+  check("the generous reader: `amplitude` + axis \"z\"", r3.ok && near3(r3.pos, ref.pos));
+}
+
+// ---- spin: string axis, rpm fallback, default pivot ------------------------
+console.log("\n━━ spin ━━");
+{
+  const base = { pos: [-1, 0, 4], yaw: -0.3 };
+  const t = 2.5;
+  const th = 0.2 + (33 * Math.PI / 180) * t;
+  const ref = refPivot(base, [1, 1, 0], [0.5, 0, 0.5], th);
+  const r = evalWholeMotion(base, { type: "spin", axis: [1, 1, 0], pivot: [0.5, 0, 0.5], degPerSec: 33, phase: 0.2, t0: T0 }, T0 + 2500);
+  check("position matches the matrix reference", r.ok && near3(r.pos, ref.pos), JSON.stringify(r));
+  check("rotation matches the matrix reference", r.ok && r.rot === true && quatMatchesM(r.quat, ref.Rtot));
+  const rpm = evalWholeMotion(base, { type: "spin", rpm: 10, t0: T0 }, T0 + 2500);
+  const refRpm = refPivot(base, [0, 1, 0], [0, 0, 0], (10 * 6 * Math.PI / 180) * t);   // rpm → deg/s ×6; default axis y, pivot origin
+  check("rpm fallback (×6) with default axis/pivot", rpm.ok && near3(rpm.pos, refRpm.pos) && quatMatchesM(rpm.quat, refRpm.Rtot));
+}
+
+// ---- orbit: face on/off, defaults ------------------------------------------
+console.log("\n━━ orbit ━━");
+{
+  const base = { pos: [7, 0.5, 7], yaw: 1.1 };
+  const t = 1.7;
+  const a = 0.3 + (45 * Math.PI / 180) * t;
+  const on = evalWholeMotion(base, { type: "orbit", center: [1, 2, 3], radius: 2.5, degPerSec: 45, phase: 0.3, t0: T0 }, T0 + 1700);
+  check("face on: position on the circle", on.ok && near3(on.pos, [1 + 2.5 * Math.sin(a), 2, 3 + 2.5 * Math.cos(a)]), JSON.stringify(on));
+  check("face on: yaw leads the tangent, rot true", on.ok && on.rot === true && near(on.yaw, a + Math.PI / 2));
+  const off = evalWholeMotion(base, { type: "orbit", center: [1, 2, 3], radius: 2.5, degPerSec: 45, phase: 0.3, face: false, t0: T0 }, T0 + 1700);
+  check("face off: same position, rot false, authored yaw", off.ok && near3(off.pos, on.pos) && off.rot === false && near(off.yaw, 1.1));
+  const dflt = evalWholeMotion(base, { type: "orbit", t0: T0 }, T0 + 1700);
+  const ad = (12 * Math.PI / 180) * t;   // defaults: center=base.pos, radius 3, 12°/s
+  check("defaults: center=base, radius 3, 12°/s", dflt.ok && near3(dflt.pos, [7 + 3 * Math.sin(ad), 0.5, 7 + 3 * Math.cos(ad)]));
+}
+
+// ---- bob: off-axis, default amp, rot policy --------------------------------
+console.log("\n━━ bob ━━");
+{
+  const base = { pos: [2, 3, 4], yaw: 0.9 };
+  const t = 0.8;
+  const offv = Math.sin((2 * Math.PI / 1.9) * t + 0.6) * 0.45;
+  const r = evalWholeMotion(base, { type: "bob", axis: "-x", amp: 0.45, period: 1.9, phase: 0.6, t0: T0 }, T0 + 800);
+  check("off-axis bob displaces along −x only", r.ok && near3(r.pos, [2 - offv, 3, 4]), JSON.stringify(r));
+  check("bob never touches rotation", r.ok && r.rot === false && near(r.yaw, 0.9));
+  const d = evalWholeMotion(base, { type: "bob", period: 1.9, phase: 0.6, t0: T0 }, T0 + 800);
+  check("default amp 0.3 on default axis y", d.ok && near3(d.pos, [2, 3 + Math.sin((2 * Math.PI / 1.9) * t + 0.6) * 0.3, 4]));
+}
+
+// ---- path: corner traversal, all loop modes, face policy -------------------
+console.log("\n━━ path ━━");
+{
+  const base = { pos: [0, 0, 0], yaw: 0.4 };
+  const pts = [[0, 0, 0], [4, 0, 0], [4, 0, 4]];                  // total length 8
+  const at = (t: number, extra = {}) => evalWholeMotion(base, { type: "path", points: pts, speed: 2, t0: T0, ...extra }, T0 + t * 1000);
+  const r1 = at(1);                                               // s=2, mid segment 1 (+x)
+  check("mid-segment interpolation", r1.ok && near3(r1.pos, [2, 0, 0]), JSON.stringify(r1));
+  check("face: yaw follows the segment (+x = π/2), rot true", r1.ok && r1.rot === true && near(r1.yaw, Math.PI / 2));
+  const r2 = at(3);                                               // s=6, segment 2 (+z), f=0.5
+  check("corner crossed: second segment, yaw 0", r2.ok && near3(r2.pos, [4, 0, 2]) && near(r2.yaw, 0));
+  const loop = at(5);                                             // s=10 → %8 = 2
+  check("loop wraps", loop.ok && near3(loop.pos, [2, 0, 0]));
+  const ping = at(5, { loop: "pingpong" });                       // s=10 → 16−10=6
+  check("pingpong reflects", ping.ok && near3(ping.pos, [4, 0, 2]));
+  const once = at(5, { loop: "once" });                           // s clamps at 8
+  check("once arrives and stays", once.ok && near3(once.pos, [4, 0, 4]));
+  const nf = at(1, { face: false });
+  check("face off: rot false, authored yaw kept", nf.ok && near3(nf.pos, [2, 0, 0]) && nf.rot === false && near(nf.yaw, 0.4));
+}
+
+// ---- missing t0: the fallback anchor's lifetime ----------------------------
+console.log("\n━━ missing t0 ━━");
+{
+  const base = { pos: [1, 1, 1], yaw: 0 };
+  const m: any = { type: "bob", amp: 0.5, period: 2 };            // phase 0, no t0
+  const first = evalWholeMotion(base, m, T0);
+  check("first evaluation anchors: t=0, at base", first.ok && near3(first.pos, [1, 1, 1]));
+  const later = evalWholeMotion(base, m, T0 + 500);               // same object → t=0.5s
+  check("same object keeps its anchor", later.ok && near3(later.pos, [1, 1 + Math.sin((2 * Math.PI / 2) * 0.5) * 0.5, 1]));
+  const fresh = evalWholeMotion(base, { type: "bob", amp: 0.5, period: 2 }, T0 + 500);
+  check("a new object anchors fresh (re-folded comp = new epoch)", fresh.ok && near3(fresh.pos, [1, 1, 1]));
+  check("evaluation never mutates the component bag", !("_t0" in m) && !("_len" in m), JSON.stringify(Object.keys(m)));
+}
+
+// ---- refusals: explicit, named, and never a throw --------------------------
+console.log("\n━━ refusals ━━");
+{
+  const base = { pos: [0, 0, 0], yaw: 0 };
+  const cases: Array<[string, any]> = [
+    ["unknown type", { type: "wiggle", t0: T0 }],
+    ["path with one point", { type: "path", points: [[0, 0, 0]], t0: T0 }],
+    ["path with no points", { type: "path", t0: T0 }],
+    ["pendulum with period 0 (non-finite phase)", { type: "pendulum", amp: 1, period: 0, t0: T0 }],
+    ["pendulum with NaN pivot", { type: "pendulum", amp: 1, pivot: [NaN, 0, 0], t0: T0 }],
+    ["no type at all", {}],
+  ];
+  for (const [label, m] of cases) {
+    let r: any = null, threw = false;
+    try { r = evalWholeMotion(base, m, T0 + 1000); } catch { threw = true; }
+    check(`${label}: refused, not thrown`, !threw && r && r.ok === false && typeof r.why === "string", JSON.stringify(r));
+  }
+  const part = evalWholeMotion({ pos: [5, 0, 5], yaw: 0.2 }, { type: "spin", part: "blades", t0: T0 }, T0 + 9000);
+  check("part-carrying motion: root unmoved, rot false", part.ok && near3(part.pos, [5, 0, 5]) && part.rot === false && near(part.yaw, 0.2));
+}
+
+console.log("");
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Closes #82. Built to the amended contract from the issue thread; full receipts are in [the issue comment](https://github.com/anima-research/eidoverse-worlds/issues/82#issuecomment-5239767526) — summary below.

## What this does

Agent perception now reports mounted cargo (and moving things) where they **actually are**, composed at read time — or refuses to give a number, naming the first link it will not vouch for. The stale pre-mount coordinate never again prints next to `mounted on`.

```
before:  - [crate1] crate: 4.2m SE at (3.0, 0.0, 3.0) — mounted on swing1
after:   - [crate1] crate: 5.4m S at (0.0, 0.7, 5.4) — mounted on bench1 (riding its pendulum)
also:    - [crate2] crate: position rides swing2 — socket "seat" rides part "plank" of swing2 — part geometry unavailable here
```

## Three commits

1. **`motioneval.js` extraction** — the whole-entity closed forms (pendulum/spin/orbit/bob/path), the generous reader, and the epoch math leave `motion.js` for a dependency-free pure module: `{base, motion, nowMs}` in, finite transform or explicit `{ok:false, why}` out. The renderer consumes it per frame, the agent at read time — mirrored math is now the same file (the `forecast.js` arrangement, applied to dynamics). `rot:false` preserves the old rotation-untouched cases exactly; the `t0`/path caches move off component bags into WeakMaps.
2. **`effective.ts` + agent wiring** — composes parent base pos + yaw + scalar scale, whole-entity motion at explicit `nowMs`, mount `offset`/`yaw` overrides before socket defaults, socket local frame, recursive parents, cycle detection, bounded depth. One helper feeds **every** numeric reader: tuple, distance, bearing, the sort, the emitter proximity gate, and the agent's own seat (flagged in the issue as a judgment call). Part sockets refuse honestly in this slice. Folded `pos` and dismount stamping untouched; live and folded join share one composition path. `mounts` now retains the wire's `offset`/`yaw` (live and folded — it was dropping them).
3. **`effective-test.ts`** — one check per acceptance bullet, expectations hand-computed from the closed forms, all time injected.

## Receipts

- Branch: `effective-test.ts` **32/32** · `smoke` **85/85** · `comptest` **33/0** · `worldops-test` **20/0** · denoise/manifest green · `permtest` 21/2 with both failures verified pre-existing on pristine main (agent-token environment).
- Fail-on-main: the test file on a pre-#82 checkout → **10 failures**, the first reproducing this issue's founding contradiction verbatim.
- Live parity over a real socket: renderer scene graph sampled the cargo at `(0, .65, 5.41) → (0, .56, 6.14) → (0, .66, 6.63)`; a connected `WorldAgent` read `(0.0, 0.7, 5.4)` then `(0.0, 0.6, 6.0)` — two runtimes, one arc.
- Replay silence pinned: folding spawn/comp/motion/mount with `live=false` produces zero events, zero pings.

No fold changes, no protocol changes, nothing server-side. Isolated branch throughout; no live world touched.

— I.M. & Cormundus
