### PR TITLE
agent: a moderation close releases its support holders — 4006 goes through close() (#83)

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -418,7 +418,13 @@ export class WorldAgent {
         // 4006 = removed by moderation (kicked or banned). Reconnecting would
         // either hammer a banned door or instantly undo a kick — the body
         // stays down; its host reconnecting later is the deliberate return.
-        if ((ev as { code?: number } | undefined)?.code === 4006) { this.closed = true; return; }
+        // The branch's meaning is close()'s meaning ("never reconnect, stop
+        // the body"), so it goes THROUGH close(): setting `closed` alone left
+        // every support holder this instance owned registered in the
+        // process-global physics state — a ghost floor by the moderation
+        // door, holding up bodies in later worlds at the same coordinates
+        // (#83; the #17 symptom reached through a ban).
+        if ((ev as { code?: number } | undefined)?.code === 4006) { this.close(); return; }
         if (!this.closed) setTimeout(() => this.connect().catch(() => {}), 1500);
       };
       ws.onmessage = async (ev) => {

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -130,6 +130,12 @@ export async function registerSupport(
   m.colliders.fitSupportBox(id, min, max, xform);
 }
 
+/** test/debug probe — who holds which support box (the world_debug spirit:
+ *  the first question about a ghost floor is answered by looking, not by
+ *  re-deriving process state). Copies, not live references. */
+export const supportHolders = (): Record<string, string[]> =>
+  Object.fromEntries([...holders].map(([id, hs]) => [id, [...hs]]));
+
 export async function removeSupport(holder: string, id: string) {
   const m = await loadSim();
   if (!m) return;

--- a/tools/modclose-support-test.ts
+++ b/tools/modclose-support-test.ts
@@ -1,0 +1,111 @@
+/**
+ * Moderation-close support-holder test — #83: a 4006 (kick/ban) must release
+ * every support holder the closed instance owns, exactly like a deliberate
+ * close(). Before the fix, the 4006 branch set `closed` and returned, and the
+ * leaked box held bodies up in LATER worlds at the same coordinates (#17's
+ * ghost floor, reached through moderation).
+ *
+ * The whole run rides the REAL moderation path over a real socket — an owner
+ * bans and kicks; nothing calls a release helper directly (the issue's
+ * acceptance). The registry is observed through physics.supportHolders(),
+ * shared module state in this process, the same state that leaked.
+ *
+ * Run:
+ *   EIDOVERSE_DIR=/path/to/eidoverse-video bun run tools/modclose-support-test.ts
+ * (spawns its own scratch sequencer; EIDOVERSE_DIR must point at a real
+ *  library checkout — support boxes come from /geom reading actual GLBs)
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorldAgent } from "../mcpl/agent.ts";
+import { supportHolders } from "../mcpl/physics.ts";
+
+const PORT = Number(process.env.PORT ?? 8996);
+const URL_ = `ws://127.0.0.1:${PORT}/ws`;
+const WORLD = "modtest";
+const CRATE = "eidoverse/assets/models/crate_large_blue.glb";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Poll until `cond` holds or `ms` elapses — moderation lands over a socket
+ *  and removeSupport is detached, so every assertion is an eventually. */
+async function until(cond: () => boolean, ms = 6000, step = 100) {
+  const t0 = Date.now();
+  while (!cond() && Date.now() - t0 < ms) await sleep(step);
+  return cond();
+}
+/** Every holder token currently registered, across all boxes. */
+const allHolders = () => new Set(Object.values(supportHolders()).flat());
+
+// ---- scratch sequencer ------------------------------------------------------
+if (!process.env.EIDOVERSE_DIR) {
+  console.error("EIDOVERSE_DIR must point at an eidoverse-video checkout (support geometry comes from /geom).");
+  process.exit(1);
+}
+const server = spawn("bun", [join(import.meta.dir, "..", "server", "server.ts")], {
+  env: { ...process.env, PORT: String(PORT), WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-modtest-")), JOIN_TOKEN: "" },
+  stdio: "ignore",
+});
+const stop = () => { try { server.kill(); } catch {} };
+process.on("exit", stop);
+await sleep(1500);
+
+// ---- the warden: first embodied joiner = owner; moderation is verbs --------
+const warden = new WebSocket(URL_);
+const wardenVerb = (verb: string, args: any) => warden.send(JSON.stringify({ type: "verb", verb, args }));
+await new Promise<void>((res, rej) => {
+  warden.onopen = () => { warden.send(JSON.stringify({ type: "join", world: WORLD, id: "warden", avatar: "eidoverse/assets/vrms/claude.vrm" })); res(); };
+  warden.onerror = () => rej(new Error("warden failed to connect — is the scratch server up?"));
+});
+await sleep(400);
+
+// ---- two residents, one platform -------------------------------------------
+const victim = new WorldAgent({ url: URL_, name: "victim", world: WORLD });
+const bystander = new WorldAgent({ url: URL_, name: "bystander", world: WORLD });
+await victim.connect();
+await bystander.connect();
+wardenVerb("spawn", { id: "deck1", lib: CRATE, pos: [0, 0, 0], yaw: 0 });
+await (victim as any).supportReady(6000);
+await (bystander as any).supportReady(6000);
+
+const vTok = (victim as any).supportHolder as string;
+const bTok = (bystander as any).supportHolder as string;
+const okSetup = await until(() => allHolders().has(vTok) && allHolders().has(bTok));
+check("both residents hold support on the shared platform", okSetup, JSON.stringify(supportHolders()));
+
+console.log("\n━━ ban: code 4006 releases the banned instance's holders ━━");
+wardenVerb("ban", { id: "victim", reason: "#83 regression" });
+check("the ban lands as a terminal close", await until(() => victim.closed), `closed=${victim.closed}`);
+check("the banned instance's holders are RELEASED", await until(() => !allHolders().has(vTok)), JSON.stringify(supportHolders()));
+check("the co-resident's holders survive the neighbor's ban", allHolders().has(bTok), JSON.stringify(supportHolders()));
+check("the box itself survives while anyone still holds it", Object.keys(supportHolders()).length > 0, JSON.stringify(supportHolders()));
+
+console.log("\n━━ kick: the final holder leaves, the box disappears ━━");
+wardenVerb("kick", { id: "bystander", reason: "#83 regression" });
+check("the kick lands as a terminal close", await until(() => bystander.closed), `closed=${bystander.closed}`);
+check("no leaked box remains — a later occupant sees terrain", await until(() => Object.keys(supportHolders()).length === 0), JSON.stringify(supportHolders()));
+
+console.log("\n━━ successor: same name, own holders, unharmed by its predecessor ━━");
+// a kick permits return (a ban would not) — the successor is a NEW instance
+// wearing the old name, which is exactly the collision #53's per-instance
+// tokens exist to survive
+const successor = new WorldAgent({ url: URL_, name: "bystander", world: WORLD });
+await successor.connect();
+await (successor as any).supportReady(6000);
+const sTok = (successor as any).supportHolder as string;
+check("the successor registers under its OWN token", await until(() => allHolders().has(sTok)), JSON.stringify(supportHolders()));
+check("no stale predecessor token rides along", !allHolders().has(bTok) && !allHolders().has(vTok), JSON.stringify(supportHolders()));
+successor.close();
+check("normal close still releases (unchanged semantics)", await until(() => Object.keys(supportHolders()).length === 0), JSON.stringify(supportHolders()));
+
+try { warden.close(); } catch {}
+stop();
+console.log("");
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Closes #83, taken up on Mica's pointer. One commit, head `e46c0cf`.

**The repair is the issue's own "likely repair."** The terminal 4006 branch's meaning is already `close()`'s meaning — "never reconnect, stop the body" — so it now routes through it instead of setting `closed` and returning. `close()` is idempotent by construction (delete-as-you-go, null-guarded throughout), verified before routing; a session that dutifully calls `close()` after a ban double-releases nothing.

**One new probe:** `physics.supportHolders()` — who holds which box, copies not live references. The world_debug spirit: the first question about a ghost floor should be answered by looking, and until now the registry was invisible except by writing a bespoke probe (as the #53 review had to).

**The regression walks the real moderation path**, per the acceptance: `tools/modclose-support-test.ts` spawns a scratch sequencer, an owner spawns a real-GLB platform, two `WorldAgent` residents register support on it over the wire, and then the owner **bans** one and **kicks** the other. No release helper is called directly. Pinned, in order: the banned instance's holders release; the co-resident's survive its neighbor's ban; the final holder's departure removes the box (a later occupant sees terrain); a same-name successor after the kick holds only its own token, no stale predecessor riding along; and a normal `close()` still releases — unchanged semantics.

**Receipts:** with the fix, **10/10**. With only the one-line branch reverted (probe and test in place), **4 failures** — and the detail lines show the disease directly: `{"modtest/deck1": ["agent#1", "agent#2"]}` after both residents were moderated out, the banned and kicked instances' tokens registered forever, then `["agent#1", "agent#2", "agent#3"]` as the successor stacks its own on top of the ghosts. Broader sweep on the branch: `effective-test` 42/42, `denoise`/`manifest` green, `smoke` 85/85.

— I.M. & Cormundus
