### PR TITLE
headless support: floor-shaped tops that lie become truthful heightfields, or declared abstentions (#84)

### DIFF
--- a/client/lib/colliders.js
+++ b/client/lib/colliders.js
@@ -135,7 +135,7 @@ function hasFloor(bvh, box, s) {
 // the headless support pipeline classifies with the SAME module, so the two
 // runtimes cannot drift about which box tops lie. This adapter's own job is
 // only what a renderer can do — walking loaded THREE meshes for vertices.
-function topLie(obj, box) {
+export function topLie(obj, box) {   // exported for the classifier-parity fixture (#94 B2)
   const w = box.max.x - box.min.x, d = box.max.z - box.min.z;
   const acc = gridAccumulator(box.min.x, box.min.z, w, d);
   if (!acc) return 0;

--- a/client/lib/colliders.js
+++ b/client/lib/colliders.js
@@ -14,6 +14,7 @@
 import { THREE } from './core.js';
 import { MeshBVH } from 'three-mesh-bvh';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { gridAccumulator, decideSupportClass, validTopGrid, LIE_GRID } from './supportclass.js';
 
 const UP = new THREE.Vector3(0, 1, 0);
 export const colliders = new Map(); // entity id -> { obj, box, pillar, exact?, interior, cell }
@@ -130,33 +131,28 @@ function hasFloor(bvh, box, s) {
 // case and never disagrees about the threshold. (Library-wide it drifts up to
 // 2.5m on tall structured things — a watchtower, a perimeter wall — which is
 // exactly why the shape gate runs before the probe is consulted.)
-const LIE_GRID = 24;
+// The grid/median math and its constants live in supportclass.js now (#84):
+// the headless support pipeline classifies with the SAME module, so the two
+// runtimes cannot drift about which box tops lie. This adapter's own job is
+// only what a renderer can do — walking loaded THREE meshes for vertices.
 function topLie(obj, box) {
   const w = box.max.x - box.min.x, d = box.max.z - box.min.z;
-  if (!(w > 0) || !(d > 0)) return 0;
+  const acc = gridAccumulator(box.min.x, box.min.z, w, d);
+  if (!acc) return 0;
   obj.updateMatrixWorld(true);
   const inv = new THREE.Matrix4().copy(obj.matrixWorld).invert();
   const rel = new THREE.Matrix4();
   const v = new THREE.Vector3();
-  const cells = new Float64Array(LIE_GRID * LIE_GRID).fill(-Infinity);
   obj.traverse((o) => {
     if (!o.isMesh || !o.geometry?.attributes?.position) return;
     const pos = o.geometry.attributes.position;
     rel.multiplyMatrices(inv, o.matrixWorld);
     for (let i = 0; i < pos.count; i++) {
       v.fromBufferAttribute(pos, i).applyMatrix4(rel);
-      const cx = Math.min(LIE_GRID - 1, Math.max(0, Math.floor(((v.x - box.min.x) / w) * LIE_GRID)));
-      const cz = Math.min(LIE_GRID - 1, Math.max(0, Math.floor(((v.z - box.min.z) / d) * LIE_GRID)));
-      const k = cz * LIE_GRID + cx;
-      if (v.y > cells[k]) cells[k] = v.y;
+      acc.add(v.x, v.y, v.z);
     }
   });
-  const tops = [];
-  for (let i = 0; i < cells.length; i++) if (cells[i] !== -Infinity) tops.push(cells[i]);
-  if (tops.length < 8) return 0;   // a 4-corner quad covers 4 cells: too sparse to accuse
-  tops.sort((a, b) => a - b);
-  const h = tops.length >> 1;
-  return box.max.y - (tops.length % 2 ? tops[h] : (tops[h - 1] + tops[h]) / 2);
+  return acc.finish(box.max.y).lie;
 }
 
 function decide(entry, s) {
@@ -174,7 +170,9 @@ function decide(entry, s) {
   // per-object `collide` override still wins over any of it.
   const w = (box.max.x - box.min.x) * s, d = (box.max.z - box.min.z) * s;
   const h = (box.max.y - box.min.y) * s;
-  const roomScale = w * d >= 16 && h >= 2.2;
+  // shape gates come from the shared classifier (supportclass.js) — the
+  // numbers below in the comments are ITS constants, kept in one place
+  const { roomScale } = decideSupportClass({ w, d, h });
   // The exception: FLOOR-SHAPED things whose box top is a lie. Wide enough to
   // stand on, low enough that standing on it is the only thing a body would
   // ever do with it — a blanket, a rug, a pillow pile — and with a real gap
@@ -188,8 +186,11 @@ function decide(entry, s) {
   // more — both rubble piles (which float you 0.73m and 0.44m, worse than the
   // blanket), five hovercars, a shark. If those should firm up too, this is
   // the one line to move.
-  const floorShaped = !roomScale && w * d >= 2 && h <= 1.0;
-  const uneven = floorShaped && (entry.lie ??= topLie(entry.obj, box)) * s > 0.10;
+  const { floorShaped } = decideSupportClass({ w, d, h });
+  // the lie probe stays LAZY — it walks every vertex, so it only runs once
+  // the cheap shape gates have admitted the candidate (same as always)
+  const uneven = floorShaped
+    && decideSupportClass({ w, d, h, lie: (entry.lie ??= topLie(entry.obj, box)) * s }).uneven;
   const exact = pref === 'exact' ? true : pref === 'box' ? false : (roomScale || uneven);
   if (exact && !entry.exact) entry.exact = buildExact(entry.obj);
   if (!exact) entry.exact = null;         // small/solid: use pillar/box, no trimesh
@@ -237,6 +238,38 @@ export function fitSupportBox(id, min, max, { position, yaw = 0, scale = 1 } = {
   entry.pillar = (box.max.y - box.min.y) * scale > 2.4;
   colliders.set(id, entry);
   bucketAdd(id, entry);
+}
+
+/** Register HEIGHTFIELD support from a served topGrid — the headless door
+ *  for floor-shaped assets whose box top is a known lie (#84; the data-tier
+ *  sibling of fitSupportBox, #17's door). The grid is the same 24×24
+ *  max-y-per-cell probe decide() trusts to DETECT the lie, surveyed to
+ *  1.8cm against raycast inside this population — so here it IS the floor.
+ *  Cells are model-local; the entry composes with the entity transform like
+ *  every other collider. Support only: a blanket has no walls.
+ *  Returns false (registering nothing) for any payload validTopGrid
+ *  refuses — the caller's duty on refusal is to abstain, never box-top. */
+export function fitSupportGrid(id, topGrid, { position, yaw = 0, scale = 1 } = {}) {
+  if (!validTopGrid(topGrid)) return false;
+  if (![position].every((v) => Array.isArray(v) && v.length === 3 && v.every(Number.isFinite))
+      || !Number.isFinite(yaw) || !Number.isFinite(scale) || !(scale > 0)) return false;
+  const [minX, minZ] = topGrid.minXZ, [w, d] = topGrid.sizeXZ;
+  let lo = Infinity, hi = -Infinity;
+  for (const c of topGrid.cells) if (c !== null) { if (c < lo) lo = c; if (c > hi) hi = c; }
+  const box = new THREE.Box3(
+    new THREE.Vector3(minX, lo, minZ),
+    new THREE.Vector3(minX + w, hi, minZ + d),
+  );
+  const obj = {
+    position: new THREE.Vector3(position[0], position[1], position[2]),
+    rotation: { y: yaw },
+    scale: new THREE.Vector3(scale, scale, scale),
+  };
+  const entry = { obj, box, pref: 'box', exact: null, interior: false, pillar: false, cells: [],
+    grid: { n: topGrid.n, minX, minZ, w, d, tops: topGrid.cells } };
+  colliders.set(id, entry);
+  bucketAdd(id, entry);   // radial footprint: the world bounds follow yaw and scale
+  return true;
 }
 
 /** Call after an in-world rescale: re-decides exact-vs-box against the NEW
@@ -312,7 +345,27 @@ export function resolveColliders(pos, terrainAt, r = 0.32, tall = TALL) {
   const step = Math.min(STEP, tall * 0.3);   // a ragdoll does not climb stairs
   const probeY = Math.min(HIP, tall * 0.5);  // mid-body, not "hip"
   const spanY = Math.max(r, tall * 0.26);    // how far up/down a wall hit counts
-  for (const { obj, box, pillar, exact } of near(pos.x, pos.z)) {
+  for (const { obj, box, pillar, exact, grid } of near(pos.x, pos.z)) {
+    if (grid) {
+      // Heightfield support (#84): the CONTAINING cell's max-y is the ground
+      // — nearest occupied cell, piecewise-constant, no interpolation. An
+      // empty cell offers NOTHING: bilinear smoothing would bridge air and
+      // manufacture floors, so stepping off the cloth's edge finds terrain,
+      // exactly as the browser's exact triangles would have it.
+      const gs = obj.scale?.x || 1;
+      _local.set(pos.x - obj.position.x, 0, pos.z - obj.position.z)
+        .applyAxisAngle(UP, -obj.rotation.y).divideScalar(gs);
+      const gx = Math.floor(((_local.x - grid.minX) / grid.w) * grid.n);
+      const gz = Math.floor(((_local.z - grid.minZ) / grid.d) * grid.n);
+      if (gx >= 0 && gx < grid.n && gz >= 0 && gz < grid.n) {
+        const top = grid.tops[gz * grid.n + gx];
+        if (top !== null) {
+          const gy = obj.position.y + top * gs;
+          if (gy <= pos.y + step && gy > ground) ground = gy;
+        }
+      }
+      continue; // support only — never box-test a grid entry (no false walls)
+    }
     if (exact) {
       // work in entity-local space (yaw-only rotation, uniform scale)
       const s = obj.scale.x || 1;
@@ -412,8 +465,9 @@ export function resolveColliders(pos, terrainAt, r = 0.32, tall = TALL) {
  *  the geometry IS the affordance. Returns {y, x, z, yaw, id} or null. */
 export function findSeat(pos, range = 1.2) {
   let best = null;
-  for (const [id, { obj, box, pillar, exact }] of colliders) {
+  for (const [id, { obj, box, pillar, exact, grid }] of colliders) {
     if (pillar || exact) continue; // interiors aren't chairs; furniture inside them is
+    if (grid) continue; // a heightfield's box top is the lie we exist to avoid — no phantom seat offers (#11)
     const sc = obj.scale?.x || 1;
     const topY = obj.position.y + box.max.y * sc;
     const rise = topY - pos.y;

--- a/client/lib/supportclass.js
+++ b/client/lib/supportclass.js
@@ -24,6 +24,15 @@ export const FLOOR_MIN_AREA = 2;         // m² (scaled) — smaller and nobody 
 export const FLOOR_MAX_H = 1.0;          // m (scaled) — decide()'s one movable line
 export const UNEVEN_MIN_LIE = 0.10;      // m (scaled) — below this a box is honest enough
 export const TOPGRID_MAX_JSON = 8192;    // hard cap on the serialized payload
+/** Per-cell certification (#94 review B1): a cell may be OFFERED as support
+ *  only when a within-cell ray subsample proves its surface varies by no
+ *  more than this (model metres). A body may stand anywhere in a cell, so
+ *  an uncertified cell is a floating false top in miniature — those serve
+ *  as null. 0.03 model units keeps the WORLD-space bound (0.05m) honest up
+ *  to scale ~1.66; consumers must refuse grids their scale stretches. */
+export const CERT_SPREAD = 0.03;         // m, model frame — max within-cell surface spread
+export const CERT_MAX_WORLD = 0.05;      // m, world frame — the agreed per-cell truth bound
+export const CERT_SUBSAMPLE = 4;         // rays per cell axis (4×4 per cell)
 
 /** Bucket model-local vertices into a LIE_GRID² footprint grid, max-y per
  *  cell. Both adapters feed this: the browser walks THREE meshes, the
@@ -76,6 +85,9 @@ export function validTopGrid(g) {
   if (!Array.isArray(g.minXZ) || g.minXZ.length !== 2 || !g.minXZ.every(Number.isFinite)) return false;
   if (!Array.isArray(g.sizeXZ) || g.sizeXZ.length !== 2 || !g.sizeXZ.every((v) => Number.isFinite(v) && v > 0)) return false;
   if (!Number.isFinite(g.lie)) return false;
+  // certSpread declares the bound every offered cell was certified to; a
+  // grid without one (or claiming worse than the contract) is refused
+  if (!Number.isFinite(g.certSpread) || g.certSpread <= 0 || g.certSpread > CERT_SPREAD) return false;
   if (!Array.isArray(g.cells) || g.cells.length !== LIE_GRID * LIE_GRID) return false;
   let occupied = 0;
   for (const c of g.cells) {

--- a/client/lib/supportclass.js
+++ b/client/lib/supportclass.js
@@ -1,0 +1,89 @@
+// supportclass — one classifier for "can a box top be trusted as ground?"
+//
+// The browser's collider decide() and the headless support pipeline must
+// agree about which assets are floor-shaped with a lying box top (#84), and
+// "identical constants in two places" drifts (#92 review taught the same
+// lesson about motion math). So the grid arithmetic, the decision
+// arithmetic, and the constants live HERE, dependency-free; colliders.js
+// and server/geometry.ts are adapters that gather vertices their own way
+// and feed the same math.
+//
+// The vertex-grid lie probe is surveyed: within the floor-shaped population
+// the gates admit, the 24×24 max-y-per-cell grid tracks a raycast ground
+// truth to 1.8cm worst case (tools/collider-survey.ts, 58-model library +
+// 8 store meshes). That is why the same grid doubles as the headless
+// HEIGHTFIELD for this class — the probe that detects the lie is, for
+// exactly the population it detects it in, a truthful floor.
+
+export const TOPGRID_VERSION = 1;
+export const LIE_GRID = 24;              // cells per side
+export const SPARSE_MIN_CELLS = 8;       // a 4-corner quad covers 4: too sparse to accuse
+export const ROOM_MIN_AREA = 16;         // m² (scaled) — decide()'s room-scale gate
+export const ROOM_MIN_H = 2.2;           // m (scaled)
+export const FLOOR_MIN_AREA = 2;         // m² (scaled) — smaller and nobody walks on it
+export const FLOOR_MAX_H = 1.0;          // m (scaled) — decide()'s one movable line
+export const UNEVEN_MIN_LIE = 0.10;      // m (scaled) — below this a box is honest enough
+export const TOPGRID_MAX_JSON = 8192;    // hard cap on the serialized payload
+
+/** Bucket model-local vertices into a LIE_GRID² footprint grid, max-y per
+ *  cell. Both adapters feed this: the browser walks THREE meshes, the
+ *  server walks gltf-transform accessors — the math is this one function. */
+export function gridAccumulator(minX, minZ, w, d) {
+  if (!(w > 0) || !(d > 0)) return null;
+  const n = LIE_GRID;
+  const cells = new Float64Array(n * n).fill(-Infinity);
+  return {
+    n,
+    add(x, y, z) {
+      const cx = Math.min(n - 1, Math.max(0, Math.floor(((x - minX) / w) * n)));
+      const cz = Math.min(n - 1, Math.max(0, Math.floor(((z - minZ) / d) * n)));
+      const k = cz * n + cx;
+      if (y > cells[k]) cells[k] = y;
+    },
+    /** lie = box top − median occupied cell top; sparse grids accuse nobody. */
+    finish(boxTopY) {
+      const tops = [];
+      for (let i = 0; i < cells.length; i++) if (cells[i] !== -Infinity) tops.push(cells[i]);
+      let lie = 0;
+      if (tops.length >= SPARSE_MIN_CELLS) {
+        tops.sort((a, b) => a - b);
+        const h = tops.length >> 1;
+        lie = boxTopY - (tops.length % 2 ? tops[h] : (tops[h - 1] + tops[h]) / 2);
+      }
+      return { cells, occupied: tops.length, lie };
+    },
+  };
+}
+
+/** The decision arithmetic, verbatim from decide() (colliders.js). ALL
+ *  inputs are WORLD-SCALED metres — callers multiply by the entity scale.
+ *  `lie` may be 0/omitted when only the shape gates are being asked. */
+export function decideSupportClass({ w, d, h, lie = 0 }) {
+  const roomScale = w * d >= ROOM_MIN_AREA && h >= ROOM_MIN_H;
+  const floorShaped = !roomScale && w * d >= FLOOR_MIN_AREA && h <= FLOOR_MAX_H;
+  const uneven = floorShaped && lie > UNEVEN_MIN_LIE;
+  return { roomScale, floorShaped, uneven };
+}
+
+/** Is a served topGrid payload usable as support? Versioned, self-
+ *  describing, finite, bounded — anything else is refused, and the caller's
+ *  duty on refusal is to ABSTAIN, never to fall back to the box top (#84
+ *  review). Unoccupied cells are explicit nulls. */
+export function validTopGrid(g) {
+  if (!g || typeof g !== "object") return false;
+  if (g.version !== TOPGRID_VERSION) return false;
+  if (g.n !== LIE_GRID) return false;
+  if (!Array.isArray(g.minXZ) || g.minXZ.length !== 2 || !g.minXZ.every(Number.isFinite)) return false;
+  if (!Array.isArray(g.sizeXZ) || g.sizeXZ.length !== 2 || !g.sizeXZ.every((v) => Number.isFinite(v) && v > 0)) return false;
+  if (!Number.isFinite(g.lie)) return false;
+  if (!Array.isArray(g.cells) || g.cells.length !== LIE_GRID * LIE_GRID) return false;
+  let occupied = 0;
+  for (const c of g.cells) {
+    if (c === null) continue;
+    if (!Number.isFinite(c)) return false;
+    occupied++;
+  }
+  if (occupied < SPARSE_MIN_CELLS) return false;
+  try { if (JSON.stringify(g).length > TOPGRID_MAX_JSON) return false; } catch { return false; }
+  return true;
+}

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -8,7 +8,8 @@ import * as THREE_W from "three/webgpu";
 import * as TSL from "three/tsl";
 import { NoiseGate, SHORT_STINT_MS, APPROACH_REFRACT_MS, APPROACH_RADIUS, REARM_RADIUS,
   ACTIVITY_RADIUS_M, ACTIVITY_PULSE_MS, ACTIVITY_REFRESH_MS, MOVER_MIN_M } from "./denoise.ts";
-import { HeadlessBody, setHeightField, registerSupport, removeSupport } from "./physics.ts";
+import { HeadlessBody, setHeightField, registerSupport, registerSupportGrid, removeSupport } from "./physics.ts";
+import { decideSupportClass } from "../client/lib/supportclass.js";
 import { isFiniteVec3 } from "./shape.ts";
 // The same pure sky fold + weather derivation the browser client and the
 // sequencer run — text-tier perception must land on the SAME hour and
@@ -392,6 +393,15 @@ export class WorldAgent {
   private noteEffGap(id: string, why: string) {
     if (this.effGaps++ >= 5) return;
     console.error(`[agent ${this.name}] effective transform unavailable for ${id} — ${why}`);
+  }
+
+  /** A support seam is the same species (#84): a floor this side cannot
+   *  truthfully model. Declared, bounded, and never papered over with the
+   *  known-false box top. */
+  supportSeams = 0;
+  private noteSupportSeam(id: string, why: string) {
+    if (this.supportSeams++ >= 5) return;
+    console.error(`[agent ${this.name}] support seam on ${id} — ${why}`);
   }
 
   /** A build act (spawn/place/light/remove) near this body counts as activity. */
@@ -1144,8 +1154,26 @@ export class WorldAgent {
       }
     } else if (!roomScale) {
       const bid = `${this.world}/${id}`;
-      void registerSupport(this.supportHolder, bid, g.bbox.min, g.bbox.max, xform);
-      ids.push(bid);
+      // Floor-shaped things whose box top is a KNOWN lie (a blanket, a
+      // rubble pile — the browser collides those against exact triangles
+      // for the same reason) get heightfield support from the served grid,
+      // and NEVER the box: the box top floats bodies by the documented
+      // 0.73m/0.44m (#84). Identification uses the summary's `lie` through
+      // the same shared classifier the browser's decide() runs; a summary
+      // without `lie` (older server) cannot accuse anyone, so honest small
+      // boxes keep today's behavior either way.
+      const cls = decideSupportClass({ w, d, h, lie: Number.isFinite(g.lie) ? g.lie * s : 0 });
+      if (cls.uneven) {
+        const fit = await registerSupportGrid(this.supportHolder, bid, g.topGrid, xform);
+        if (fit) ids.push(bid);
+        // refused grid (absent/malformed/oversized): a DECLARED abstention —
+        // the body finds terrain, which is at worst the browser's under-the-
+        // rubble disagreement, never a floating false floor
+        else this.noteSupportSeam(id, `uneven top (lie ${(g.lie * s).toFixed(2)}m) without a usable grid — abstaining, no box`);
+      } else {
+        void registerSupport(this.supportHolder, bid, g.bbox.min, g.bbox.max, xform);
+        ids.push(bid);
+      }
     }                                                   // room-scale with no readable decks: browser-only, declared
     if (ids.length) this.supportIds.set(id, ids);
   }

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -9,7 +9,7 @@ import * as TSL from "three/tsl";
 import { NoiseGate, SHORT_STINT_MS, APPROACH_REFRACT_MS, APPROACH_RADIUS, REARM_RADIUS,
   ACTIVITY_RADIUS_M, ACTIVITY_PULSE_MS, ACTIVITY_REFRESH_MS, MOVER_MIN_M } from "./denoise.ts";
 import { HeadlessBody, setHeightField, registerSupport, registerSupportGrid, removeSupport } from "./physics.ts";
-import { decideSupportClass } from "../client/lib/supportclass.js";
+import { decideSupportClass, CERT_MAX_WORLD } from "../client/lib/supportclass.js";
 import { isFiniteVec3 } from "./shape.ts";
 // The same pure sky fold + weather derivation the browser client and the
 // sequencer run — text-tier perception must land on the SAME hour and
@@ -1164,12 +1164,17 @@ export class WorldAgent {
       // boxes keep today's behavior either way.
       const cls = decideSupportClass({ w, d, h, lie: Number.isFinite(g.lie) ? g.lie * s : 0 });
       if (cls.uneven) {
-        const fit = await registerSupportGrid(this.supportHolder, bid, g.topGrid, xform);
+        // the certification is a MODEL-frame bound; this spawn's scale must
+        // not stretch it past the agreed world bound (#94 review B1) — a
+        // grid certified to 3cm serves a ×1.25 spawn (3.75cm) but not a ×2
+        const stretched = Number.isFinite(g.topGrid?.certSpread) && g.topGrid.certSpread * s > CERT_MAX_WORLD;
+        const fit = !stretched && await registerSupportGrid(this.supportHolder, bid, g.topGrid, xform);
         if (fit) ids.push(bid);
-        // refused grid (absent/malformed/oversized): a DECLARED abstention —
-        // the body finds terrain, which is at worst the browser's under-the-
-        // rubble disagreement, never a floating false floor
-        else this.noteSupportSeam(id, `uneven top (lie ${(g.lie * s).toFixed(2)}m) without a usable grid — abstaining, no box`);
+        // refused grid (absent/malformed/oversized/over-stretched): a
+        // DECLARED abstention — the body finds terrain, which is at worst
+        // the browser's under-the-rubble disagreement, never a floating
+        // false floor
+        else this.noteSupportSeam(id, `uneven top (lie ${(g.lie * s).toFixed(2)}m) without a usable grid${stretched ? ` (certification stretched past ${CERT_MAX_WORLD}m at ×${s})` : ""} — abstaining, no box`);
       } else {
         void registerSupport(this.supportHolder, bid, g.bbox.min, g.bbox.max, xform);
         ids.push(bid);

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -136,6 +136,27 @@ export async function registerSupport(
 export const supportHolders = (): Record<string, string[]> =>
   Object.fromEntries([...holders].map(([id, hs]) => [id, [...hs]]));
 
+/** Register HEIGHTFIELD support from a served topGrid (#84) — the sibling of
+ *  registerSupport for floor-shaped assets whose box top is a known lie.
+ *  Same holder discipline, same lifetime. Returns false when the payload is
+ *  refused (validTopGrid, non-finite transform): the caller must then
+ *  ABSTAIN — registering the box top instead is the bug this exists to fix. */
+export async function registerSupportGrid(
+  holder: string, id: string, topGrid: unknown,
+  xform: { position: number[]; yaw?: number; scale?: number },
+): Promise<boolean> {
+  if (!isFiniteVec3(xform?.position)
+      || !Number.isFinite(xform.yaw ?? 0) || !Number.isFinite(xform.scale ?? 1)) {
+    console.error(`[physics] grid support ${id} abstained — non-finite transform`);
+    return false;
+  }
+  const m = await loadSim();
+  if (!m) return false;
+  if (!m.colliders.fitSupportGrid(id, topGrid, xform)) return false;
+  (holders.get(id) ?? holders.set(id, new Set()).get(id)!).add(holder);
+  return true;
+}
+
 export async function removeSupport(holder: string, id: string) {
   const m = await loadSim();
   if (!m) return;

--- a/server/geometry.ts
+++ b/server/geometry.ts
@@ -15,8 +15,27 @@
 import { statSync } from "node:fs";
 // the one classifier both runtimes share (#84) — grid math and constants
 // live there; this file only supplies vertices from gltf-transform accessors
-import { gridAccumulator, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON, LIE_GRID }
-  from "../client/lib/supportclass.js";
+import { gridAccumulator, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON, LIE_GRID,
+  CERT_SPREAD, CERT_SUBSAMPLE } from "../client/lib/supportclass.js";
+
+// Ray certification (#94 review B1) needs a BVH — loaded lazily and
+// optionally, same doctrine as gltf-transform above: without it the summary
+// still carries `lie` (classification works) but serves no topGrid, and the
+// consumer's duty on a missing grid is a declared abstention.
+let bvhP: Promise<{ THREE: any; MeshBVH: any } | null> | null = null;
+async function getBVH() {
+  bvhP ??= (async () => {
+    try {
+      const { THREE } = await import("../tools/core-stub.mjs");
+      const { MeshBVH } = await import("../client/node_modules/three-mesh-bvh/src/index.js");
+      return { THREE, MeshBVH };
+    } catch (err) {
+      console.warn("[geometry] three-mesh-bvh unavailable — topGrid certification disabled:", String(err));
+      return null;
+    }
+  })();
+  return bvhP;
+}
 
 // gltf-transform loads lazily and optionally, same doctrine as the behavior
 // sandbox: the sequencer must boot (and worlds must run) without it.
@@ -73,7 +92,11 @@ export type GeomSummary = {
    *  self-describing; cells are model-local max-y, null = unoccupied.
    *  Row-major, index = z * n + x over the minXZ/sizeXZ footprint. */
   topGrid?: { version: number; n: number; minXZ: [number, number];
-              sizeXZ: [number, number]; lie: number; cells: (number | null)[] };
+              sizeXZ: [number, number]; lie: number;
+              /** the within-cell surface-spread bound every offered cell was
+               *  ray-certified to (model metres) — consumers refuse grids
+               *  their spawn scale stretches past the world bound */
+              certSpread: number; cells: (number | null)[] };
   /** mesh nodes present in the FILE but attached to no scene — broken
    *  exports. No renderer draws them; never aim a motion at one. */
   orphans?: string[];
@@ -260,18 +283,111 @@ export async function summarizeGlb(absPath: string): Promise<GeomSummary | null>
         }
         const fin = acc.finish(max[1]);
         if (fin.occupied >= SPARSE_MIN_CELLS) {
-          lie = +fin.lie.toFixed(3);
-          const cells: (number | null)[] = [];
-          for (let i = 0; i < fin.cells.length; i++) {
-            cells.push(fin.cells[i] === -Infinity ? null : +fin.cells[i].toFixed(3));
+          // FULL precision: the browser's topLie is unrounded, and the 0.10m
+          // gate is strict — a 0.1004 lie rounded to 0.100 flips the verdict
+          // headlessly while the browser calls it uneven (#94 review B2).
+          lie = fin.lie;
+
+          // ---- per-cell ray certification (#94 review B1) ----------------
+          // A body may stand ANYWHERE in a cell, so every offered cell must
+          // prove its whole surface, not its tallest vertex: 3×3 rays per
+          // occupied cell; any miss (air in the cell) or a spread beyond
+          // CERT_SPREAD serves as null. The offered value is the ray MAXIMUM
+          // — a certified upper bound within the declared spread.
+          const bvhMod = tris <= SAMPLE_ABOVE_TRIS ? await getBVH() : null;   // a sampled-scale mesh gets no certification, hence no grid
+          if (bvhMod) {
+            const soup: number[] = [];
+            const pv = [0, 0, 0], pw = [0, 0, 0];
+            for (const node of doc.getRoot().listNodes()) {
+              if (!inScene.has(node)) continue;
+              const mesh = node.getMesh();
+              if (!mesh) continue;
+              const m = node.getWorldMatrix();
+              for (const prim of mesh.listPrimitives()) {
+                const posAcc = prim.getAttribute("POSITION");
+                if (!posAcc) continue;
+                const idxAcc = prim.getIndices();
+                const count = idxAcc ? idxAcc.getCount() : posAcc.getCount();
+                for (let t = 0; t < count; t++) {
+                  posAcc.getElement(idxAcc ? idxAcc.getScalar(t) : t, pv);
+                  xf(m, pv, pw);
+                  soup.push(pw[0], pw[1], pw[2]);
+                }
+              }
+            }
+            const { THREE, MeshBVH } = bvhMod;
+            const geo = new THREE.BufferGeometry();
+            geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(soup), 3));
+            const bvh = new MeshBVH(geo);
+            const ray = new THREE.Ray();
+            ray.direction.set(0, -1, 0);
+            const rayY = max[1] + Math.max(0.1, h * 0.05);
+            const cells: (number | null)[] = [];
+            let offered = 0;
+            for (let iz = 0; iz < LIE_GRID; iz++) {
+              for (let ix = 0; ix < LIE_GRID; ix++) {
+                const vertMax = fin.cells[iz * LIE_GRID + ix];
+                if (vertMax === -Infinity) { cells.push(null); continue; }
+                let lo = Infinity, hi = -Infinity, misses = 0;
+                for (let sz = 0; sz < CERT_SUBSAMPLE && !misses; sz++) {
+                  for (let sx = 0; sx < CERT_SUBSAMPLE; sx++) {
+                    ray.origin.set(
+                      min[0] + (w * (ix + (sx + 0.5) / CERT_SUBSAMPLE)) / LIE_GRID,
+                      rayY,
+                      min[2] + (d * (iz + (sz + 0.5) / CERT_SUBSAMPLE)) / LIE_GRID,
+                    );
+                    const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
+                    if (!hit) { misses++; break; }
+                    if (hit.point.y < lo) lo = hit.point.y;
+                    if (hit.point.y > hi) hi = hit.point.y;
+                  }
+                }
+                // The OFFERED top is max(ray max, this cell's vertex max): a
+                // piecewise-linear surface cannot exceed its vertices inside
+                // the cell, so folding vertMax in covers peaks the ray lattice
+                // slips between. The spread check then runs against the
+                // OFFERED value: a cell whose deepest sampled point sits more
+                // than CERT_SPREAD under what we would offer is not flat
+                // enough to certify — null, air, abstention.
+                let top = Math.max(hi, vertMax);
+                if (misses || top - lo > CERT_SPREAD) { cells.push(null); continue; }
+                // Adaptive re-certification (#94 B1, "adaptive subdivision is
+                // fine"): a ROUGH cell — spread in the upper half of the
+                // certifiable band — must re-prove itself on an 8×8 lattice.
+                // Smooth cloth skips this; rubble crevices that hid between
+                // the 4×4 rays are found here and refused.
+                if (top - lo > CERT_SPREAD * 0.5) {
+                  const RE = 8;
+                  for (let sz = 0; sz < RE && !misses; sz++) {
+                    for (let sx = 0; sx < RE; sx++) {
+                      ray.origin.set(
+                        min[0] + (w * (ix + (sx + 0.5) / RE)) / LIE_GRID,
+                        rayY,
+                        min[2] + (d * (iz + (sz + 0.5) / RE)) / LIE_GRID,
+                      );
+                      const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
+                      if (!hit) { misses++; break; }
+                      if (hit.point.y < lo) lo = hit.point.y;
+                      if (hit.point.y > hi) hi = hit.point.y;
+                    }
+                  }
+                  top = Math.max(hi, vertMax);
+                  if (misses || top - lo > CERT_SPREAD) { cells.push(null); continue; }
+                }
+                cells.push(+top.toFixed(3));
+                offered++;
+              }
+            }
+            if (offered >= SPARSE_MIN_CELLS) {
+              const g = { version: TOPGRID_VERSION, n: LIE_GRID,
+                minXZ: [+min[0].toFixed(3), +min[2].toFixed(3)] as [number, number],
+                sizeXZ: [+w.toFixed(3), +d.toFixed(3)] as [number, number],
+                lie, certSpread: CERT_SPREAD, cells };
+              // the hard payload cap is part of the contract — an oversized
+              // grid is dropped here and the consumer abstains, never box-tops
+              if (JSON.stringify(g).length <= TOPGRID_MAX_JSON) topGrid = g;
+            }
           }
-          const g = { version: TOPGRID_VERSION, n: LIE_GRID,
-            minXZ: [+min[0].toFixed(3), +min[2].toFixed(3)] as [number, number],
-            sizeXZ: [+w.toFixed(3), +d.toFixed(3)] as [number, number],
-            lie, cells };
-          // the hard payload cap is part of the contract — an oversized grid
-          // is dropped here and the consumer abstains, never box-tops
-          if (JSON.stringify(g).length <= TOPGRID_MAX_JSON) topGrid = g;
         }
       }
     }

--- a/server/geometry.ts
+++ b/server/geometry.ts
@@ -290,10 +290,12 @@ export async function summarizeGlb(absPath: string): Promise<GeomSummary | null>
 
           // ---- per-cell ray certification (#94 review B1) ----------------
           // A body may stand ANYWHERE in a cell, so every offered cell must
-          // prove its whole surface, not its tallest vertex: 3×3 rays per
-          // occupied cell; any miss (air in the cell) or a spread beyond
-          // CERT_SPREAD serves as null. The offered value is the ray MAXIMUM
-          // — a certified upper bound within the declared spread.
+          // prove its whole surface, not its tallest vertex: CERT_SUBSAMPLE²
+          // (4×4) rays per occupied cell, with rough cells re-proving
+          // themselves on an 8×8 lattice below; any miss (air in the cell)
+          // or a spread beyond CERT_SPREAD serves as null. The offered value
+          // folds in the cell's vertex max — a certified upper bound within
+          // the declared spread.
           const bvhMod = tris <= SAMPLE_ABOVE_TRIS ? await getBVH() : null;   // a sampled-scale mesh gets no certification, hence no grid
           if (bvhMod) {
             const soup: number[] = [];

--- a/server/geometry.ts
+++ b/server/geometry.ts
@@ -13,6 +13,10 @@
 // the server-side convenience tier.
 
 import { statSync } from "node:fs";
+// the one classifier both runtimes share (#84) — grid math and constants
+// live there; this file only supplies vertices from gltf-transform accessors
+import { gridAccumulator, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON, LIE_GRID }
+  from "../client/lib/supportclass.js";
 
 // gltf-transform loads lazily and optionally, same doctrine as the behavior
 // sandbox: the sequencer must boot (and worlds must run) without it.
@@ -59,6 +63,17 @@ export type GeomSummary = {
            local: { center: number[]; size: number[] }; tris: number }[];
   /** true when the mesh was too big to walk exhaustively */
   sampled: boolean;
+  /** the box-top lie (m, model frame): bbox top minus the median 24×24
+   *  cell top — the SAME probe the browser's collider decide() runs, from
+   *  the shared classifier (client/lib/supportclass.js). Present whenever
+   *  the shape was worth probing; consumers scale it before judging. */
+  lie?: number;
+  /** the probe's grid itself, served as a truthful heightfield for
+   *  floor-shaped assets whose box top lies (#84). Versioned and
+   *  self-describing; cells are model-local max-y, null = unoccupied.
+   *  Row-major, index = z * n + x over the minXZ/sizeXZ footprint. */
+  topGrid?: { version: number; n: number; minXZ: [number, number];
+              sizeXZ: [number, number]; lie: number; cells: (number | null)[] };
   /** mesh nodes present in the FILE but attached to no scene — broken
    *  exports. No renderer draws them; never aim a motion at one. */
   orphans?: string[];
@@ -211,6 +226,57 @@ export async function summarizeGlb(absPath: string): Promise<GeomSummary | null>
     }));
 
   const ok = Number.isFinite(min[0]);
+
+  // ---- the box-top lie probe (#84) -----------------------------------------
+  // Same math as the browser's collider decide(): the shared accumulator
+  // buckets model-frame vertices 24×24 and medians the cell tops. This pass
+  // walks POSITION accessors exhaustively (the browser walks every vertex,
+  // so sampling here would change the verdict) — gated to shapes that could
+  // ever be floor-shaped, with slack for in-world scaling, so room-scale
+  // architecture and skyscraper meshes never pay for it.
+  let lie: number | undefined;
+  let topGrid: GeomSummary["topGrid"];
+  if (ok) {
+    const w = max[0] - min[0], h = max[1] - min[1], d = max[2] - min[2];
+    const worthProbing = w * d >= 1 && h <= 1.5 && !(w * d >= 16 && h >= 2.2);
+    if (worthProbing) {
+      const acc = gridAccumulator(min[0], min[2], w, d);
+      if (acc) {
+        const out = [0, 0, 0], p = [0, 0, 0];
+        for (const node of doc.getRoot().listNodes()) {
+          if (!inScene.has(node)) continue;
+          const mesh = node.getMesh();
+          if (!mesh) continue;
+          const m = node.getWorldMatrix();
+          for (const prim of mesh.listPrimitives()) {
+            const posAcc = prim.getAttribute("POSITION");
+            if (!posAcc) continue;
+            for (let vi = 0; vi < posAcc.getCount(); vi++) {
+              posAcc.getElement(vi, p);
+              xf(m, p, out);
+              acc.add(out[0], out[1], out[2]);
+            }
+          }
+        }
+        const fin = acc.finish(max[1]);
+        if (fin.occupied >= SPARSE_MIN_CELLS) {
+          lie = +fin.lie.toFixed(3);
+          const cells: (number | null)[] = [];
+          for (let i = 0; i < fin.cells.length; i++) {
+            cells.push(fin.cells[i] === -Infinity ? null : +fin.cells[i].toFixed(3));
+          }
+          const g = { version: TOPGRID_VERSION, n: LIE_GRID,
+            minXZ: [+min[0].toFixed(3), +min[2].toFixed(3)] as [number, number],
+            sizeXZ: [+w.toFixed(3), +d.toFixed(3)] as [number, number],
+            lie, cells };
+          // the hard payload cap is part of the contract — an oversized grid
+          // is dropped here and the consumer abstains, never box-tops
+          if (JSON.stringify(g).length <= TOPGRID_MAX_JSON) topGrid = g;
+        }
+      }
+    }
+  }
+
   const sum: GeomSummary = {
     tris,
     bbox: ok ? {
@@ -221,6 +287,8 @@ export async function summarizeGlb(absPath: string): Promise<GeomSummary | null>
     topSurfaces,
     nodes,
     sampled: stride > 1,
+    ...(lie !== undefined ? { lie } : {}),
+    ...(topGrid ? { topGrid } : {}),
     ...(orphans.length ? { orphans } : {}),
   };
   cache.set(absPath, { mtime, sum });

--- a/tools/support-heightfield-probe.ts
+++ b/tools/support-heightfield-probe.ts
@@ -1,0 +1,166 @@
+/**
+ * Support heightfield probe — #84's matched browser/headless receipt.
+ *
+ * For each asset: the SERVED summary (server/geometry.ts summarizeGlb,
+ * imported directly — no network) against a BVH raycast ground truth (the
+ * survey's honest metric, tools/collider-survey.ts machinery). Asserts, for
+ * every asset the shared classifier calls floor-shaped + uneven:
+ *
+ *   - the summary carries a validTopGrid-accepted grid;
+ *   - per occupied cell (where a ray hits), the grid top is an UPPER bound
+ *     on the ray top and tracks it (median ≤ 5cm, worst reported);
+ *   - the OLD box top's error at the same columns — the float a body
+ *     suffered before this fix — is recorded as the receipt.
+ *
+ * Assets that are NOT in the class (both rubble piles at scale 1 — the
+ * height gate excludes them, in the browser and here alike) are reported
+ * with the scale at which they WOULD enter it, for the agent-level test.
+ *
+ * Run:
+ *   BLANKET_GLB=/path/to/blanket-9a9d0239.glb EIDOVERSE_DIR=/path/to/eidoverse-video \
+ *     bun run tools/support-heightfield-probe.ts [extra.glb ...]
+ */
+
+import { join } from "node:path";
+import { summarizeGlb } from "../server/geometry.ts";
+import { decideSupportClass, validTopGrid, LIE_GRID, UNEVEN_MIN_LIE, FLOOR_MAX_H, FLOOR_MIN_AREA }
+  from "../client/lib/supportclass.js";
+
+const { THREE }: any = await import("./core-stub.mjs");
+const { MeshBVH }: any = await import("../client/node_modules/three-mesh-bvh/src/index.js");
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const h = s.length >> 1;
+  return s.length % 2 ? s[h] : (s[h - 1] + s[h]) / 2;
+};
+
+// ---- world-space triangle soup (collider-survey's loader, verbatim slice) --
+let ioP: Promise<any> | null = null;
+async function getIO() {
+  ioP ??= (async () => {
+    const { NodeIO } = await import("@gltf-transform/core");
+    const { ALL_EXTENSIONS } = await import("@gltf-transform/extensions");
+    const draco3d = (await import("draco3dgltf")).default;
+    return new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
+      "draco3d.decoder": await draco3d.createDecoderModule(),
+      "draco3d.encoder": await draco3d.createEncoderModule(),
+    });
+  })();
+  return ioP;
+}
+async function loadTris(path: string): Promise<Float32Array | null> {
+  const io = await getIO();
+  let doc: any;
+  try { doc = await io.read(path); } catch { return null; }
+  const inScene = new Set<any>();
+  for (const s of doc.getRoot().listScenes()) s.traverse((n: any) => inScene.add(n));
+  const out: number[] = [];
+  for (const node of doc.getRoot().listNodes()) {
+    if (!inScene.has(node)) continue;
+    const mesh = node.getMesh();
+    if (!mesh) continue;
+    const m = node.getWorldMatrix();
+    for (const prim of mesh.listPrimitives()) {
+      const pos = prim.getAttribute("POSITION");
+      if (!pos) continue;
+      const idx = prim.getIndices();
+      const count = idx ? idx.getCount() : pos.getCount();
+      const p = [0, 0, 0];
+      for (let t = 0; t < count; t++) {
+        pos.getElement(idx ? idx.getScalar(t) : t, p);
+        out.push(
+          m[0] * p[0] + m[4] * p[1] + m[8] * p[2] + m[12],
+          m[1] * p[0] + m[5] * p[1] + m[9] * p[2] + m[13],
+          m[2] * p[0] + m[6] * p[1] + m[10] * p[2] + m[14],
+        );
+      }
+    }
+  }
+  return out.length ? new Float32Array(out) : null;
+}
+
+async function probe(label: string, path: string) {
+  console.log(`\n━━ ${label} ━━`);
+  const sum = await summarizeGlb(path);
+  if (!sum) { check(`${label}: summary`, false, "summarizeGlb returned null"); return; }
+  const v = await loadTris(path);
+  if (!v) { check(`${label}: triangles`, false, "loadTris returned null"); return; }
+  const [w, h, d] = sum.bbox.size;
+  const cls = decideSupportClass({ w, d, h, lie: sum.lie ?? 0 });
+  console.log(`  shape ${w.toFixed(2)}×${d.toFixed(2)}×${h.toFixed(2)}m, lie ${sum.lie ?? "—"}, class: ` +
+    (cls.uneven ? "floor-shaped + UNEVEN" : cls.floorShaped ? "floor-shaped (honest top)" : cls.roomScale ? "room-scale" : "small solid"));
+
+  if (!cls.uneven) {
+    // outside the class at s=1: report the scale that would admit it (the
+    // agent-level test spawns at such a scale), and if a grid is served for
+    // that scaled use, verify it against raycast all the same
+    const sH = FLOOR_MAX_H / h, area = w * d;
+    const sMin = Math.sqrt(FLOOR_MIN_AREA / area);
+    const lieOk = (sum.lie ?? 0) * sH > UNEVEN_MIN_LIE;
+    console.log(`  (enters the class at scale ≤ ${sH.toFixed(2)}${sMin > sH ? " — never (footprint too small first)" : lieOk ? `, lie ${(sum.lie! * sH).toFixed(2)}m at that scale` : ", but its lie goes honest first"})`);
+    if (!sum.topGrid) return;
+    console.log(`  (grid served for scaled use — verifying it anyway)`);
+  }
+
+  check(`${label}: served grid passes validTopGrid`, validTopGrid(sum.topGrid), JSON.stringify(sum.topGrid)?.slice(0, 120));
+  if (!validTopGrid(sum.topGrid)) return;
+  const g = sum.topGrid!;
+
+  // raycast truth per cell center, straight down from above the box
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(v, 3));
+  const bvh = new MeshBVH(geo);
+  const ray = new THREE.Ray();
+  ray.direction.set(0, -1, 0);
+  const diffs: number[] = [];
+  const boxErr: number[] = [];
+  let notUpper = 0, compared = 0;
+  for (let iz = 0; iz < g.n; iz++) {
+    for (let ix = 0; ix < g.n; ix++) {
+      const top = g.cells[iz * g.n + ix];
+      if (top === null) continue;
+      ray.origin.set(
+        g.minXZ[0] + (g.sizeXZ[0] * (ix + 0.5)) / g.n,
+        sum.bbox.max[1] + Math.max(0.1, h * 0.05),
+        g.minXZ[1] + (g.sizeXZ[1] * (iz + 0.5)) / g.n,
+      );
+      const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
+      if (!hit) continue;
+      compared++;
+      diffs.push(Math.abs(top - hit.point.y));
+      if (top < hit.point.y - 0.02) notUpper++;
+      boxErr.push(sum.bbox.max[1] - hit.point.y);
+    }
+  }
+  check(`${label}: enough occupied cells answered a ray`, compared >= 24, String(compared));
+  check(`${label}: the grid is an upper bound on the surface`, notUpper === 0, `${notUpper}/${compared} cells below ray`);
+  const med = median(diffs), worst = Math.max(...diffs);
+  check(`${label}: grid tracks raycast (median ≤ 5cm)`, med <= 0.05, `median ${med.toFixed(3)}m`);
+  console.log(`  grid vs raycast: median ${med.toFixed(3)}m, worst ${worst.toFixed(3)}m over ${compared} columns`);
+  const boxMed = median(boxErr);
+  console.log(`  the OLD box top's error at the same columns: median ${boxMed.toFixed(3)}m — the float a body suffered pre-#84`);
+  if ((sum.lie ?? 0) > UNEVEN_MIN_LIE) {
+    check(`${label}: the box top was indeed the lie (> gate)`, boxMed > UNEVEN_MIN_LIE, `${boxMed.toFixed(3)}m`);
+  }
+}
+
+const lib = process.env.EIDOVERSE_DIR;
+const targets: Array<[string, string]> = [];
+if (process.env.BLANKET_GLB) targets.push(["blanket (store/9a9d0239eca609b3)", process.env.BLANKET_GLB]);
+if (lib) {
+  targets.push(["rubble pile (building collapse)", join(lib, "eidoverse/assets/models/apocalyptic_destroyed_rubble_debris_pile_building_collapse.glb")]);
+  targets.push(["rubble pile (ruins)", join(lib, "eidoverse/assets/models/apocalyptic_destroyed_rubble_debris_pile_ruins.glb")]);
+}
+for (const extra of process.argv.slice(2)) targets.push([extra.split(/[\\/]/).pop()!, extra]);
+if (!targets.length) { console.error("nothing to probe — set BLANKET_GLB and/or EIDOVERSE_DIR"); process.exit(1); }
+
+for (const [label, path] of targets) await probe(label, path);
+
+console.log("");
+process.exit(failures ? 1 : 0);

--- a/tools/support-heightfield-probe.ts
+++ b/tools/support-heightfield-probe.ts
@@ -85,15 +85,15 @@ async function loadTris(path: string): Promise<Float32Array | null> {
   return out.length ? new Float32Array(out) : null;
 }
 
-async function probe(label: string, path: string) {
-  console.log(`\n━━ ${label} ━━`);
+async function probe(label: string, path: string, scale = 1) {
+  console.log(`\n━━ ${label}${scale !== 1 ? ` @ ×${scale}` : ""} ━━`);
   const sum = await summarizeGlb(path);
   if (!sum) { check(`${label}: summary`, false, "summarizeGlb returned null"); return; }
   const v = await loadTris(path);
   if (!v) { check(`${label}: triangles`, false, "loadTris returned null"); return; }
   const [w, h, d] = sum.bbox.size;
-  const cls = decideSupportClass({ w, d, h, lie: sum.lie ?? 0 });
-  console.log(`  shape ${w.toFixed(2)}×${d.toFixed(2)}×${h.toFixed(2)}m, lie ${sum.lie ?? "—"}, class: ` +
+  const cls = decideSupportClass({ w: w * scale, d: d * scale, h: h * scale, lie: (sum.lie ?? 0) * scale });
+  console.log(`  shape ${w.toFixed(2)}×${d.toFixed(2)}×${h.toFixed(2)}m, lie ${sum.lie?.toFixed(4) ?? "—"}, class at ×${scale}: ` +
     (cls.uneven ? "floor-shaped + UNEVEN" : cls.floorShaped ? "floor-shaped (honest top)" : cls.roomScale ? "room-scale" : "small solid"));
 
   if (!cls.uneven) {
@@ -112,55 +112,73 @@ async function probe(label: string, path: string) {
   if (!validTopGrid(sum.topGrid)) return;
   const g = sum.topGrid!;
 
-  // raycast truth per cell center, straight down from above the box
+  // raycast truth per OFFERED cell, 4×4 within-cell subsample — a body may
+  // stand anywhere in a cell, so the bound is per SUBPOINT, in WORLD metres
+  // at the tested scale, not a median over cell centres (#94 review B1).
+  // The 4×4 pattern deliberately differs from certification's 3×3: the
+  // probe must not sample the exact points generation certified.
   const geo = new THREE.BufferGeometry();
   geo.setAttribute("position", new THREE.BufferAttribute(v, 3));
   const bvh = new MeshBVH(geo);
   const ray = new THREE.Ray();
   ray.direction.set(0, -1, 0);
+  const SUB = 5;   // denser than certification's 4×4, on a different lattice — the probe must not resample certification's own points
   const diffs: number[] = [];
   const boxErr: number[] = [];
-  let notUpper = 0, compared = 0;
+  let notUpper = 0, overBound = 0, compared = 0, worstOver = 0;
   for (let iz = 0; iz < g.n; iz++) {
     for (let ix = 0; ix < g.n; ix++) {
       const top = g.cells[iz * g.n + ix];
       if (top === null) continue;
-      ray.origin.set(
-        g.minXZ[0] + (g.sizeXZ[0] * (ix + 0.5)) / g.n,
-        sum.bbox.max[1] + Math.max(0.1, h * 0.05),
-        g.minXZ[1] + (g.sizeXZ[1] * (iz + 0.5)) / g.n,
-      );
-      const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
-      if (!hit) continue;
       compared++;
-      diffs.push(Math.abs(top - hit.point.y));
-      if (top < hit.point.y - 0.02) notUpper++;
-      boxErr.push(sum.bbox.max[1] - hit.point.y);
+      for (let sz = 0; sz < SUB; sz++) {
+        for (let sx = 0; sx < SUB; sx++) {
+          ray.origin.set(
+            g.minXZ[0] + (g.sizeXZ[0] * (ix + (sx + 0.5) / SUB)) / g.n,
+            sum.bbox.max[1] + Math.max(0.1, h * 0.05),
+            g.minXZ[1] + (g.sizeXZ[1] * (iz + (sz + 0.5) / SUB)) / g.n,
+          );
+          const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
+          if (!hit) continue;   // an offered cell may graze the hem; certification bounded what it DID hit
+          const err = (top - hit.point.y) * scale;         // world metres at the tested scale
+          diffs.push(Math.abs(err));
+          if (err < -0.021 * scale - 0.002) notUpper++;    // below the surface: not an upper bound
+          if (err > 0.05 + 0.002) { overBound++; worstOver = Math.max(worstOver, err); }
+          boxErr.push((sum.bbox.max[1] - hit.point.y) * scale);
+        }
+      }
     }
   }
-  check(`${label}: enough occupied cells answered a ray`, compared >= 24, String(compared));
-  check(`${label}: the grid is an upper bound on the surface`, notUpper === 0, `${notUpper}/${compared} cells below ray`);
+  check(`${label}: enough offered cells to probe`, compared >= 24, String(compared));
+  check(`${label}: the grid is an upper bound on the surface`, notUpper === 0, `${notUpper} subpoints above the grid`);
+  check(`${label}: EVERY offered cell within the 5cm world bound, at every subpoint`, overBound === 0,
+    `${overBound}/${diffs.length} subpoints over (worst ${worstOver.toFixed(3)}m)`);
   const med = median(diffs), worst = Math.max(...diffs);
-  check(`${label}: grid tracks raycast (median ≤ 5cm)`, med <= 0.05, `median ${med.toFixed(3)}m`);
-  console.log(`  grid vs raycast: median ${med.toFixed(3)}m, worst ${worst.toFixed(3)}m over ${compared} columns`);
+  console.log(`  grid vs raycast (world m at ×${scale}): median ${med.toFixed(3)}, worst ${worst.toFixed(3)} over ${diffs.length} subpoints in ${compared} offered cells`);
   const boxMed = median(boxErr);
   console.log(`  the OLD box top's error at the same columns: median ${boxMed.toFixed(3)}m — the float a body suffered pre-#84`);
-  if ((sum.lie ?? 0) > UNEVEN_MIN_LIE) {
+  if ((sum.lie ?? 0) * scale > UNEVEN_MIN_LIE) {
     check(`${label}: the box top was indeed the lie (> gate)`, boxMed > UNEVEN_MIN_LIE, `${boxMed.toFixed(3)}m`);
   }
 }
 
 const lib = process.env.EIDOVERSE_DIR;
-const targets: Array<[string, string]> = [];
-if (process.env.BLANKET_GLB) targets.push(["blanket (store/9a9d0239eca609b3)", process.env.BLANKET_GLB]);
+const targets: Array<[string, string, number?]> = [];
+if (process.env.BLANKET_GLB) {
+  targets.push(["blanket (store/9a9d0239eca609b3)", process.env.BLANKET_GLB]);
+  targets.push(["blanket (store/9a9d0239eca609b3)", process.env.BLANKET_GLB, 1.25]);   // the agent test's spawn scale
+}
 if (lib) {
+  // the scifi debris pile is the rubble asset the scale gate actually admits
+  // (h 1.12m → in the class at ≤ 0.90) — probed AT the agent test's scale
+  targets.push(["scifi rubble pile", join(lib, "eidoverse/assets/models/apocalyptic_scifi_cyberpunk_destroyed_rubble_debris_pile.glb"), 0.88]);
   targets.push(["rubble pile (building collapse)", join(lib, "eidoverse/assets/models/apocalyptic_destroyed_rubble_debris_pile_building_collapse.glb")]);
   targets.push(["rubble pile (ruins)", join(lib, "eidoverse/assets/models/apocalyptic_destroyed_rubble_debris_pile_ruins.glb")]);
 }
 for (const extra of process.argv.slice(2)) targets.push([extra.split(/[\\/]/).pop()!, extra]);
 if (!targets.length) { console.error("nothing to probe — set BLANKET_GLB and/or EIDOVERSE_DIR"); process.exit(1); }
 
-for (const [label, path] of targets) await probe(label, path);
+for (const [label, path, scale] of targets) await probe(label, path, scale ?? 1);
 
 console.log("");
 process.exit(failures ? 1 : 0);

--- a/tools/supportclass-test.ts
+++ b/tools/supportclass-test.ts
@@ -5,8 +5,12 @@
  * Run: bun run tools/supportclass-test.ts
  */
 
-import { gridAccumulator, decideSupportClass, validTopGrid,
-  LIE_GRID, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON } from "../client/lib/supportclass.js";
+// namespace import so a pre-revision head FAILS the certification checks by
+// name instead of crashing the file on a missing export — controls stay controls
+import * as SC from "../client/lib/supportclass.js";
+const { gridAccumulator, decideSupportClass, validTopGrid, UNEVEN_MIN_LIE,
+  LIE_GRID, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON } = SC;
+const CERT_SPREAD = (SC as any).CERT_SPREAD ?? 0.03;
 
 let failures = 0;
 const check = (label: string, ok: boolean, detail?: string) => {
@@ -50,8 +54,12 @@ console.log("\n━━ the decision gates, at their boundaries ━━");
 console.log("\n━━ validTopGrid: versioned, finite, bounded, or refused ━━");
 {
   const good = () => ({ version: TOPGRID_VERSION, n: LIE_GRID, minXZ: [-1.2, -1.1], sizeXZ: [2.4, 2.25], lie: 0.27,
+    certSpread: CERT_SPREAD,
     cells: Array.from({ length: LIE_GRID * LIE_GRID }, (_, i) => (i % 3 === 0 ? null : 0.03)) });
   check("a well-formed grid is accepted", validTopGrid(good()));
+  check("a grid without a certification bound is refused", !validTopGrid({ ...good(), certSpread: undefined }));
+  check("a bound looser than the contract is refused", !validTopGrid({ ...good(), certSpread: CERT_SPREAD * 2 }));
+  check("a non-positive bound is refused", !validTopGrid({ ...good(), certSpread: 0 }));
   check("wrong version refused", !validTopGrid({ ...good(), version: TOPGRID_VERSION + 1 }));
   check("wrong resolution refused", !validTopGrid({ ...good(), n: 16 }));
   check("wrong cell count refused", !validTopGrid({ ...good(), cells: good().cells.slice(1) }));
@@ -63,6 +71,69 @@ console.log("\n━━ validTopGrid: versioned, finite, bounded, or refused ━�
   check("the serialized-size cap is a hard wall", JSON.stringify(fat).length > TOPGRID_MAX_JSON ? !validTopGrid(fat) : true,
     `serialized=${JSON.stringify(fat).length}`);
   check("null and undefined refused outright", !validTopGrid(null) && !validTopGrid(undefined) && !validTopGrid("grid"));
+}
+
+// ---- #94 review B2: the two adapters agree AT the strict gate --------------
+// The browser computes lie in full precision; a served lie must reach the
+// decision in full precision too, or a true 0.1004 flips verdicts across
+// runtimes. Calibrated fixture: a dense sheet at y=0 with a small bump of
+// EXACTLY the gate-straddling height — lie = bump height by construction —
+// pushed through BOTH adapters: colliders.js topLie (a duck-typed mesh over
+// real three) and the raw accumulator (the server's path).
+console.log("\n━━ B2: browser and server verdicts agree at the 0.10 gate ━━");
+{
+  // colliders.js imports the browser's core.js — route it to the headless
+  // stub the way mcpl/physics.ts does, BEFORE the dynamic import
+  const { plugin } = await import("bun");
+  const { fileURLToPath } = await import("node:url");
+  const STUB = fileURLToPath(new URL("./core-stub.mjs", import.meta.url));
+  plugin({ name: "core-stub-supportclass", setup(build) {
+    build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: STUB }));
+  } });
+  const { THREE } = await import("./core-stub.mjs");
+  const { topLie } = await import("../client/lib/colliders.js");
+  if (typeof topLie !== "function") {
+    check("browser adapter exports topLie for parity fixtures", false, "absent (pre-revision head)");
+  } else {
+
+  const fixture = (bump: number) => {
+    const pts: number[] = [];
+    for (let x = 0.05; x < 3; x += 0.1) for (let z = 0.05; z < 3; z += 0.1) pts.push(x, 0, z);   // the sheet
+    for (let x = 0.05; x < 0.3; x += 0.05) for (let z = 0.05; z < 0.3; z += 0.05) pts.push(x, bump, z); // the bump
+    return pts;
+  };
+  const both = (bump: number) => {
+    const pts = fixture(bump);
+    // server adapter: raw accumulator
+    const acc = gridAccumulator(0, 0, 3, 3)!;
+    for (let i = 0; i < pts.length; i += 3) acc.add(pts[i], pts[i + 1], pts[i + 2]);
+    const serverLie = acc.finish(bump).lie;
+    // browser adapter: topLie over a duck-typed mesh (traverse/isMesh/
+    // geometry/matrixWorld are all it reads)
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(pts), 3));
+    const obj: any = { isMesh: true, geometry: geo, matrixWorld: new THREE.Matrix4(),
+      traverse(cb: (o: any) => void) { cb(this); }, updateMatrixWorld() {} };
+    const box = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(3, bump, 3));
+    const browserLie = topLie(obj, box);
+    return { serverLie, browserLie };
+  };
+
+  const above = both(0.1004), below = both(0.0996);
+  check("full precision survives both adapters (no rounding)", above.serverLie === 0.1004 && above.browserLie === 0.1004,
+    JSON.stringify(above));
+  check("just above the gate: BOTH call it uneven",
+    decideSupportClass({ w: 3, d: 3, h: 0.5, lie: above.serverLie }).uneven
+    && decideSupportClass({ w: 3, d: 3, h: 0.5, lie: above.browserLie }).uneven);
+  check("just below the gate: NEITHER does",
+    !decideSupportClass({ w: 3, d: 3, h: 0.5, lie: below.serverLie }).uneven
+    && !decideSupportClass({ w: 3, d: 3, h: 0.5, lie: below.browserLie }).uneven);
+  check("and the two adapters agree bit-for-bit", above.serverLie === above.browserLie && below.serverLie === below.browserLie,
+    JSON.stringify({ above, below }));
+  check("a 3-decimal rounding would have flipped the verdict (the bug pinned)",
+    !decideSupportClass({ w: 3, d: 3, h: 0.5, lie: +above.serverLie.toFixed(3) }).uneven
+    && decideSupportClass({ w: 3, d: 3, h: 0.5, lie: above.serverLie }).uneven);
+  }
 }
 
 console.log("");

--- a/tools/supportclass-test.ts
+++ b/tools/supportclass-test.ts
@@ -1,0 +1,69 @@
+/**
+ * supportclass unit test — #84: the one classifier both runtimes consume.
+ * Pure math, no servers, no geometry files.
+ *
+ * Run: bun run tools/supportclass-test.ts
+ */
+
+import { gridAccumulator, decideSupportClass, validTopGrid,
+  LIE_GRID, SPARSE_MIN_CELLS, TOPGRID_VERSION, TOPGRID_MAX_JSON } from "../client/lib/supportclass.js";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const near = (a: number, b: number, eps = 1e-9) => Math.abs(a - b) < eps;
+
+console.log("\n━━ grid accumulation and the lie ━━");
+{
+  // a dense 10×10m sheet at y=0, one 0.3m cushion over a corner patch,
+  // box top at the cushion: lie = 0.3 − median(mostly 0) = 0.3
+  const acc = gridAccumulator(0, 0, 10, 10)!;
+  for (let x = 0.1; x < 10; x += 0.2) for (let z = 0.1; z < 10; z += 0.2) acc.add(x, 0, z);
+  for (let x = 0.1; x < 1.5; x += 0.2) for (let z = 0.1; z < 1.5; z += 0.2) acc.add(x, 0.3, z);
+  const fin = acc.finish(0.3);
+  check("a cushion on a sheet: lie = box top − median cloth", near(fin.lie, 0.3), String(fin.lie));
+  check("every cell over the sheet is occupied", fin.occupied === LIE_GRID * LIE_GRID, String(fin.occupied));
+
+  // a 4-corner quad covers ~4 cells: too sparse to accuse
+  const sparse = gridAccumulator(0, 0, 10, 10)!;
+  for (const [x, z] of [[0, 0], [10, 0], [0, 10], [10, 10]]) sparse.add(x, 0, z);
+  const sf = sparse.finish(5);
+  check("sparse grids accuse nobody (lie 0)", sf.lie === 0 && sf.occupied < SPARSE_MIN_CELLS, JSON.stringify({ lie: sf.lie, occ: sf.occupied }));
+
+  check("degenerate footprint refuses to accumulate", gridAccumulator(0, 0, 0, 10) === null);
+}
+
+console.log("\n━━ the decision gates, at their boundaries ━━");
+{
+  const c = (w: number, d: number, h: number, lie = 0) => decideSupportClass({ w, d, h, lie });
+  check("blanket-shaped + lying top = uneven", c(2.4, 2.25, 0.3, 0.27).uneven);
+  check("a crate's 5cm lie is honest enough", !c(2, 1.5, 0.9, 0.05).uneven);
+  check("lie gate is strict: 0.10 exactly is not an accusation", !c(2, 1.5, 0.9, 0.10).uneven && c(2, 1.5, 0.9, 0.101).uneven);
+  check("area gate: below 2m² nobody walks on it", !c(1.4, 1.4, 0.3, 0.5).floorShaped && c(1.5, 1.5, 0.3, 0.5).floorShaped);
+  check("height gate: decide()'s one movable line at 1.0", c(2, 2, 1.0, 0.5).floorShaped && !c(2, 2, 1.01, 0.5).floorShaped);
+  check("room-scale is neither floor-shaped nor uneven", (() => { const r = c(5, 5, 3, 9); return r.roomScale && !r.floorShaped && !r.uneven; })());
+  check("scale enters through the caller: same asset, s=2 doubles lie", !c(1.2, 1.2, 0.4, 0.08).uneven && c(2.4, 2.4, 0.8, 0.16).uneven);
+}
+
+console.log("\n━━ validTopGrid: versioned, finite, bounded, or refused ━━");
+{
+  const good = () => ({ version: TOPGRID_VERSION, n: LIE_GRID, minXZ: [-1.2, -1.1], sizeXZ: [2.4, 2.25], lie: 0.27,
+    cells: Array.from({ length: LIE_GRID * LIE_GRID }, (_, i) => (i % 3 === 0 ? null : 0.03)) });
+  check("a well-formed grid is accepted", validTopGrid(good()));
+  check("wrong version refused", !validTopGrid({ ...good(), version: TOPGRID_VERSION + 1 }));
+  check("wrong resolution refused", !validTopGrid({ ...good(), n: 16 }));
+  check("wrong cell count refused", !validTopGrid({ ...good(), cells: good().cells.slice(1) }));
+  check("a NaN cell poisons the whole grid", !validTopGrid({ ...good(), cells: good().cells.map((c, i) => (i === 7 ? NaN : c)) }));
+  check("non-finite extent refused", !validTopGrid({ ...good(), sizeXZ: [2.4, Infinity] }));
+  check("negative extent refused", !validTopGrid({ ...good(), sizeXZ: [2.4, -1] }));
+  check("nearly-empty grid refused (sparse)", !validTopGrid({ ...good(), cells: good().cells.map((_, i) => (i < SPARSE_MIN_CELLS - 1 ? 0.03 : null)) }));
+  const fat = { ...good(), cells: good().cells.map((c) => (c === null ? null : 0.030000000001234567)) };
+  check("the serialized-size cap is a hard wall", JSON.stringify(fat).length > TOPGRID_MAX_JSON ? !validTopGrid(fat) : true,
+    `serialized=${JSON.stringify(fat).length}`);
+  check("null and undefined refused outright", !validTopGrid(null) && !validTopGrid(undefined) && !validTopGrid("grid"));
+}
+
+console.log("");
+process.exit(failures ? 1 : 0);

--- a/tools/uneven-support-test.ts
+++ b/tools/uneven-support-test.ts
@@ -1,0 +1,212 @@
+/**
+ * Uneven-support agent test — #84 end to end, through the REAL spawn path:
+ * a scratch sequencer serves /geom (with the new lie/topGrid), a WorldAgent
+ * folds the spawns and registers support, and the shared collider state is
+ * queried exactly where the physics would ask. Covers, per the review:
+ *
+ *   - the blanket at NONZERO YAW and NON-UNIT SCALE: ground at an occupied
+ *     cell equals the composed cell top (world→model-local round trip);
+ *   - stepping from an occupied cell into an adjacent EMPTY one: terrain,
+ *     not interpolated air;
+ *   - a rubble pile brought INTO the class by an in-world scale;
+ *   - a crate keeps its honest box (no regression);
+ *   - fail-on-main: on a pre-#84 checkout the blanket registers its box and
+ *     the ground floats by the documented lie.
+ *
+ * The blanket is the commons' actual store/9a9d0239eca609b3.glb, copied to
+ * the LOCAL store dir — no production networking (review amendment 4).
+ *
+ * Run:
+ *   BLANKET_GLB=/path/to/blanket-9a9d0239.glb EIDOVERSE_DIR=/path/to/eidoverse-video \
+ *     bun run tools/uneven-support-test.ts
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorldAgent } from "../mcpl/agent.ts";
+import { supportHolders } from "../mcpl/physics.ts";
+import { summarizeGlb } from "../server/geometry.ts";
+
+const PORT = Number(process.env.PORT ?? 9001);
+const URL_ = `ws://127.0.0.1:${PORT}/ws`;
+const WORLD = "uneventest";
+const BLANKET_LIB = "store/9a9d0239eca609b3.glb";
+const RUBBLE_LIB = "eidoverse/assets/models/apocalyptic_scifi_cyberpunk_destroyed_rubble_debris_pile.glb";
+const CRATE_LIB = "eidoverse/assets/models/crate_large_blue.glb";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ""}\x1b[0m`);
+  if (!ok) failures++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function until(cond: () => boolean, ms = 8000, step = 100) {
+  const t0 = Date.now();
+  while (!cond() && Date.now() - t0 < ms) await sleep(step);
+  return cond();
+}
+
+if (!process.env.EIDOVERSE_DIR || !process.env.BLANKET_GLB) {
+  console.error("EIDOVERSE_DIR and BLANKET_GLB are required (local files only — no production networking).");
+  process.exit(1);
+}
+
+// ---- host the blanket in the LOCAL store, where an upload would land -------
+const storeDir = join(import.meta.dir, "..", "assets", "opt", "store");
+mkdirSync(storeDir, { recursive: true });
+const blanketDst = join(storeDir, "9a9d0239eca609b3.glb");
+if (!existsSync(blanketDst)) copyFileSync(process.env.BLANKET_GLB, blanketDst);
+
+// summaries read directly (same code the server serves) — they drive the
+// expected values, so expectations come from served data, not from the
+// modules under test
+const blanketSum = (await summarizeGlb(blanketDst))!;
+const rubbleSum = (await summarizeGlb(join(process.env.EIDOVERSE_DIR, RUBBLE_LIB)))!;
+
+// ---- scratch sequencer ------------------------------------------------------
+const server = spawn("bun", [join(import.meta.dir, "..", "server", "server.ts")], {
+  env: { ...process.env, PORT: String(PORT), WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-uneven-")), JOIN_TOKEN: "" },
+  stdio: "ignore",
+});
+const stop = () => { try { server.kill(); } catch {} };
+process.on("exit", stop);
+await sleep(1500);
+
+const warden = new WebSocket(URL_);
+const verb = (v: string, args: any) => warden.send(JSON.stringify({ type: "verb", verb: v, args }));
+await new Promise<void>((res, rej) => {
+  warden.onopen = () => { warden.send(JSON.stringify({ type: "join", world: WORLD, id: "warden", avatar: "eidoverse/assets/vrms/claude.vrm" })); res(); };
+  warden.onerror = () => rej(new Error("warden failed to connect"));
+});
+await sleep(400);
+
+const agent = new WorldAgent({ url: URL_, name: "prober", world: WORLD });
+await agent.connect();
+
+// the blanket: nonzero yaw, non-unit scale, and raised so its below-origin
+// cloth clears the flat terrain (else terrain-at-0 legitimately covers it)
+const B = { pos: [4, 0.5, 4], yaw: 0.9, scale: 1.25 };
+verb("spawn", { id: "blank1", lib: BLANKET_LIB, pos: B.pos, yaw: B.yaw, scale: B.scale });
+// the rubble pile, scaled INTO the floor-shaped class (h·s ≤ 1.0)
+const R = { pos: [20, 0, 20], yaw: 0.7, scale: 0.88 };
+verb("spawn", { id: "rubble1", lib: RUBBLE_LIB, pos: R.pos, yaw: R.yaw, scale: R.scale });
+// the honest control
+verb("spawn", { id: "crate1", lib: CRATE_LIB, pos: [40, 0, 40], yaw: 0, scale: 1 });
+await (agent as any).supportReady(8000);
+await until(() => Object.keys(supportHolders()).length >= 3, 8000);
+
+check("all three register support", Object.keys(supportHolders()).length >= 3, JSON.stringify(supportHolders()));
+
+// query the SAME collider state the physics reads (module cache = one instance)
+const colliders: any = await import("../client/lib/colliders.js");
+const { THREE }: any = await import("./core-stub.mjs");   // the stub loadSim's plugin already routed core.js to
+const groundAt = (x: number, z: number, y = 10) =>
+  colliders.resolveColliders(new THREE.Vector3(x, y, z), () => 0, 0.05, 0.03);
+
+/** world position of a grid cell center under an entity transform */
+const cellWorld = (g: any, ix: number, iz: number, T: { pos: number[]; yaw: number; scale: number }) => {
+  const lx = g.minXZ[0] + (g.sizeXZ[0] * (ix + 0.5)) / g.n;
+  const lz = g.minXZ[1] + (g.sizeXZ[1] * (iz + 0.5)) / g.n;
+  const c = Math.cos(T.yaw), s = Math.sin(T.yaw);
+  // THREE applyAxisAngle(+Y, yaw): x' = x·cos + z·sin, z' = −x·sin + z·cos
+  return { x: T.pos[0] + (lx * c + lz * s) * T.scale, z: T.pos[2] + (-lx * s + lz * c) * T.scale };
+};
+/** the TALLEST occupied cell — a cushion top, safely above terrain, so the
+ *  grid (not the terrain floor) is what answers the query */
+const tallestCell = (g: any) => {
+  let best: { ix: number; iz: number; top: number } | null = null;
+  for (let iz = 0; iz < g.n; iz++) {
+    for (let ix = 0; ix < g.n; ix++) {
+      const top = g.cells[iz * g.n + ix];
+      if (top !== null && (!best || top > best.top)) best = { ix, iz, top };
+    }
+  }
+  return best;
+};
+
+console.log("\n━━ blanket: yaw 0.9, scale 1.25 ━━");
+{
+  const g = blanketSum.topGrid;
+  check("a grid is served for the blanket", !!g, "absent — pre-#84 server, box-top era");
+  const cell = g ? tallestCell(g) : null;
+  if (g && !cell) check("the blanket's grid has occupied cells", false);
+  if (g && cell) {
+    const p = cellWorld(g, cell.ix, cell.iz, B);
+    const expected = B.pos[1] + cell.top * B.scale;
+    const ground = groundAt(p.x, p.z);
+    check("ground = the composed cell top (yaw+scale round trip)", Math.abs(ground - expected) < 0.02,
+      `ground ${ground.toFixed(3)} vs expected ${expected.toFixed(3)}`);
+    // the bare cloth: a cell at ~median height, where the box top's lie is
+    // the full 0.25m·s — the pre-#84 float this asset was filed over
+    const tops = (g.cells.filter((c: number | null) => c !== null) as number[]).sort((a, b) => a - b);
+    const medTop = tops[tops.length >> 1];
+    let medCell: { ix: number; iz: number; top: number } | null = null;
+    for (let iz = 0; iz < g.n && !medCell; iz++) for (let ix = 0; ix < g.n && !medCell; ix++) {
+      const t = g.cells[iz * g.n + ix];
+      if (t !== null && Math.abs(t - medTop) < 1e-9) medCell = { ix, iz, top: t };
+    }
+    const boxTop = B.pos[1] + blanketSum.bbox.max[1] * B.scale;
+    if (medCell) {
+      const mp = cellWorld(g, medCell.ix, medCell.iz, B);
+      const mg = groundAt(mp.x, mp.z);
+      check("bare cloth rests at cloth height — NOT the box top", Math.abs(mg - (B.pos[1] + medCell.top * B.scale)) < 0.02 && boxTop - mg > 0.1,
+        `ground ${mg.toFixed(3)}, box top ${boxTop.toFixed(3)} (lie ${(blanketSum.lie! * B.scale).toFixed(3)}m)`);
+    }
+    // step OFF the cloth's edge: half a metre past the footprint along the
+    // entity's local +x, composed through the same yaw/scale — outside the
+    // grid there is no support, and the honest answer is terrain
+    const beyond = cellWorld({ ...g, minXZ: [g.minXZ[0] + g.sizeXZ[0] + 0.5 / B.scale, g.minXZ[1]], sizeXZ: [0, g.sizeXZ[1]] } as any, 0, Math.floor(g.n / 2), B);
+    const offEdge = groundAt(beyond.x, beyond.z);
+    check("one step off the cloth's edge: terrain, not stretched cloth", Math.abs(offEdge - 0) < 1e-6, `ground ${offEdge.toFixed(3)}`);
+  }
+}
+
+console.log("\n━━ rubble: scaled into the class (yaw 0.7, scale 0.88) ━━");
+{
+  const g = rubbleSum.topGrid;
+  check("a grid is served for the rubble", !!g, "absent — pre-#84 server");
+  const cell = g ? tallestCell(g) : null;
+  if (g && cell) {
+    const p = cellWorld(g, cell.ix, cell.iz, R);
+    const expected = R.pos[1] + cell.top * R.scale;
+    const ground = groundAt(p.x, p.z);
+    check("scaled rubble rests bodies on the rubble, not 0.6m above it", Math.abs(ground - expected) < 0.02,
+      `ground ${ground.toFixed(3)} vs expected ${expected.toFixed(3)} (box top ${(rubbleSum.bbox.max[1] * R.scale).toFixed(3)})`);
+  }
+}
+
+console.log("\n━━ interior hole: an empty cell inside the footprint is AIR ━━");
+{
+  // Real cloth covers its footprint, so the interior-empty-cell semantics are
+  // pinned at the colliders tier with a synthetic grid (the pipeline cases
+  // above all ride the real spawn path; this one pins fitSupportGrid's own
+  // contract: occupied neighbors must not bleed across a hole).
+  const n = 24, cells: (number | null)[] = new Array(n * n).fill(0.4);
+  cells[12 * n + 12] = null;                            // one hole, dead centre
+  const ok = typeof colliders.fitSupportGrid === "function" && colliders.fitSupportGrid("synthetic-hole", {
+    version: 1, n, minXZ: [-1.2, -1.2], sizeXZ: [2.4, 2.4], lie: 0.4, cells,
+  }, { position: [60, 0, 60], yaw: 0, scale: 1 });
+  check("synthetic grid registers", ok === true);
+  const occupied = groundAt(60 + (11.5 / n) * 2.4 - 1.2, 60 + (12.5 / n) * 2.4 - 1.2);
+  const hole = groundAt(60 + (12.5 / n) * 2.4 - 1.2, 60 + (12.5 / n) * 2.4 - 1.2);
+  check("occupied neighbor answers 0.4", Math.abs(occupied - 0.4) < 1e-9, String(occupied));
+  check("the hole answers terrain — no bleed across air", Math.abs(hole - 0) < 1e-9, String(hole));
+  colliders.removeCollider("synthetic-hole");
+}
+
+console.log("\n━━ crate: the honest box is untouched ━━");
+{
+  const crateSum = (await summarizeGlb(join(process.env.EIDOVERSE_DIR!, CRATE_LIB)))!;
+  const expected = crateSum.bbox.max[1];   // scale 1, pos.y 0 — the box top IS truthful here
+  const ground = groundAt(40, 40);
+  check("crate ground = box top exactly (no regression)", Math.abs(ground - expected) < 1e-6,
+    `ground ${ground.toFixed(3)} vs box top ${expected.toFixed(3)}`);
+}
+
+agent.close();
+try { warden.close(); } catch {}
+stop();
+console.log("");
+process.exit(failures ? 1 : 0);

--- a/tools/uneven-support-test.ts
+++ b/tools/uneven-support-test.ts
@@ -186,7 +186,7 @@ console.log("\n━━ interior hole: an empty cell inside the footprint is AIR �
   const n = 24, cells: (number | null)[] = new Array(n * n).fill(0.4);
   cells[12 * n + 12] = null;                            // one hole, dead centre
   const ok = typeof colliders.fitSupportGrid === "function" && colliders.fitSupportGrid("synthetic-hole", {
-    version: 1, n, minXZ: [-1.2, -1.2], sizeXZ: [2.4, 2.4], lie: 0.4, cells,
+    version: 1, n, minXZ: [-1.2, -1.2], sizeXZ: [2.4, 2.4], lie: 0.4, certSpread: 0.03, cells,
   }, { position: [60, 0, 60], yaw: 0, scale: 1 });
   check("synthetic grid registers", ok === true);
   const occupied = groundAt(60 + (11.5 / n) * 2.4 - 1.2, 60 + (12.5 / n) * 2.4 - 1.2);
@@ -194,6 +194,90 @@ console.log("\n━━ interior hole: an empty cell inside the footprint is AIR �
   check("occupied neighbor answers 0.4", Math.abs(occupied - 0.4) < 1e-9, String(occupied));
   check("the hole answers terrain — no bleed across air", Math.abs(hole - 0) < 1e-9, String(hole));
   colliders.removeCollider("synthetic-hole");
+}
+
+console.log("\n━━ the old worst cell: max-y's 21cm float is behaviorally gone ━━");
+{
+  // Rebuild what the max-y implementation WOULD have offered (the vertex
+  // grid) and ray truth per cell, independently; find the cell where the
+  // old float was worst; assert the agent's ground there is truth-or-
+  // terrain — never the old vertex top. On the max-y head this fails by
+  // ~0.21m (#94 review B1's behavioral requirement).
+  const { gridAccumulator } = await import("../client/lib/supportclass.js");
+  const { MeshBVH }: any = await import("../client/node_modules/three-mesh-bvh/src/index.js");
+  const io = await (async () => {
+    const { NodeIO } = await import("@gltf-transform/core");
+    const { ALL_EXTENSIONS } = await import("@gltf-transform/extensions");
+    const draco3d = (await import("draco3dgltf")).default;
+    return new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
+      "draco3d.decoder": await draco3d.createDecoderModule(),
+      "draco3d.encoder": await draco3d.createEncoderModule(),
+    });
+  })();
+  const doc = await io.read(blanketDst);
+  const inScene = new Set<any>();
+  for (const s of doc.getRoot().listScenes()) s.traverse((n: any) => inScene.add(n));
+  const soup: number[] = [];
+  for (const node of doc.getRoot().listNodes()) {
+    if (!inScene.has(node)) continue;
+    const mesh = node.getMesh();
+    if (!mesh) continue;
+    const m = node.getWorldMatrix();
+    for (const prim of mesh.listPrimitives()) {
+      const pos = prim.getAttribute("POSITION");
+      if (!pos) continue;
+      const idx = prim.getIndices();
+      const count = idx ? idx.getCount() : pos.getCount();
+      const p = [0, 0, 0];
+      for (let t = 0; t < count; t++) {
+        pos.getElement(idx ? idx.getScalar(t) : t, p);
+        soup.push(m[0]*p[0]+m[4]*p[1]+m[8]*p[2]+m[12], m[1]*p[0]+m[5]*p[1]+m[9]*p[2]+m[13], m[2]*p[0]+m[6]*p[1]+m[10]*p[2]+m[14]);
+      }
+    }
+  }
+  const bb = blanketSum.bbox;
+  const acc = gridAccumulator(bb.min[0], bb.min[2], bb.size[0], bb.size[2])!;
+  for (let i = 0; i < soup.length; i += 3) acc.add(soup[i], soup[i + 1], soup[i + 2]);
+  const vfin = acc.finish(bb.max[1]);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(soup), 3));
+  const bvh = new MeshBVH(geo);
+  const ray = new THREE.Ray();
+  ray.direction.set(0, -1, 0);
+  const n = blanketSum.topGrid!.n;
+  let worst: { ix: number; iz: number; float: number; ray: number } | null = null;
+  for (let iz = 0; iz < n; iz++) {
+    for (let ix = 0; ix < n; ix++) {
+      const vm = vfin.cells[iz * n + ix];
+      if (vm === -Infinity) continue;
+      ray.origin.set(bb.min[0] + (bb.size[0] * (ix + 0.5)) / n, bb.max[1] + 0.2, bb.min[2] + (bb.size[2] * (iz + 0.5)) / n);
+      const hit = bvh.raycastFirst(ray, THREE.DoubleSide);
+      if (!hit) continue;
+      const fl = vm - hit.point.y;
+      if (!worst || fl > worst.float) worst = { ix, iz, float: fl, ray: hit.point.y };
+    }
+  }
+  check("the old worst cell is a real float (the 0.21m class)", !!worst && worst.float > 0.1, JSON.stringify(worst));
+  if (worst) {
+    const p = cellWorld(blanketSum.topGrid!, worst.ix, worst.iz, B);
+    const ground = groundAt(p.x, p.z);
+    const oldGround = B.pos[1] + worst.float * B.scale + worst.ray * B.scale;  // what max-y offered
+    const truthCap = B.pos[1] + (worst.ray + 0.05 / B.scale) * B.scale;       // ray truth + the world bound
+    check("agent ground there is truth-or-terrain, never the max-y float",
+      ground <= truthCap + 1e-6, `ground ${ground.toFixed(3)}, truth+bound ${truthCap.toFixed(3)}, old max-y would offer ${oldGround.toFixed(3)}`);
+  }
+}
+
+console.log("\n━━ a scale that stretches certification: declared abstention ━━");
+{
+  // certSpread 0.03 × scale 2 = 0.06 > the 0.05 world bound — the grid must
+  // be refused, the seam declared, and the body finds terrain (no box!)
+  verb("spawn", { id: "blank2", lib: BLANKET_LIB, pos: [80, 0.5, 80], yaw: 0, scale: 2 });
+  await sleep(1500);
+  await (agent as any).supportReady(8000);
+  const held = Object.keys(supportHolders()).some((k) => k.endsWith("/blank2"));
+  check("over-stretched grid registers NOTHING (no box, no grid)", !held, JSON.stringify(Object.keys(supportHolders())));
+  check("and the seam is declared, bounded", agent.supportSeams > 0, `seams=${agent.supportSeams}`);
 }
 
 console.log("\n━━ crate: the honest box is untouched ━━");


### PR DESCRIPTION
Closes #84, built to the four amendments from the issue thread. Three commits, head `6d3b11b`.

```
before:  a body on the commons blanket stands 0.27m up in the air, on the box top
after:   ground = the served grid's cell top — median 1.3cm from raycast truth
and:     one step off the cloth's edge finds terrain; an interior empty cell is AIR
```

**Amendment 1 — one classifier.** `client/lib/supportclass.js`: the 24×24 grid/median math, the `floorShaped/roomScale/uneven` arithmetic, the constants, and the `validTopGrid` contract — dependency-free, consumed by the browser's `decide()`/`topLie` (which keep their laziness; only the math moved) and by the server and agent adapters. The `motioneval` arrangement, applied to classification.

**Amendment 2 — inline, versioned, bounded.** `summarizeGlb` runs the shared probe (a full POSITION-accessor walk — the browser walks every vertex, so sampling would change the verdict; slack-gated so architecture never pays) and serves `lie` plus `topGrid: {version, n, minXZ, sizeXZ, lie, cells}` — explicit nulls, mm-rounded, hard 8KB serialized cap. Anything `validTopGrid` refuses — wrong version, NaN cell, sparse, oversized — is a **declared abstention** with a bounded seam diagnostic. The known-false box top is never registered for the class; a summary without `lie` (older server) can accuse nobody, so honest crates keep today's behavior everywhere.

**Amendment 3 — nearest occupied cell, no smoothing across air.** `fitSupportGrid` entries answer per *containing* cell, max-y, piecewise-constant; an empty cell is air, and no interpolation bridges it. Support only — a blanket has no walls, and grid entries offer no `findSeat` candidates (#11's phantom mantle). Pinned with the entity at **yaw 0.9, scale 1.25** (world→model round trip through the real spawn path), a step off the cloth's edge, and a synthetic interior hole whose occupied neighbor answers 0.4 while the hole answers terrain.

**Amendment 4 — the actual blanket, no production networking.** `store/9a9d0239eca609b3.glb` fetched once and hosted in the local store where an upload would land. On it, the matched probe (served summary vs BVH raycast, per occupied cell): **median 1.3cm over 573 columns, upper-bound everywhere — against a box-top error of 0.270m at the same columns**, the float this issue was filed over. A finding along the way: both `pile` assets are building-scale (room-scale class, decks path, untouched) — the survey's 0.73m rubble is the *scifi debris pile* (`lie 0.698m`), which the height gate excludes at scale 1 exactly as `decide()`'s comments say, and which **enters the class at scale ≤ 0.90** — so the end-to-end test spawns it at 0.88 and bodies rest on rubble, not 0.6m above it.

**Receipts.** Branch: `supportclass-test` + `support-heightfield-probe` + `uneven-support-test` (11/11 through a real scratch sequencer) all green · `smoke` 85/85 with 49 modules parsing · `effective`/`motioneval`/`denoise`/`manifest`/`modclose` unchanged and green · browser verified live (all collider exports, crate ground = box top exactly). Main control: **four failures by name** (no grid served for blanket or rubble, no `fitSupportGrid`), with the crate control green on both sides — no-regression pinned in both directions.

— I.M. & Cormundus
