### PR TITLE
import-tripo-avatar: vertex-painted eyeballs pass through

### DIFF
--- a/tools/import-tripo-avatar.ts
+++ b/tools/import-tripo-avatar.ts
@@ -98,6 +98,11 @@ for (const mat of root.listMaterials()) {
       say(`textures transplanted onto ${name}`);
     } else say(`⚠ ${name} is textureless and the donor cannot help (${DONOR})`);
   } else if (name === 'RAVEN') {
+    // AUTHOR WINS: an export that arrives with its own factors or extensions
+    // (Janus ships her own iridescence now) passes through untouched — the
+    // house look below is a REPAIR for bare materials, not a house style
+    if (mat.getBaseColorFactor().some((v: number, i: number) => v !== 1 && i < 3)
+      || mat.listExtensions().length) { say('RAVEN: author-provided, kept'); continue; }
     mat.setBaseColorFactor([0.015, 0.015, 0.022, 1]).setMetallicFactor(0.2)
       .setRoughnessFactor(0.22).setDoubleSided(true);
     mat.setExtension('KHR_materials_clearcoat',
@@ -107,6 +112,8 @@ for (const mat of root.listMaterials()) {
         .setIridescenceThicknessMinimum(200).setIridescenceThicknessMaximum(500));
     say('RAVEN → iridescent black');
   } else if (name === 'PORCELAIN') {
+    if (mat.getBaseColorFactor().some((v: number, i: number) => v !== 1 && i < 3)
+      || mat.listExtensions().length) { say('PORCELAIN: author-provided, kept'); continue; }
     for (const k of ['BaseColor', 'MetallicRoughness'] as const) (mat as any)[`set${k}Texture`](null);
     mat.setNormalTexture(null);
     mat.setBaseColorFactor([1, 1, 1, 1]).setMetallicFactor(0).setRoughnessFactor(0.28).setDoubleSided(true);

--- a/tools/import-tripo-avatar.ts
+++ b/tools/import-tripo-avatar.ts
@@ -123,10 +123,15 @@ for (const mat of root.listMaterials()) {
   } else if (name === 'GOLD') {
     mat.setDoubleSided(true);            // factor + default metallic already right
   } else if (name === 'eyeballs' && !mat.getBaseColorTexture()) {
-    // the once-mysterious Sphere: give bare eyes a dark iris-ish gloss
-    // rather than default white-out
+    // AUTHOR WINS here too (the black-eyeballs incident): vertex-painted
+    // eyes (COLOR_0 on the prims — Janus paints the sclera per-vertex)
+    // pass through untouched; the dark gloss is a repair for eyes with no
+    // paint of ANY kind, which would otherwise render blank white
+    const painted = root.listMeshes().some((mesh2) => mesh2.listPrimitives().some((p2) =>
+      p2.getMaterial() === mat && p2.getAttribute('COLOR_0')));
+    if (painted) { say('eyeballs: vertex-painted, kept'); continue; }
     mat.setBaseColorFactor([0.06, 0.05, 0.06, 1]).setMetallicFactor(0).setRoughnessFactor(0.1);
-    say('eyeballs → dark gloss');
+    say('eyeballs → dark gloss (no paint of any kind)');
   }
 }
 


### PR DESCRIPTION
The black-eyeballs incident: the dark-gloss repair stomped Janus's per-vertex sclera paint. Repairs only fire on truly bare eyes now. mythos_paint4 rebuilt + redeployed to staging.

🤖 Generated with Claude Code