### PR TITLE
ammodoll: terrain-following ground — heads stop clipping into hillsides

### DIFF
--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -444,7 +444,39 @@ export class AmmoRagdoll {
     };
     const hips = live.hips ?? avatar.root.position;
     this.groundY = heightAt(hips.x, hips.z);
-    addStatic(60, 0.5, 60, { x: hips.x, y: this.groundY - 0.5, z: hips.z }, null, FRICTION);
+    // TERRAIN-FOLLOWING GROUND. The Verlet resolves heightAt(x,z) per joint
+    // per step, so its bodies follow every slope; a single flat cuboid
+    // sampled at the hips buried heads wherever the field rose above that
+    // one sample (antra, live on a meadow hillside). Sample a grid around
+    // the fall and lay box TILES at the field's own heights; a flat world
+    // (every sample within 2cm) keeps the one-cuboid fast path. Beyond the
+    // grid, a wide apron at the LOWEST sampled height catches a long tumble
+    // without ever poking above a tile inside it.
+    {
+      // TILE bounds the stair-step error: a flat tile is slope×TILE/2 below the
+      // field at its uphill edge — 0.75m keeps a steep 40% grade within 15cm
+      // (a box half-width), and gentle meadows within a few cm.
+      const GROUND_R = 12, TILE = 0.75;
+      const tiles = [];
+      let lo = this.groundY, flat = true;
+      for (let gx = -GROUND_R; gx <= GROUND_R; gx += TILE) {
+        for (let gz = -GROUND_R; gz <= GROUND_R; gz += TILE) {
+          const h = heightAt(hips.x + gx, hips.z + gz);
+          tiles.push([gx, gz, h]);
+          lo = Math.min(lo, h);
+          if (Math.abs(h - this.groundY) > 0.02) flat = false;
+        }
+      }
+      if (flat) {
+        addStatic(60, 0.5, 60, { x: hips.x, y: this.groundY - 0.5, z: hips.z }, null, FRICTION);
+      } else {
+        addStatic(60, 0.5, 60, { x: hips.x, y: lo - 0.5, z: hips.z }, null, FRICTION);
+        for (const [gx, gz, h] of tiles) {
+          addStatic(TILE / 2 + 0.02, 0.5, TILE / 2 + 0.02,
+            { x: hips.x + gx, y: h - 0.5, z: hips.z + gz }, null, FRICTION);
+        }
+      }
+    }
     for (const [, c] of colliders) {
       const obj = c.obj;
       if (!obj || c.interior || !c.box) continue;

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -653,9 +653,31 @@ export class AmmoRagdoll {
       const w = part === 'head' ? Math.max(limbW(ra, rb2), torsoR * 0.55)
         : part === 'foot' ? Math.max(limbW(ra, rb2), 0.03)
           : limbW(ra, rb2);
+      // …and the skull is a VOLUME the head bone only anchors: VRM puts that
+      // bone at the skull base, so a box ending there — and only as wide as
+      // the neck — leaves the face and crown hollow, and a prone body sank
+      // face-first to the ears before its neck stub touched ground (antra,
+      // live, on FLAT terrain — the slope fix was innocent). Two dimensions
+      // matter and only one is obvious: the box runs ON past the bone to a
+      // height-scaled crown point, and — the one that actually carries a
+      // prone head — its PERPENDICULAR half-extents grow to skull scale
+      // (extending along the bone axis lifts nothing when that axis lies on
+      // the ground; measured: crown-only moved the prone head 2.7→2.9cm).
+      // The verlet never shows this because its head particle carries an
+      // explicit clearance radius; the source rig never shows it because its
+      // head box was measured from the MESH. Collision only — seg endpoints,
+      // .p and pins keep the true bone.
+      const isHead = part === 'head';
+      const boxEnd = isHead
+        ? rb2.clone().addScaledVector(
+          rb2.clone().sub(ra).normalize(),
+          Math.min(0.22, Math.max(0.08, H * 0.11)))
+        : rb2;
+      const wHead = isHead ? Math.max(w, H * 0.05) : w;
+      const dHead = isHead ? Math.max(w, H * 0.058) : w;
       const body = mkBody(
         MASS_FRAC[part] * massScale, liveMid, qB,
-        [boxFor(restMid, ra, rb2, w)], false);
+        [boxFor(restMid, ra, boxEnd, wHead, dHead)], false);
       const seg = {
         key, a, b: b2, body, torso: false,
         restA: ra.clone(), restB: rb2.clone(),

--- a/tools/ammodoll-test.ts
+++ b/tools/ammodoll-test.ts
@@ -524,6 +524,38 @@ console.log('\nfingers (spring phalanges, additive by absence):');
   }
 }
 
+// ---------------------------------------------------------------------------
+// SLOPED TERRAIN — the ground must follow the field, not one sample. The
+// Verlet resolves heightAt per joint per step; the first ammo build laid a
+// single flat cuboid at heightAt(hips) and heads buried wherever the field
+// rose above that sample (antra, live on a meadow hillside). The terrain
+// module is headless-injectable by design (issue #17), so the suite tilts
+// the world and drops a body on the grade.
+console.log('\nsloped terrain (the ground follows the field):');
+{
+  const { setTerrain, heightAt } = await import('../client/lib/terrain.js');
+  setTerrain({ heightAt: (x: number, z: number) => 0.4 * x + 0.15 * Math.sin(z) });
+  const rig: any = FLEET[0];
+  const bad: string[] = [];
+  for (const yaw of [0, Math.PI / 2]) {
+    const av = makeAvatar(rig.P, { realParent: rig.realParent });
+    av.root.rotation.y = yaw;
+    av.root.position.y = heightAt(av.root.position.x, av.root.position.z);
+    av.root.updateMatrixWorld(true);
+    const rd: any = new AmmoRagdoll(av, toppleLean(yaw, 6), av.restBonePositions());
+    let steps = 0;
+    while (!rd.done && steps < 900) { rd.step(1 / 60); steps++; }
+    for (const [j, p] of Object.entries(rd.p) as any) {
+      const under = heightAt(p.x, p.z) - p.y;
+      // tolerance = a box half-width of grazing; the flat-cuboid bug buried
+      // parts by the full local rise (0.3-0.5m on this grade)
+      if (under > 0.25) bad.push(`${yaw ? 'E' : 'N'}:${j}(${(under * 100).toFixed(0)}cm under)`);
+    }
+  }
+  setTerrain(null);
+  check('no joint rests buried in a sloped field', bad.length === 0, bad.slice(0, 6).join(' '));
+}
+
 console.log('\nlifecycle (one rig, every downstream contract):');
 {
   const rig: any = FLEET[0];

--- a/tools/ammodoll-test.ts
+++ b/tools/ammodoll-test.ts
@@ -556,6 +556,36 @@ console.log('\nsloped terrain (the ground follows the field):');
   check('no joint rests buried in a sloped field', bad.length === 0, bad.slice(0, 6).join(' '));
 }
 
+// ---------------------------------------------------------------------------
+// FACE-PLANT — the skull is collision volume, not just the head bone. VRM
+// puts the head bone at the skull base; a head box ending there leaves the
+// face and crown hollow, and a prone body sinks face-first to the ears
+// before its neck stub touches ground (antra, live, on FLAT terrain). Shove
+// a body over face-first and demand the head bone rests clear of the floor
+// by more than a neck's half-width.
+console.log('\nface-plant (the skull keeps the face out of the floor):');
+{
+  const bad: string[] = [];
+  for (const rig of FLEET.slice(0, 5)) {
+    const P: any = rig.P;
+    const up = (P.neck ?? P.chest).clone().sub(P.hips).normalize();
+    const lat = P.leftUpperArm.clone().sub(P.rightUpperArm);
+    lat.addScaledVector(up, -lat.dot(up)).normalize();
+    const fwd = new THREE.Vector3().crossVectors(lat, up).normalize();
+    const av = makeAvatar(rig.P, { realParent: rig.realParent });
+    const rd: any = new AmmoRagdoll(av, fwd.multiplyScalar(5), av.restBonePositions());
+    let steps = 0;
+    while (!rd.done && steps < 900) { rd.step(1 / 60); steps++; }
+    // height-scaled bar: a skull is ~14% of standing height, so the head
+    // BONE (skull base) prone on the ground rests about half a skull depth
+    // up — small rigs have proportionally small heads
+    const H = (P.head.y - Math.min(P.leftFoot?.y ?? 0, P.rightFoot?.y ?? 0)) * 1.12;
+    const clear = rd.p.head?.y ?? 0;   // flat world: ground is y=0
+    if (clear < H * 0.045) bad.push(`${rig.name}(head at ${(clear * 100).toFixed(1)}cm, bar ${(H * 4.5).toFixed(1)}cm)`);
+  }
+  check('a face-first fall rests the head clear of the floor', bad.length === 0, bad.join(' '));
+}
+
 console.log('\nlifecycle (one rig, every downstream contract):');
 {
   const rig: any = FLEET[0];


### PR DESCRIPTION
Field report from antra on staging: *"the head occasionally clips inside of terrain."*

Root cause is an engine-parity gap from #96: the **Verlet resolves `heightAt(x,z)` per joint per step** and follows every slope, while ammodoll laid **one flat ground cuboid at `heightAt(hips)`** sampled at fall time — wherever the field rises above that single sample, body parts bury by the full local rise (measured 26–32cm on a 40% test grade). rapierdoll shares the same one-cuboid design and presumably the same symptom; this PR fixes ammo only.

Fix: sample the field on a **0.75m grid over ±12m** and lay static box tiles at the field's own heights. A flat world (every sample within 2cm) keeps the original one-cuboid fast path — the whole existing suite runs that path unchanged. Beyond the grid, a wide apron at the *lowest* sampled height catches long tumbles without poking above any tile. 0.75m tiles bound stair-step error to slope×0.375: ~15cm on a steep 40% grade, a few cm on a real meadow.

Suite: new sloped-terrain section (terrain is headless-injectable by design) tilts the field 40% and drops a body on the grade; no joint may rest more than a box half-width under the local field. **Negative-controlled**: fails 26–32cm-under against the previous ground code at identical tolerances — and an earlier, gentler version of the check passed vacuously against the bug, so the grade and shove are load-bearing and commented as such.

ammodoll-test **38/38** on this branch (bare-repo caveat: run with the usual worktree symlinks).

Also running on eidoverse2 via the `cc/telos-plus-ammo` hybrid (same commit cherry-picked) for antra to verify on the hillside where she found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)