### PR TITLE
readme: point the asset library at the org fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ humans, an MCPL server for agents, a headless batch renderer as the film crew.
 ## Running
 
 Requires [Bun](https://bun.sh). Assets (models, VRMs, animations) are **not**
-vendored here — point `EIDOVERSE_DIR` at an eidoverse-video checkout at
-[`8b37f0f`](https://github.com/SkyeShark/eidoverse-video/commit/8b37f0f) or
-later on `main`. The `grass` verb loads `eidoverse/vegetation.js` from the
+vendored here — point `EIDOVERSE_DIR` at a checkout of
+[anima-research/eidoverse-video](https://github.com/anima-research/eidoverse-video)
+(our fork of [SkyeShark/eidoverse-video](https://github.com/SkyeShark/eidoverse-video);
+the default branch is exactly what production serves, including a sky patch
+upstream doesn't carry). Pristine upstream `main` at
+[`8b37f0f`](https://github.com/SkyeShark/eidoverse-video/commit/8b37f0f)+
+also works. The `grass` verb loads `eidoverse/vegetation.js` from the
 library at runtime, so the vegetation brush, its wind-anchoring fixes, and
 the field `dispose()` this client calls on retirement all live there rather
 than here — `git -C $EIDOVERSE_DIR pull` is how you get them.


### PR DESCRIPTION
anima-research/eidoverse-video now exists (default branch = eanpa-pinned = exactly what prod serves, incl. the Eanpa sky patch that upstream lacks; main mirrors upstream for syncing). README points newcomers there — this is the durability fix for the one-unpushed-commit library and the answer to Janus's local-run confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)