### PR TITLE
bodysim: ammo becomes the default body engine

### DIFF
--- a/client/lib/bodysim.js
+++ b/client/lib/bodysim.js
@@ -31,8 +31,13 @@ const ENGINES = new Map([
   }],
 ]);
 
+// The DEFAULT is the Bullet engine (antra, after a day of live falls across
+// old and new avatars: "these physics are just plainly better than anything
+// else we had so far"). The ladder below keeps every promise the old default
+// made: while the wasm warms — or if it never opens — falls run verlet, and
+// a stored choice always wins over the default.
 const stored = localStorage.getItem(KEY);
-let engine = ENGINES.has(stored) ? stored : 'verlet';
+let engine = ENGINES.has(stored) ? stored : 'ammo';
 
 async function loadEngine(name) {
   const e = ENGINES.get(name);


### PR DESCRIPTION
Operator's call after live testing: the Bullet engine ships as the default. Stored choices win; verlet remains the load/failure fallback and the headless-agent engine. Suites: ammodoll 39, ragdoll 59, rapierdoll 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)