### PR TITLE
voice: a FAILED lane reaches back — drop is not the end of wanting to hear

### DIFF
--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -242,7 +242,28 @@ function peerFor(id) {
       // back here, so persistent unreachability retries at ICE cadence rather
       // than looping hot. 'closed' stays terminal: WE closed that peer on
       // purpose (leave, replacement), and re-offering would resurrect it.
-      if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent) offerTo(id);
+      // Repair OWNERSHIP is split by who courts: humans are ours (we offer,
+      // so we reach back). Agent lanes are agent-initiated (we never offer to
+      // agents — line ~10), so their 'failed' repair belongs to the agent's
+      // voice source; reaching from here would invert the direction
+      // convention and race their own re-offer.
+      // ONE side reaches back, by rank (r2 review). Both peers usually see
+      // 'failed' near-simultaneously; if both re-offered, two fresh peer
+      // objects (_everStable false) meet as rivals the glare logic cannot
+      // tie-break — it reads never-settled as REJOIN, both roll back and
+      // answer, and the pair marries mismatched sessions that fail again at
+      // ICE cadence. Same convention as the mesh-heal sweep: the lower id
+      // offers, the higher id answers through the normal path. If only the
+      // higher side noticed the death, the lower side's own ICE fails within
+      // its timeout and lands here — converging late beats storming forever.
+      //
+      // Repair OWNERSHIP is also split by who courts: humans are ours. Agent
+      // lanes are agent-initiated (we never offer to agents — line ~10), so
+      // their 'failed' repair belongs to the agent's voice source; reaching
+      // from here would invert the direction convention and race their own
+      // re-offer.
+      if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent
+        && (myId ?? '') < id) offerTo(id);
       return;
     }
     if (st === 'connected') { clearTimeout(p._discoTimer); p._discoTimer = null; return; }

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -441,13 +441,20 @@ function scheduleSoleCourterReach(id) {
   // re-occupies the key before the timer fires, the predecessor's repair debt
   // must not court the successor. Same object-identity guard the avatar loader
   // uses (remotes.get(id) !== r): the successor is a different object.
+  // Capture the record identity if there IS one. remotes can hold a nullish
+  // value under a present key (the surrounding code hedges remotes.get(id)?.),
+  // so a nullish capture must NOT abort the schedule (Opus-5 review): that would
+  // silently drop the last-resort reach with nothing to reschedule it. When we
+  // captured a record, the fire-time check demands the SAME object (reject a
+  // fresh successor); when we captured nothing, fall back to presence, the
+  // pre-fix behaviour, and re-check the record freshly at fire.
   const expected = remotes.get(id);
-  if (!expected) return;                          // nothing to owe a reach to
   const t = setTimeout(() => {
     _soleReach.delete(id);
-    // still unhealed, still present, still not an agent — AND still the SAME
-    // remote generation that scheduled this reach (identity, not mere presence).
-    if (!peers.has(id) && remotes.get(id) === expected && !expected.agent) offerTo(id);
+    const now = remotes.get(id);
+    // still unhealed, still present, still not an agent — and, if we pinned a
+    // record, still that SAME generation (identity, not mere presence).
+    if (!peers.has(id) && now && !now.agent && (expected ? now === expected : true)) offerTo(id);
   }, 380);                                        // > the 300ms sweep period, with margin
   _soleReach.set(id, t);
 }

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -318,6 +318,12 @@ function peerFor(id) {
 }
 
 function dropPeer(id) {
+  // Cancel any deferred sole-courter reach FIRST — before the no-peer early
+  // return (#102 review): a reach is scheduled precisely when no peer exists
+  // yet, so leaving it to expire would retain a dead id in _soleReach and (were
+  // the object-identity guard ever weakened) risk courting a successor. Cancel
+  // on the true leave.
+  cancelSoleCourterReach(id);
   const p = peers.get(id);
   if (!p) return;
   // A pending disconnect timer outlives the peer it was watching unless it is
@@ -429,10 +435,19 @@ async function offerTo(id) {
 const _soleReach = new Map();
 function scheduleSoleCourterReach(id) {
   if (_soleReach.has(id)) return;                 // one outstanding deferred reach per id
+  // Bind the debt to the EXACT remote record that incurred it, not just the id
+  // (#102 review). #97 makes a same-id takeover a FRESH remote object; if the
+  // predecessor leaves/takes over inside this 380ms window and a successor
+  // re-occupies the key before the timer fires, the predecessor's repair debt
+  // must not court the successor. Same object-identity guard the avatar loader
+  // uses (remotes.get(id) !== r): the successor is a different object.
+  const expected = remotes.get(id);
+  if (!expected) return;                          // nothing to owe a reach to
   const t = setTimeout(() => {
     _soleReach.delete(id);
-    // only if STILL unhealed and the peer is still present & still not an agent
-    if (!peers.has(id) && remotes.has(id) && !remotes.get(id)?.agent) offerTo(id);
+    // still unhealed, still present, still not an agent — AND still the SAME
+    // remote generation that scheduled this reach (identity, not mere presence).
+    if (!peers.has(id) && remotes.get(id) === expected && !expected.agent) offerTo(id);
   }, 380);                                        // > the 300ms sweep period, with margin
   _soleReach.set(id, t);
 }

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -247,23 +247,24 @@ function peerFor(id) {
       // agents — line ~10), so their 'failed' repair belongs to the agent's
       // voice source; reaching from here would invert the direction
       // convention and race their own re-offer.
-      // ONE side reaches back, by rank (r2 review). Both peers usually see
-      // 'failed' near-simultaneously; if both re-offered, two fresh peer
-      // objects (_everStable false) meet as rivals the glare logic cannot
-      // tie-break — it reads never-settled as REJOIN, both roll back and
-      // answer, and the pair marries mismatched sessions that fail again at
-      // ICE cadence. Same convention as the mesh-heal sweep: the lower id
-      // offers, the higher id answers through the normal path. If only the
-      // higher side noticed the death, the lower side's own ICE fails within
-      // its timeout and lands here — converging late beats storming forever.
-      //
-      // Repair OWNERSHIP is also split by who courts: humans are ours. Agent
-      // lanes are agent-initiated (we never offer to agents — line ~10), so
-      // their 'failed' repair belongs to the agent's voice source; reaching
-      // from here would invert the direction convention and race their own
-      // re-offer.
+      // WHO reaches back = WHO COURTED (r2, revised in-review). Both peers
+      // usually see 'failed' near-simultaneously; if both re-offered, two
+      // fresh never-settled rivals meet and the glare logic reads them as
+      // rejoins — both roll back and answer, each marries a different
+      // session, and the pair storms at ICE cadence. So:
+      //   · the lane's SOLE courter (we offered, they never have — an agent's
+      //     leg toward humans, or a one-mic human pair) reaches back
+      //     unconditionally: nobody else ever will;
+      //   · a DUAL-courtship lane (both sides have offered — two live mics)
+      //     is arbitrated by rank, the mesh-heal sweep's own convention:
+      //     lower id offers, higher answers through the normal path.
+      // A first version rank-gated everything and silently disarmed the
+      // agent leg's only repair whenever it ranked high. If only the
+      // non-reaching side noticed the death, the reacher's own ICE fails
+      // within its timeout and lands here — late beats storming.
+      // (We still never reach TOWARD agent peers: their lanes are theirs.)
       if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent
-        && (myId ?? '') < id) offerTo(id);
+        && p._court && (!p._theyEverOffered || (myId ?? '') < id)) offerTo(id);
       return;
     }
     if (st === 'connected') { clearTimeout(p._discoTimer); p._discoTimer = null; return; }
@@ -370,7 +371,9 @@ async function renegotiate(id) {
 }
 
 async function offerTo(id) {
-  await offerOn(peerFor(id), id, 'voice offer');
+  const p = peerFor(id);
+  p._court = true;               // we courted this lane (repair-ownership tell)
+  await offerOn(p, id, 'voice offer');
 }
 
 async function onRtc(msg) {
@@ -438,6 +441,7 @@ async function onRtc(msg) {
 async function processSignal(p, from, payload) {
   try {
     if (payload.sdp?.type === 'offer') {
+      p._theyEverOffered = true;   // dual courtship: rank must arbitrate repair
       // glare: both sides offered at once — the LOWER id's offer stands, the
       // higher id rolls back and answers (deterministic, no extra messages)
       if (p.pc.signalingState === 'have-local-offer') {

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -233,6 +233,15 @@ function peerFor(id) {
     // Give it a grace period and try an ICE restart before giving up. Only
     // 'failed' and 'closed' are terminal.
     if (st === 'failed' || st === 'closed') {
+      // STALENESS GUARD (r5, review): after reach-back replaces this peer,
+      // the OLD pc is closed and can still emit state changes ('closed', or a
+      // late 'failed'). Without this check a ghost event drops the fresh
+      // REPLACEMENT — and 'closed' being terminal, nothing rebuilds it: the
+      // repair mechanism itself becomes the killer. A dead generation's
+      // events are void; only the registry's current peer may act. This is
+      // also the one-outstanding-retry bound: repeated events on one dead pc
+      // cannot fan out into duplicate offers.
+      if (peers.get(id) !== p) return;
       clearTimeout(p._discoTimer); dropPeer(id);
       // Field, 2026-08-10 (voicetest, cellular×2): dropping on 'failed' left the
       // id with NO peer and nothing re-offered — roster rescans run only on

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -232,7 +232,19 @@ function peerFor(id) {
     //
     // Give it a grace period and try an ICE restart before giving up. Only
     // 'failed' and 'closed' are terminal.
-    if (st === 'failed' || st === 'closed') { clearTimeout(p._discoTimer); dropPeer(id); return; }
+    if (st === 'failed' || st === 'closed') {
+      clearTimeout(p._discoTimer); dropPeer(id);
+      // Field, 2026-08-10 (voicetest, cellular×2): dropping on 'failed' left the
+      // id with NO peer and nothing re-offered — roster rescans run only on
+      // roster events, which a mid-session ICE death does not produce. The
+      // neighbor is still here; the lane just died. Reach again immediately,
+      // exactly once — if that offer's ICE fails too, the next 'failed' lands
+      // back here, so persistent unreachability retries at ICE cadence rather
+      // than looping hot. 'closed' stays terminal: WE closed that peer on
+      // purpose (leave, replacement), and re-offering would resurrect it.
+      if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent) offerTo(id);
+      return;
+    }
     if (st === 'connected') { clearTimeout(p._discoTimer); p._discoTimer = null; return; }
     if (st === 'disconnected' && !p._discoTimer) {
       p._discoTimer = setTimeout(() => {

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -174,6 +174,7 @@ function peerFor(id) {
   audio.playsInline = true;
   p = { pc, audio, gen: ++_peerGen };
   peers.set(id, p);
+  cancelSoleCourterReach(id);   // a lane exists again — a pending deferred reach is moot
   if (micStream) for (const t of micStream.getTracks()) pc.addTrack(t, micStream);
   pc.ontrack = (e) => {
     // FAIL CLOSED: consent can be revoked mid-negotiation, and a track that
@@ -272,8 +273,33 @@ function peerFor(id) {
       // non-reaching side noticed the death, the reacher's own ICE fails
       // within its timeout and lands here — late beats storming.
       // (We still never reach TOWARD agent peers: their lanes are theirs.)
-      if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent
-        && p._court && (!p._theyEverOffered || (myId ?? '') < id)) offerTo(id);
+      //
+      // ⚠️ ARBITRATION MUST MATCH THE 300ms RECONCILE SWEEP (r6, adversarial
+      // review). The recut onto post-#91 main pulled in a reconcile interval
+      // (see ~line 1036) that offers to any roster HOLE when (myId < id) —
+      // court-ignorant, rank-only. So an UNCONDITIONAL sole-courter reach-back
+      // that ranks HIGH races that sweep: both ends drop on 'failed', we reach
+      // immediately, and within ≤300ms the low peer's sweep offers too — two
+      // never-stable pcs cross and glare-storm, the exact failure this repair
+      // claims to prevent. The two mechanisms must share ONE rule: the LOWER
+      // id offers.
+      //   · we rank LOW  (myId < id): reach immediately — the sweep would make
+      //     the same offer, and sooner is strictly better;
+      //   · we rank HIGH and the lane is DUAL: rank says wait to be offered to
+      //     (unchanged);
+      //   · we rank HIGH and are the SOLE courter (the agent-leg-toward-human
+      //     case, no sweep will ever cover it because the human ranks higher
+      //     than the agent id... or the peer simply never noticed the death):
+      //     DEFER past one sweep cycle, then reach only if still unhealed. This
+      //     gives the low peer's sweep deterministic first crack (no glare) yet
+      //     preserves the agent leg's only repair when nobody else acts.
+      if (st === 'failed' && remotes.has(id) && !remotes.get(id)?.agent && p._court) {
+        const weRankLow = (myId ?? '') < id;
+        if (weRankLow || !p._theyEverOffered) {
+          if (weRankLow) offerTo(id);                 // matches the sweep — immediate, no race
+          else scheduleSoleCourterReach(id);          // high & sole: defer past the sweep window
+        }
+      }
       return;
     }
     if (st === 'connected') { clearTimeout(p._discoTimer); p._discoTimer = null; return; }
@@ -390,6 +416,29 @@ async function renegotiate(id) {
 
 async function offerTo(id) {
   await offerOn(peerFor(id), id, 'voice offer');
+}
+
+// SOLE-COURTER HIGH-RANK REACH-BACK (r6): we outrank the peer, so the 300ms
+// reconcile sweep's "lower id offers" rule means the PEER should re-establish
+// the lane — but if they never noticed the death (mid-session ICE failure
+// produces no roster event on their side), nobody sweeps and the lane stays
+// dead. Wait past one sweep cycle: if the peer's sweep (or their own
+// reach-back) rebuilt the lane, `peers.has(id)` is true and we do nothing —
+// no glare. If it's still a hole, we are the last resort and reach. Deferred
+// reaches are keyed by id so repeated 'failed' events don't stack timers.
+const _soleReach = new Map();
+function scheduleSoleCourterReach(id) {
+  if (_soleReach.has(id)) return;                 // one outstanding deferred reach per id
+  const t = setTimeout(() => {
+    _soleReach.delete(id);
+    // only if STILL unhealed and the peer is still present & still not an agent
+    if (!peers.has(id) && remotes.has(id) && !remotes.get(id)?.agent) offerTo(id);
+  }, 380);                                        // > the 300ms sweep period, with margin
+  _soleReach.set(id, t);
+}
+function cancelSoleCourterReach(id) {
+  const t = _soleReach.get(id);
+  if (t) { clearTimeout(t); _soleReach.delete(id); }
 }
 
 async function onRtc(msg) {

--- a/client/lib/voice.js
+++ b/client/lib/voice.js
@@ -319,6 +319,15 @@ async function offerOn(p, id, label) {
     await p.pc.setLocalDescription(offer);
     p._offeredAt = Date.now();     // for the rejoin-vs-glare distinction
     sendRtc(id, { sdp: p.pc.localDescription });
+    // Repair-ownership tell (r3, moved here in r4 review): a COURTER is
+    // anyone who has actually SENT an offer on this lane — courtship,
+    // renegotiation, ICE-restart follow-ups alike. Setting it only in
+    // offerTo let a renegotiating answerer mark the far side dual
+    // (_theyEverOffered) while never owning repair itself: courter
+    // rank-blocked, answerer court-blocked, NOBODY reaches. And setting it
+    // before the await marked lanes courted when the offer never left the
+    // building. After the send: the flag states a fact.
+    p._court = true;
   } catch (e) { report(label, e); } finally { p._offering = false; }
 }
 
@@ -371,9 +380,7 @@ async function renegotiate(id) {
 }
 
 async function offerTo(id) {
-  const p = peerFor(id);
-  p._court = true;               // we courted this lane (repair-ownership tell)
-  await offerOn(p, id, 'voice offer');
+  await offerOn(peerFor(id), id, 'voice offer');
 }
 
 async function onRtc(msg) {

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1278,5 +1278,36 @@ check("unhush rejoins the SAME peer at full volume",
   ax.__resetForTest();          // later blocks get a working context again
 }
 
+
+// ── a FAILED lane reaches back (field, 2026-08-10) ───────────────────────────
+// ICE 'failed' dropped the peer and nothing re-offered until a roster event —
+// which a mid-session death never produces. One-way audio until manual reload.
+// Contract: failed → drop → ONE immediate fresh offer while the neighbor is
+// still in the roster. 'closed' stays terminal. FAILS on pre-fix main.
+{
+  stubs.remotes.set("cellular-peer", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const pcF = created.at(-1)!;
+  const nBefore = created.length;
+  pcF.connectionState = "failed";
+  (pcF.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("failed lane: a fresh offer goes out for the same id",
+        created.length > nBefore, `${created.length - nBefore} new pc(s)`);
+  const pcG = created.at(-1)!;
+  check("failed lane: the replacement is a different pc that actually offered",
+        pcG !== pcF && (pcG.offers ?? 0) >= 1,
+        `same=${pcG === pcF} offers=${pcG.offers}`);
+  // closed is deliberate teardown — must NOT resurrect
+  const nBefore2 = created.length;
+  pcG.connectionState = "closed";
+  (pcG.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("closed lane: stays down (no zombie re-offer)", created.length === nBefore2,
+        `${created.length - nBefore2} unexpected pc(s)`);
+  stubs.remotes.delete("cellular-peer");
+}
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1282,10 +1282,15 @@ check("unhush rejoins the SAME peer at full volume",
 // ── a FAILED lane reaches back (field, 2026-08-10) ───────────────────────────
 // ICE 'failed' dropped the peer and nothing re-offered until a roster event —
 // which a mid-session death never produces. One-way audio until manual reload.
-// Contract: failed → drop → ONE immediate fresh offer while the neighbor is
-// still in the roster. 'closed' stays terminal. FAILS on pre-fix main.
+// Contract (r2: rank-split — if BOTH sides re-offered, two never-settled
+// rivals meet and the glare logic reads them as rejoins; both roll back,
+// marry mismatched sessions, and storm at ICE cadence): failed → drop →
+// ONE immediate fresh offer FROM THE LOWER ID while the neighbor is still
+// in the roster; the higher id waits and answers. 'closed' stays terminal.
+// FAILS on pre-fix main. Local id is "me"; "zz-cellular" ranks above us, so
+// we are the reacher here.
 {
-  stubs.remotes.set("cellular-peer", { agent: false });
+  stubs.remotes.set("zz-cellular", { agent: false });
   bus.emit("roster");
   await settle();
   const pcF = created.at(-1)!;
@@ -1306,7 +1311,24 @@ check("unhush rejoins the SAME peer at full volume",
   await settle(); await settle();
   check("closed lane: stays down (no zombie re-offer)", created.length === nBefore2,
         `${created.length - nBefore2} unexpected pc(s)`);
-  stubs.remotes.delete("cellular-peer");
+  stubs.remotes.delete("zz-cellular");
+}
+
+// Higher-rank side of the same contract: when the FAILED peer ranks BELOW us,
+// we do NOT re-offer — their side owns the reach, ours answers through the
+// normal path. (Both sides offering is the storm this convention prevents.)
+{
+  stubs.remotes.set("aa-cellular", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const pcA = created.at(-1)!;
+  const nA = created.length;
+  pcA.connectionState = "failed";
+  (pcA.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("failed lane, peer ranks below us: no immediate re-offer (they reach, we answer)",
+    created.length === nA, `${created.length - nA} new pc(s)`);
+  stubs.remotes.delete("aa-cellular");
 }
 
 console.log(`\n${pass} passed, ${fail} failed\n`);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1279,56 +1279,83 @@ check("unhush rejoins the SAME peer at full volume",
 }
 
 
-// ── a FAILED lane reaches back (field, 2026-08-10) ───────────────────────────
+// ── a FAILED lane reaches back (field, 2026-08-10; r2: by courtship) ─────────
 // ICE 'failed' dropped the peer and nothing re-offered until a roster event —
-// which a mid-session death never produces. One-way audio until manual reload.
-// Contract (r2: rank-split — if BOTH sides re-offered, two never-settled
-// rivals meet and the glare logic reads them as rejoins; both roll back,
-// marry mismatched sessions, and storm at ICE cadence): failed → drop →
-// ONE immediate fresh offer FROM THE LOWER ID while the neighbor is still
-// in the roster; the higher id waits and answers. 'closed' stays terminal.
-// FAILS on pre-fix main. Local id is "me"; "zz-cellular" ranks above us, so
-// we are the reacher here.
+// which a mid-session death never produces. Contract (r2): the lane's SOLE
+// courter reaches back unconditionally (nobody else ever will — the agent-leg
+// case); a DUAL-courtship lane is arbitrated by rank (lower offers, higher
+// answers) so the two sides cannot re-offer into each other as never-settled
+// rivals the glare logic misreads as rejoins. 'closed' stays terminal.
+// Mic must be LIVE for courtship — a vacuous version of these pins asserted
+// on a stale pc with the mic off and passed against every implementation.
+// (The harness's pcs carry no id — anchor each case on created.length GROWTH
+// after courting so a silent no-court can't leave a stale pc standing in.)
+const failPc = async (pc: any) => {
+  pc.connectionState = "failed";
+  (pc.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+};
+
+consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
+                                 // without this the injected rival offers die
+                                 // at the gate and every "dual" pin is vacuous
+// A. sole courter, peer ranks BELOW us: we courted, they never offered — we
+//    reach regardless of rank (the agent-leg case: an agent leg ranking above
+//    its human peer is that lane's only possible repairer). Rank-only gating
+//    fails exactly this pin: it was the regression that silently disarmed the
+//    agent leg's only repair.
 {
-  stubs.remotes.set("zz-cellular", { agent: false });
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("aa-solo", { agent: false });
   bus.emit("roster");
   await settle();
-  const pcF = created.at(-1)!;
-  const nBefore = created.length;
-  pcF.connectionState = "failed";
-  (pcF.onconnectionstatechange as () => void)?.();
-  await settle(); await settle();
-  check("failed lane: a fresh offer goes out for the same id",
-        created.length > nBefore, `${created.length - nBefore} new pc(s)`);
-  const pcG = created.at(-1)!;
+  check("sole-courter setup: courting built exactly one pc (pin is not vacuous)",
+    created.length === n0 + 1, `${created.length - n0} pc(s)`);
+  const lane = created.at(-1)!;
+  await failPc(lane);
+  check("failed lane, sole courter, lower-ranked peer: we re-offer (nobody else will)",
+    created.length === n0 + 2, `${created.length - n0 - 1} new pc(s)`);
   check("failed lane: the replacement is a different pc that actually offered",
-        pcG !== pcF && (pcG.offers ?? 0) >= 1,
-        `same=${pcG === pcF} offers=${pcG.offers}`);
-  // closed is deliberate teardown — must NOT resurrect
-  const nBefore2 = created.length;
-  pcG.connectionState = "closed";
-  (pcG.onconnectionstatechange as () => void)?.();
-  await settle(); await settle();
-  check("closed lane: stays down (no zombie re-offer)", created.length === nBefore2,
-        `${created.length - nBefore2} unexpected pc(s)`);
-  stubs.remotes.delete("zz-cellular");
+    created.at(-1) !== lane && created.at(-1)!.offers >= 1, `offers=${created.at(-1)!.offers}`);
+  stubs.remotes.delete("aa-solo"); bus.emit("roster"); await settle();
 }
 
-// Higher-rank side of the same contract: when the FAILED peer ranks BELOW us,
-// we do NOT re-offer — their side owns the reach, ours answers through the
-// normal path. (Both sides offering is the storm this convention prevents.)
+// B. dual courtship, we rank HIGHER: they also offered at some point — rank
+//    arbitrates, and higher waits (they reach, we answer).
 {
-  stubs.remotes.set("aa-cellular", { agent: false });
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("aa-dual", { agent: false });
   bus.emit("roster");
   await settle();
-  const pcA = created.at(-1)!;
-  const nA = created.length;
-  pcA.connectionState = "failed";
-  (pcA.onconnectionstatechange as () => void)?.();
-  await settle(); await settle();
-  check("failed lane, peer ranks below us: no immediate re-offer (they reach, we answer)",
-    created.length === nA, `${created.length - nA} new pc(s)`);
-  stubs.remotes.delete("aa-cellular");
+  check("dual setup: courting built the lane", created.length === n0 + 1, `${created.length - n0}`);
+  const lane = created.at(-1)!;
+  offerFrom("aa-dual");            // their courtship: marks the lane dual
+  await settle();
+  const nB = created.length;
+  await failPc(lane);
+  check("failed dual lane, peer ranks below us: no re-offer (rank: they reach, we answer)",
+    created.length === nB, `${created.length - nB} new pc(s)`);
+  stubs.remotes.delete("aa-dual"); bus.emit("roster"); await settle();
+}
+
+// C. dual courtship, we rank LOWER: rank picks us — one clean re-offer.
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("zz-dual", { agent: false });
+  bus.emit("roster");
+  await settle();
+  check("dual-low setup: courting built the lane", created.length === n0 + 1, `${created.length - n0}`);
+  const lane = created.at(-1)!;
+  offerFrom("zz-dual");
+  await settle();
+  const nC = created.length;
+  await failPc(lane);
+  check("failed dual lane, we rank lower: exactly one fresh re-offer",
+    created.length === nC + 1, `${created.length - nC} new pc(s)`);
+  stubs.remotes.delete("zz-dual"); bus.emit("roster"); await settle();
 }
 
 console.log(`\n${pass} passed, ${fail} failed\n`);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1352,6 +1352,61 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
   stubs.remotes.delete("aa-race"); bus.emit("roster"); await settle();
 }
 
+// A3a (#102 review). The GENERATION-DEBT seam, isolating the object-identity
+// fire-check: sole courter, high rank, fails and schedules the deferred reach —
+// then a SAME-ID successor re-occupies the key as a FRESH record (#97 takeover)
+// via the roster path, WITHOUT a participant-teardown, inside the 380ms window.
+// The id-only guard (remotes.has(id) && !agent) sees the successor present and
+// courts it — the predecessor's debt relabelled onto a new generation. Bound to
+// the exact remote record, the stale reach must stand down: ZERO offers.
+// (No teardown here on purpose — a teardown would cancel the timer and mask
+//  this guard; A3b covers the teardown-cancel path separately.)
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("aa-gen", { agent: false });        // predecessor
+  bus.emit("roster");
+  await settle();
+  check("gen-debt setup: courting built the lane", created.length === n0 + 1, `${created.length - n0}`);
+  const lane = created.at(-1)!;
+  await failPc(lane);                        // schedules the deferred reach for the predecessor record
+  check("gen-debt: no immediate re-offer (defers)", created.length === n0 + 1, `${created.length - n0 - 1}`);
+  // same-id successor as a FRESH object (a new generation), no teardown event
+  stubs.remotes.set("aa-gen", { agent: false });
+  await settle();
+  const beforeDefer = created.length;
+  await new Promise((r) => setTimeout(r, 480));   // let the stale defer window pass
+  check("gen-debt: stale reach stands down against a fresh same-id successor (ZERO offers)",
+    created.length === beforeDefer, `${created.length - beforeDefer} stale pc(s) courted the successor`);
+  stubs.remotes.delete("aa-gen"); bus.emit("roster"); await settle();
+}
+
+// A3b (#102 review). A departed id's deferred reach fires zero offers. Two
+// mechanisms guarantee this and this test pins the OBSERVABLE result of both:
+// the object-identity fire-check already stands down (remotes.get(id) is now
+// undefined ≠ the predecessor), AND dropPeer cancels the timer on teardown so
+// _soleReach does not retain a dead id until expiry (map hygiene Antra asked
+// for; its effect is retention, not the offer count, which the fire-check
+// covers). dropPeer cancels even though no peer pc exists (the reach lives in
+// exactly the no-peer state).
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("aa-leave", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const lane = created.at(-1)!;
+  await failPc(lane);                        // schedules the deferred reach
+  check("teardown-cancel setup: no immediate re-offer (defers)", created.length === n0 + 1, `${created.length - n0 - 1}`);
+  bus.emit("participant-teardown", "aa-leave");   // the id truly leaves
+  stubs.remotes.delete("aa-leave");
+  const beforeDefer = created.length;
+  await new Promise((r) => setTimeout(r, 480));   // the cancelled timer must never fire
+  check("teardown-cancel: a departed id's deferred reach fires ZERO offers",
+    created.length === beforeDefer, `${created.length - beforeDefer} pc(s) against a gone id`);
+  bus.emit("roster"); await settle();
+}
+
 // B. dual courtship, we rank HIGHER: they also offered at some point — rank
 //    arbitrates, and higher waits (they reach, we answer).
 {

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1358,5 +1358,29 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
   stubs.remotes.delete("zz-dual"); bus.emit("roster"); await settle();
 }
 
+// D. (r4) the ANSWERER who has since renegotiated owns repair too: courting
+// is "ever sent an offer on this lane", not "created the peer". Under r3,
+// a lane born from THEIR offer kept _court=false here forever — if the far
+// courter ranked high it was rank-blocked and we were court-blocked: NOBODY
+// reached. Our mic toggle renegotiates (a real offer through offerOn), which
+// makes us a courter of record; their original offer makes the lane dual;
+// we rank lower than zz-ren, so rank picks us. FAILS on r3.
+{
+  consent.setReceiveVoice(true);
+  if (voice.micOn()) await voice.toggleMic("me");
+  offerFrom("zz-ren");                    // lane born from THEIR offer: we answer
+  await settle();
+  const lane = created.at(-1)!;
+  await voice.toggleMic("me");            // mic up → renegotiate → we now court
+  await settle();
+  const nD = created.length;
+  lane.connectionState = "failed";
+  (lane.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("failed lane born from their offer, renegotiated by us: we reach (dual, we rank lower)",
+    created.length === nD + 1, `${created.length - nD} new pc(s)`);
+  stubs.remotes.delete("zz-ren"); bus.emit("roster"); await settle();
+}
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1382,5 +1382,50 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
   stubs.remotes.delete("zz-ren"); bus.emit("roster"); await settle();
 }
 
+// ── backoff bound: retries ride ICE cadence, never a hot loop (r5 review) ──
+// Antra's vector: repeated failure must produce exactly ONE outstanding retry
+// per failed generation — no synchronous storm, no duplicate offers — and a
+// dead generation's ghost events must not touch its replacement.
+{
+  stubs.remotes.set("aa-flaky", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const gen1 = created.at(-1)!;
+  const n1 = created.length;
+  // the same dead pc fires 'failed' THREE times (browsers can re-emit; a hot
+  // loop would mint three replacements)
+  gen1.connectionState = "failed";
+  (gen1.onconnectionstatechange as () => void)?.();
+  (gen1.onconnectionstatechange as () => void)?.();
+  (gen1.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("backoff: three failure events on ONE generation → exactly one replacement",
+        created.length === n1 + 1, `${created.length - n1} new pc(s)`);
+  const gen2 = created.at(-1)!;
+  check("backoff: the single replacement offered exactly once",
+        gen2 !== gen1 && (gen2.offers ?? 0) === 1, `offers=${gen2.offers}`);
+  // ghost 'closed' from the DEAD generation must not kill the live one:
+  // without the staleness guard this drops the replacement, and 'closed'
+  // being terminal, the lane dies silently — the repair becomes the killer.
+  gen1.connectionState = "closed";
+  (gen1.onconnectionstatechange as () => void)?.();
+  await settle();
+  check("backoff: dead generation's late 'closed' cannot mint or drop peers",
+        created.length === n1 + 1 && gen2.closed !== true,
+        `${created.length - n1} pcs, replacement closed=${gen2.closed}`);
+  const gen2offers = gen2.offers ?? 0;
+  check("backoff: ...and provokes no extra offer from the replacement",
+        (created.at(-1) === gen2) && (gen2.offers ?? 0) === gen2offers && gen2.closed !== true,
+        `offers=${gen2.offers} closed=${gen2.closed}`);
+  // each NEW generation failing earns exactly one more retry — ICE cadence,
+  // one outstanding at a time
+  gen2.connectionState = "failed";
+  (gen2.onconnectionstatechange as () => void)?.();
+  await settle(); await settle();
+  check("backoff: next generation's failure earns exactly one more offer",
+        created.length === n1 + 2, `${created.length - n1} total new`);
+  stubs.remotes.delete("aa-flaky"); bus.emit("roster"); await settle();
+}
+
 console.log(`\n${pass} passed, ${fail} failed\n`);
 process.exit(fail ? 1 : 0);

--- a/tools/voice-lifecycle-test.ts
+++ b/tools/voice-lifecycle-test.ts
@@ -1314,11 +1314,42 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
     created.length === n0 + 1, `${created.length - n0} pc(s)`);
   const lane = created.at(-1)!;
   await failPc(lane);
-  check("failed lane, sole courter, lower-ranked peer: we re-offer (nobody else will)",
-    created.length === n0 + 2, `${created.length - n0 - 1} new pc(s)`);
-  check("failed lane: the replacement is a different pc that actually offered",
-    created.at(-1) !== lane && created.at(-1)!.offers >= 1, `offers=${created.at(-1)!.offers}`);
+  // r6 (adversarial review): sole courter + HIGH rank ("me" < "aa-solo" is
+  // false) no longer reaches IMMEDIATELY — that raced the 300ms sweep. It
+  // DEFERS past one sweep cycle, then reaches only if still unhealed. So no
+  // new pc at settle-time...
+  check("failed lane, sole courter, high rank: NO immediate re-offer (would race the sweep)",
+    created.length === n0 + 1, `${created.length - n0 - 1} premature pc(s)`);
+  // ...but the deferred reach fires (~380ms) because nobody else repaired it.
+  await new Promise((r) => setTimeout(r, 480));
+  check("failed lane, sole courter, high rank: the DEFERRED reach re-offers (last resort)",
+    created.length === n0 + 2 && created.at(-1) !== lane && created.at(-1)!.offers >= 1,
+    `${created.length - n0 - 1} new pc(s) offers=${created.at(-1)!.offers}`);
   stubs.remotes.delete("aa-solo"); bus.emit("roster"); await settle();
+}
+
+// A2 (r6). The GLARE-RACE the defer exists to kill: sole courter, high rank,
+// and the peer's reconcile sweep rebuilds the lane DURING the defer window.
+// The deferred reach must see the healed lane and stand down — no second pc,
+// no glare.
+{
+  if (!voice.micOn()) await voice.toggleMic("me");
+  const n0 = created.length;
+  stubs.remotes.set("aa-race", { agent: false });
+  bus.emit("roster");
+  await settle();
+  const lane = created.at(-1)!;
+  await failPc(lane);
+  check("glare-race setup: no immediate re-offer", created.length === n0 + 1, `${created.length - n0 - 1}`);
+  // simulate the peer's sweep winning: a fresh inbound offer rebuilds the lane
+  // before the deferred reach fires.
+  offerFrom("aa-race");
+  await settle();
+  const healed = created.length;
+  await new Promise((r) => setTimeout(r, 480));   // let the deferred reach window pass
+  check("glare-race: the deferred reach STANDS DOWN once the lane is healed (no glare pc)",
+    created.length === healed, `${created.length - healed} glare pc(s)`);
+  stubs.remotes.delete("aa-race"); bus.emit("roster"); await settle();
 }
 
 // B. dual courtship, we rank HIGHER: they also offered at some point — rank
@@ -1387,7 +1418,7 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
 // per failed generation — no synchronous storm, no duplicate offers — and a
 // dead generation's ghost events must not touch its replacement.
 {
-  stubs.remotes.set("aa-flaky", { agent: false });
+  stubs.remotes.set("zz-flaky", { agent: false });
   bus.emit("roster");
   await settle();
   const gen1 = created.at(-1)!;
@@ -1424,7 +1455,7 @@ consent.setReceiveVoice(true);   // a late consent block leaves receive OFF —
   await settle(); await settle();
   check("backoff: next generation's failure earns exactly one more offer",
         created.length === n1 + 2, `${created.length - n1} total new`);
-  stubs.remotes.delete("aa-flaky"); bus.emit("roster"); await settle();
+  stubs.remotes.delete("zz-flaky"); bus.emit("roster"); await settle();
 }
 
 console.log(`\n${pass} passed, ${fail} failed\n`);


### PR DESCRIPTION
Split out of #90 per the narrow-scope offer there (this is reachability, not gate work).

**The bug, reproduced twice in one evening (once on a pure human↔human pair):** ICE `failed` on a hard-NAT peer → `dropPeer` → the id has no peer object, and the roster rescan that would re-offer runs only on roster *events* — which a mid-session lane death never produces. Result: one-way audio until someone reloads. This is the mobile/cellular flavor of the stale-binding class.

**The fix:** a failed lane reaches back — on `failed` (not `disconnected`, which recovers on its own) the dropped side re-offers once through the existing signaling path, with the same consent gates. Adds 3 lifecycle tests (failed→fresh-offer, replacement-is-a-different-pc, closed-stays-down).

Tests: voice-lifecycle 116/116 with this commit on the rebased #90; smoke 85/85. Stacks cleanly on current main + #90; if #90 lands first this is a 1-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)