### PR TITLE
travel: in-session world walking, as an eidoverse-local extension

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -408,6 +408,12 @@ export class WorldAgent {
         // door, holding up bodies in later worlds at the same coordinates
         // (#83; the #17 symptom reached through a ban).
         if ((ev as { code?: number } | undefined)?.code === 4006) { this.close(); return; }
+        // 4005 = the sequencer REFUSED the join (bad/reserved name, bad token).
+        // A refusal is an answer, not an outage — redialing it every 1.5s is
+        // the polite-DoS the sequencer's own comments warn about (RFC-005
+        // review D1: a granted ?world= dial with a name the sequencer rejects
+        // used to hammer forever).
+        if ((ev as { code?: number } | undefined)?.code === 4005) { this.close(); return; }
         if (!this.closed) setTimeout(() => this.connect().catch(() => {}), 1500);
       };
       ws.onmessage = async (ev) => {

--- a/mcpl/declaration.ts
+++ b/mcpl/declaration.ts
@@ -287,6 +287,10 @@ export const MCPL_ADVERTISEMENT = {
   channels: {
     register: true,
     lifecycle: true,
+    // RFC-005: channels/open naming a sibling world is a JOIN request,
+    // policy-gated (worlds allowlist on the credential; absence denies).
+    // Advertisement leaf only — authorization stays on channels.lifecycle.
+    join: true,
     publish: true,
     incoming: true,
     streaming: true,

--- a/mcpl/declaration.ts
+++ b/mcpl/declaration.ts
@@ -241,6 +241,9 @@ export const FEATURE_SETS: Record<string, FeatureSetDecl> = {
   "eidoverse.world": {
     description:
       "Embodied presence in a world. The world's chat is an MCPL channel: speech, whispers, approaches, presence and an ambient activity digest arrive as channels/incoming, and publishing on the world channel IS saying it aloud in-world.",
+    // channels.lifecycle is here because the world an agent is IN can change —
+    // see eidoverse.travel, which shares the leaf. Presence and travel are
+    // separable feature sets so a host can take the world without the door.
     uses: [CAP.channelsRegister, CAP.channelsLifecycle, CAP.channelsPublish, CAP.channelsIncoming],
     tagOntology: TAG_ONTOLOGY,
   },
@@ -248,6 +251,11 @@ export const FEATURE_SETS: Record<string, FeatureSetDecl> = {
     description:
       "The body's hands and senses as tools: look, snapshot, walking, gesture and pose, building, moderation. Survives on its own — this is what a plain-MCP client gets.",
     uses: [CAP.tools],
+  },
+  "eidoverse.travel": {
+    description:
+      "Walking between the worlds this door fronts, without dropping the connection. Two lanes, one mechanism: the `travel` tool, and `channels/open` naming a sibling world (a generic host that only knows MCPL can travel without knowing our tool names). Authorization is `channels.lifecycle` — a host that declines it keeps a resident who cannot leave, which is exactly today's behavior.",
+    uses: [CAP.channelsLifecycle, CAP.tools],
   },
   "eidoverse.typing": {
     description:
@@ -287,10 +295,6 @@ export const MCPL_ADVERTISEMENT = {
   channels: {
     register: true,
     lifecycle: true,
-    // RFC-005: channels/open naming a sibling world is a JOIN request,
-    // policy-gated (worlds allowlist on the credential; absence denies).
-    // Advertisement leaf only — authorization stays on channels.lifecycle.
-    join: true,
     publish: true,
     incoming: true,
     streaming: true,

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -279,11 +279,13 @@ class Session {
         id: `world:${w}`,
         label: `eidoverse — ${w}`,
         address: { world: w },
-        // §3.2.3d: NO epoch here. The epoch names a COMMITTED attachment; a
-        // proposal that may be declined must not hand the host a generation
-        // number that will never exist (review A(c) — the shipped client
-        // believed it and drifted by one per aborted join).
-        metadata: { ...(founding ? { created: true } : {}) },
+        // §3.2.3d: the descriptor MUST carry metadata.epoch — it is the only
+        // place the client learns it. v3 dropped the field entirely to avoid
+        // promising a generation that an aborted join would never reach, which
+        // traded drift-by-one for never-advancing-at-all. The fix is on the
+        // CLIENT (defer the assignment until commit is observed), not here:
+        // prepare states the epoch this transition WOULD commit to.
+        metadata: { epoch: this.epoch + 1, ...(founding ? { created: true } : {}) },
       } as ChannelDescriptor;
       let accepted = false;
       try {
@@ -1392,6 +1394,7 @@ wss.on("connection", (ws, req) => {
   ws.on("message", hold);
   const reqWorld = new URL(req.url ?? "/", "http://localhost").searchParams.get("world");
   const dialWorld = reqWorld;
+  const mintedWorld = auth.world ?? "commons";   // before the dial lane rewrites it
   if (reqWorld && reqWorld !== (auth.world ?? "commons")) {
     if (joinAllowed(auth, reqWorld)) {
       console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" granted (policy)`);
@@ -1419,22 +1422,40 @@ wss.on("connection", (ws, req) => {
   // `world` claim is where its operator put it — refusing that would brick a
   // fresh deployment (whose "commons" does not exist until someone arrives)
   // and would be gating the operator, not the agent.
-  const chosen = dialWorld !== null;            // ?world= is a choice; the claim is not
+  // The AGENT chose only if it named a world OTHER than the one its credential
+  // was minted into. Dialing your own home explicitly — the natural,
+  // RFC-004-composing thing to do — is not a choice of destination, and gating
+  // it bricks any deployment whose default world has not been founded yet.
+  // (v3 got this wrong: it tested `dialWorld !== null` and then gated
+  // `auth.world`, so ?world=commons refused where no ?world= admitted. Found by
+  // review, proven on a fresh deployment with the same destination both ways.)
+  const chosen = dialWorld !== null && dialWorld !== mintedWorld;
   if (chosen) {
-    const wname = auth.world ?? "commons";
+    const wname = dialWorld!;                  // the DIALLED name, not the claim
     void (async () => {
-      if (!auth!.create && !(await worldExists(wname))) {
+      const exists = await worldExists(wname); // one probe, one verdict
+      if (!exists && !auth!.create) {
         console.log(`[${ts()}] [audit] founding DENIED: ${auth!.id} → "${wname}" (dial-time, no create authority)`);
-        refuseWithGuidance(ws, `world "${wname}" does not exist and this credential has no create authority`);
+        refuse(`world "${wname}" does not exist and this credential has no create authority`);
         return;
       }
-      if (!(await worldExists(wname))) {
-        console.log(`[${ts()}] [audit] founding GRANTED: ${auth!.id} → "${wname}" (dial-time, create authority)`);
-      }
+      if (!exists) console.log(`[${ts()}] [audit] founding GRANTED: ${auth!.id} → "${wname}" (dial-time, create authority)`);
       admit();
     })();
   } else {
     admit();
+  }
+
+  /** Refuse AFTER the hold-buffer is installed: drop the buffer first, and
+   *  replay what the agent already said so refuseWithGuidance's teaching path
+   *  can answer it. Without this a fast client — one that sends `initialize`
+   *  synchronously on open — got silence and an unexplained close instead of
+   *  the guidance this door goes out of its way to provide. */
+  function refuse(why: string) {
+    ws.off("message", hold);
+    refuseWithGuidance(ws, why);
+    for (const d of held) ws.emit("message", d);
+    held.length = 0;
   }
 
   function admit() {

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -126,6 +126,7 @@ const TOOLS = [
   { name: "place", description: "Move an entity (id from look) to x,z (y defaults to terrain; pass y to seat on furniture).", inputSchema: { type: "object", properties: { id: { type: "string" }, x: { type: "number" }, z: { type: "number" }, y: { type: "number" }, yaw: { type: "number" } }, required: ["id", "x", "z"] } },
   { name: "light", description: "Place a light source in the world, or update one you can already see: calling with the id of an existing light changes ONLY the fields you pass (brightness via intensity, color, range, position) and leaves the rest alone. Persists like any placed thing. color is a hex integer (e.g. 0xffd9a0 warm, 0x88bbff cool, 0xff5533 red), intensity (default 16) and range are optional. keep: true means the light ALWAYS casts: it lives outside the per-client point-light budget (consumes no slot, so unkept lights keep their full budget) and framerate governors never douse it. Every casting light has real GPU cost — keep it for lights that matter. Position defaults to just in front of you. A small glowing sphere marks it; move or remove it by id like any entity.", inputSchema: { type: "object", properties: { color: { type: "number" }, intensity: { type: "number" }, range: { type: "number" }, keep: { type: "boolean" }, x: { type: "number" }, y: { type: "number" }, z: { type: "number" }, id: { type: "string" } } } },
   { name: "remove", description: "Remove a placed entity.", inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } },
+  { name: "travel", description: "Walk to another world this door fronts, keeping your identity, body and attention settings — no reconnect. Subject to your credential's join policy; founding a world that does not exist yet needs separate create authority. Your held pose and posture survive; your chat cursor resets to the new world.", inputSchema: { type: "object", properties: { world: { type: "string", description: "world name, e.g. \"commons\"" } }, required: ["world"] } },
   { name: "world_verb", description: "Raw world-log verb. The verb set is CLOSED by design — say, use, punt, force, mount, dismount, spawn, place, remove, light, comp, motion, behavior, asset, terrain, grass, sky, weather, grant, kick, ban, unban — and the door refuses others; extend STATE with comp types you invent, EVENTS with use actions, SEMANTICS with behavior scripts, never by hoping a new verb exists. This is also the authoring surface for components: comp {id, type, data|null} attaches data to an entity (sockets, reactions, or anything you invent); motion {id, type: pendulum|spin|orbit|bob|path, …} sets it moving; see AGENTS.md in the eidoverse-worlds repo for the full vocabulary.", inputSchema: { type: "object", properties: { verb: { type: "string" }, args: { type: "object" } }, required: ["verb", "args"] } },
   { name: "measure", description: "Geometry as data: bounding box, up-facing flat zones (seat/table/deck candidates), and named parts of a placed thing (id) or a library model (lib). Flat-zone coords are the MODEL's local frame — the same frame sockets use, so a zone's center IS a socket pos: comp {id, type:'sockets', data:{seat:{pos:[cx,y,cz], yaw}}}. Use this to find where a body can sit before declaring the seat; verify by mounting it yourself and taking a selfie snapshot. Raw GLB bytes are at GET <sequencer>/library/<lib> if you want to process the mesh locally.", inputSchema: { type: "object", properties: { id: { type: "string" }, lib: { type: "string" } } } },
   { name: "world_history", description: "Pull raw entries from the world log — the append-only record every world IS. Filter by verbs (e.g. ['use','motion'] to trace an interaction, ['comp'] to see how something was built), page backwards with before. Every entry has {seq, ts, actor, verb, args}; reaction-authored entries carry {cause, by}. This is the debugging primitive: the log is the world, so reading it is reading the world's source.", inputSchema: { type: "object", properties: { verbs: { type: "array", items: { type: "string" } }, before: { type: "number" }, after: { type: "number" }, limit: { type: "number" } } } },
@@ -267,6 +268,30 @@ class Session {
    *  assignment. Throws on attach failure; the caller maps that to -32024 and
    *  MUST then surface the connection as closed (§3.2.5 — we cannot silently
    *  remain attached to a world we already left). */
+  /** The ONE authorization path for changing worlds, shared by both lanes:
+   *  the `travel` tool and `channels/open` naming a sibling. Extracted because
+   *  two copies of a three-part gate is two policies that will drift — and the
+   *  founding check in particular took three rounds of review to get right.
+   *
+   *  Three questions, in this order, each with its own answer shape:
+   *    1. may this HOST act on channels at all      → capability (-32002)
+   *    2. may this CREDENTIAL reach that world      → join policy (-32017)
+   *    3. may it CREATE a world that isn't there    → create authority (-32023)
+   *  Founding is deliberately last and separate: an operator granting broad
+   *  travel has not thereby granted unbounded world-founding. */
+  private async travelGate(target: string): Promise<
+    { ok: true; founding: boolean } | { ok: false; code: number; why: string }
+  > {
+    if (!this.granted(CAP.channelsLifecycle))
+      return { ok: false, code: -32002, why: `capability denied: ${CAP.channelsLifecycle}` };
+    if (!joinAllowed(this.auth, target))
+      return { ok: false, code: -32017, why: `channel not permitted: world "${target}" is not in this credential's join policy` };
+    const founding = !(await worldExists(target));
+    if (founding && !this.auth.create)
+      return { ok: false, code: -32023, why: `unknown channel: world "${target}" does not exist (founding requires create authority)` };
+    return { ok: true, founding };
+  }
+
   private async joinWorld(w: string, founding = false): Promise<void> {
     // ── PREPARE (RFC-005 §3.2.3a-c, Mica review #2) ────────────────────────
     // The host's acceptance is PART of the transition, not a notification
@@ -734,27 +759,15 @@ class Session {
                 }
                 const target = byId ?? byAddr;   // channelId wins (conflict rejected above)
                 if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
-                // RFC-005 §3.1: join intent requires the channels.join grant
-                // (in addition to channels.lifecycle), BEFORE policy.
-                if (!this.granted("channels.join")) {
-                  this.conn.sendError(req.id, -32002, "capability denied: channels.join");
-                  break;
-                }
-                if (!joinAllowed(this.auth, target)) {
-                  this.conn.sendError(req.id, -32017, `channel not permitted: world "${target}" is not in this credential's join policy`);
-                  break;
-                }
-                // §3.2.7 (Mica review): FOUNDING IS NOT JOINING. This deployment
-                // founds a world on first attach, so a join naming an unused
-                // name would create one — an operator granting broad travel has
-                // not thereby granted unbounded world-founding. Creation needs
-                // its own positive authority (`create: true` on the credential).
-                const founding = !(await worldExists(target));
-                if (founding && !this.auth.create) {
-                  this.conn.sendError(req.id, -32023,
-                    `unknown channel: world "${target}" does not exist (founding requires create authority)`);
-                  break;
-                }
+                // Join intent is authorized by channels.lifecycle — the same
+                // grant that covers opening any channel. An earlier draft gated
+                // it on an invented `channels.join` leaf, which is NOT in the
+                // spec's §6.2 capability list: declaring it would have made this
+                // a protocol change. It isn't one. (antra, 2026-08-14: "this can
+                // be done well within eidoverse mcpl".)
+                const gate = await this.travelGate(target);
+                if (!gate.ok) { this.conn.sendError(req.id, gate.code, gate.why); break; }
+                const founding = gate.founding;
                 try {
                   await this.joinWorld(target, founding);
                 } catch (e) {
@@ -1174,6 +1187,25 @@ class Session {
         return text(`placed light [${id}] at (${x.toFixed(1)}, ${y.toFixed(1)}, ${z.toFixed(1)})`);
       }
       case "remove": ag.verb("remove", { id: a.id }); return text(`removed ${a.id}`);
+      case "travel": {
+        const target = String(a.world ?? "").trim();
+        if (!WORLD_NAME_RE.test(target))
+          return { content: [{ type: "text", text: `travel refused: "${target}" is not a valid world name` }], isError: true };
+        if (target === ag.world) return text(`Already in "${target}".`);
+        const gate = await this.travelGate(target);
+        if (!gate.ok) return { content: [{ type: "text", text: `travel refused: ${gate.why}` }], isError: true };
+        try {
+          await this.joinWorld(target, gate.founding);
+        } catch (e) {
+          return { content: [{ type: "text", text: `travel failed: ${(e as Error).message}` }], isError: true };
+        }
+        // The host is told by channels/changed (same as the channels/open lane);
+        // this string is for the AGENT, so it says what actually moved.
+        return text(
+          `${gate.founding ? "Founded and entered" : "Arrived in"} "${target}" (attachment ${this.epoch}). ` +
+          `Your body, avatar and held pose came with you; your chat cursor starts fresh here. Use \`look\` to see where you are.`,
+        );
+      }
       case "world_verb": {
         // the raw door forwards verbatim, so shape is checked HERE — a
         // malformed place in the log is permanent history every replayer

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -751,7 +751,24 @@ class Session {
     persistState();
     seenTimer = setInterval(() => {
       lastSeen[this.auth.id] = Date.now();
-      lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
+      // 🔴 NEVER PERSIST A WATERMARK FROM A BODY THAT HAS NOT SYNCED
+      // (adversarial review, 2026-08-17). WorldAgent.lastSeq is -1 until the
+      // first snapshot lands (agent.ts:245), and joinWorld assigns
+      // `this.agent = next` BEFORE awaiting next.connect() — a window of up to
+      // the 8s join timeout. A tick landing in that window wrote
+      // `{id}@{newworld}: -1`.
+      //
+      // -1 is not "nothing recorded", it is a NUMBER: the reader at :716 takes
+      // any non-null value, so skipInboxThrough(-1) skips nothing and
+      // missedSince(-1) reaches back to the dawn of the log — the next connect
+      // to that world replays its ENTIRE history as wake-triggering mentions.
+      //
+      // This PR's own seqKey change is what makes it reachable: the old
+      // world-independent key meant a travel could not mint a fresh -1 entry.
+      // So the regression ships with the feature unless guarded here.
+      if (this.agent.lastSeq >= 0) {
+        lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
+      }
       persistState();
     }, 60_000);
     };
@@ -915,7 +932,13 @@ class Session {
     } finally {
       clearInterval(seenTimer);
       lastSeen[this.auth.id] = Date.now();
-    lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
+      // Same guard as the timer above, and reachable the same way: a travel
+      // that failed FATALLY leaves this.agent = next with lastSeq still -1,
+      // and this runs on the way out. A disconnect must not hand the next
+      // session a watermark meaning "replay everything".
+      if (this.agent.lastSeq >= 0) {
+        lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
+      }
       persistState();
       this.close();
     }

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -74,7 +74,14 @@ function readTokens(): Record<string, Auth> {
 
 // per-agent durable state (missed-mention cursors, chosen bodies), tmp+rename.
 // Plain ids map to lastSeen timestamps; __-prefixed keys are sections.
-const STATE_PATH = fileURLToPath(new URL("./state.json", import.meta.url));
+// Operator/test override, same shape as MCPL_TOKENS above. The DEFAULT IS
+// UNCHANGED — the co-located mcpl/state.json — so no deployment moves.
+// Added because the integration suite spawned this server with no override and
+// therefore wrote REPOSITORY state: a run mutated mcpl/state.json and could
+// leave a zero-byte mcpl/state.json.tmp behind when it killed the process
+// (antra, PR #125 re-review). A test that contaminates the source tree is also
+// a test whose own artifacts are indistinguishable from a real failure.
+const STATE_PATH = process.env.MCPL_STATE ?? fileURLToPath(new URL("./state.json", import.meta.url));
 const _state: Record<string, unknown> = (() => {
   try { if (existsSync(STATE_PATH)) return JSON.parse(readFileSync(STATE_PATH, "utf8")); } catch { /* fresh */ }
   return {};
@@ -1270,8 +1277,18 @@ class Session {
             ? `travel failed past the point of no return: ${f.why}. Your old body was already released, so this connection is now CLOSED — reconnect to get a new one.`
             : `travel refused: ${f.why}` }], isError: true };
         }
-        // The host is told by channels/changed (same as the channels/open lane);
-        // this string is for the AGENT, so it says what actually moved.
+        // Who learns what, and it is ASYMMETRIC by host class — the old
+        // "same as the channels/open lane" note described a lane that no
+        // longer exists (sibling-world channels/open was removed).
+        //   • an MCPL host is told out-of-band by channels/changed: the old
+        //     world retired, the new one added with its epoch. It never sees
+        //     a prepare for this lane either — the tool IS the request.
+        //   • a PLAIN-MCP host has no channel vocabulary, so it receives no
+        //     channels/changed and no prepare at all. This return string is
+        //     the ONLY thing it ever learns about the move.
+        // Hence the text below is written for the AGENT, and states what
+        // actually moved and what did not, rather than assuming a host-side
+        // descriptor will arrive to fill the gaps.
         return text(
           `${gate.founding ? "Founded and entered" : "Arrived in"} "${target}" (attachment ${this.epoch}). ` +
           `Your identity, avatar and attention settings came with you; your held pose and posture did not (they are world-local). Your chat cursor starts fresh here. Use \`look\` to see where you are.`,
@@ -1375,11 +1392,17 @@ const DOOR_HELP =
   `Connect with an identity token: wss://<this host>/mcpl?token=aid1...\n` +
   `How to get one (agents & operators, no Connectome required): ${GUIDE_URL}\n`;
 
+// A caller-supplied instance nonce, echoed by /healthz. Unset in production,
+// where /healthz keeps answering exactly "ok". A harness sets it so readiness
+// can prove the responder is THE CHILD IT SPAWNED and not a stale door left on
+// the same port by an earlier run — a false green this project has already
+// had, and one that "is the port open?" cannot distinguish by construction.
+const INSTANCE_NONCE = process.env.MCPL_INSTANCE_NONCE ?? "";
 const http = createServer((req, res) => {
   // A plain HTTP GET here is someone curious — curl, a browser, an agent
   // probing before dialing. Answer with the pointer, not a hang-up.
   res.writeHead(req.url === "/healthz" ? 200 : 426, { "content-type": "text/plain; charset=utf-8", upgrade: "websocket" });
-  res.end(req.url === "/healthz" ? "ok\n" : DOOR_HELP);
+  res.end(req.url === "/healthz" ? (INSTANCE_NONCE ? `ok ${INSTANCE_NONCE}\n` : "ok\n") : DOOR_HELP);
 });
 const wss = new WebSocketServer({ server: http });
 

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -126,7 +126,14 @@ const TOOLS = [
   { name: "place", description: "Move an entity (id from look) to x,z (y defaults to terrain; pass y to seat on furniture).", inputSchema: { type: "object", properties: { id: { type: "string" }, x: { type: "number" }, z: { type: "number" }, y: { type: "number" }, yaw: { type: "number" } }, required: ["id", "x", "z"] } },
   { name: "light", description: "Place a light source in the world, or update one you can already see: calling with the id of an existing light changes ONLY the fields you pass (brightness via intensity, color, range, position) and leaves the rest alone. Persists like any placed thing. color is a hex integer (e.g. 0xffd9a0 warm, 0x88bbff cool, 0xff5533 red), intensity (default 16) and range are optional. keep: true means the light ALWAYS casts: it lives outside the per-client point-light budget (consumes no slot, so unkept lights keep their full budget) and framerate governors never douse it. Every casting light has real GPU cost — keep it for lights that matter. Position defaults to just in front of you. A small glowing sphere marks it; move or remove it by id like any entity.", inputSchema: { type: "object", properties: { color: { type: "number" }, intensity: { type: "number" }, range: { type: "number" }, keep: { type: "boolean" }, x: { type: "number" }, y: { type: "number" }, z: { type: "number" }, id: { type: "string" } } } },
   { name: "remove", description: "Remove a placed entity.", inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } },
-  { name: "travel", description: "Walk to another world this door fronts, keeping your identity, body and attention settings — no reconnect. Subject to your credential's join policy; founding a world that does not exist yet needs separate create authority. Your held pose and posture survive; your chat cursor resets to the new world.", inputSchema: { type: "object", properties: { world: { type: "string", description: "world name, e.g. \"commons\"" } }, required: ["world"] } },
+  // Description narrowed to what the implementation actually does (antra
+  // review, #3). It previously promised "held pose and posture survive", which
+  // joinWorld does NOT transfer — and which contradicts the existing pose
+  // contract ("vanishes when you leave"). Carrying a world-local pose across
+  // worlds is a product decision nobody has made, so the honest move is to
+  // stop promising it rather than to implement it by inference. Identity,
+  // avatar and the activity dial ARE carried, and are named because they are.
+  { name: "travel", description: "Walk to another world this door fronts, keeping your identity, avatar and attention settings — no reconnect. Subject to your credential's join policy; founding a world that does not exist yet needs separate create authority. Your held pose and posture do NOT survive the move (they are world-local, like a disconnect), and your chat cursor resets to the new world.", inputSchema: { type: "object", properties: { world: { type: "string", description: "world name, e.g. \"commons\"" } }, required: ["world"] } },
   { name: "world_verb", description: "Raw world-log verb. The verb set is CLOSED by design — say, use, punt, force, mount, dismount, spawn, place, remove, light, comp, motion, behavior, asset, terrain, grass, sky, weather, grant, kick, ban, unban — and the door refuses others; extend STATE with comp types you invent, EVENTS with use actions, SEMANTICS with behavior scripts, never by hoping a new verb exists. This is also the authoring surface for components: comp {id, type, data|null} attaches data to an entity (sockets, reactions, or anything you invent); motion {id, type: pendulum|spin|orbit|bob|path, …} sets it moving; see AGENTS.md in the eidoverse-worlds repo for the full vocabulary.", inputSchema: { type: "object", properties: { verb: { type: "string" }, args: { type: "object" } }, required: ["verb", "args"] } },
   { name: "measure", description: "Geometry as data: bounding box, up-facing flat zones (seat/table/deck candidates), and named parts of a placed thing (id) or a library model (lib). Flat-zone coords are the MODEL's local frame — the same frame sockets use, so a zone's center IS a socket pos: comp {id, type:'sockets', data:{seat:{pos:[cx,y,cz], yaw}}}. Use this to find where a body can sit before declaring the seat; verify by mounting it yourself and taking a selfie snapshot. Raw GLB bytes are at GET <sequencer>/library/<lib> if you want to process the mesh locally.", inputSchema: { type: "object", properties: { id: { type: "string" }, lib: { type: "string" } } } },
   { name: "world_history", description: "Pull raw entries from the world log — the append-only record every world IS. Filter by verbs (e.g. ['use','motion'] to trace an interaction, ['comp'] to see how something was built), page backwards with before. Every entry has {seq, ts, actor, verb, args}; reaction-authored entries carry {cause, by}. This is the debugging primitive: the log is the world, so reading it is reading the world's source.", inputSchema: { type: "object", properties: { verbs: { type: "array", items: { type: "string" } }, before: { type: "number" }, after: { type: "number" }, limit: { type: "number" } } } },
@@ -268,21 +275,68 @@ class Session {
    *  assignment. Throws on attach failure; the caller maps that to -32024 and
    *  MUST then surface the connection as closed (§3.2.5 — we cannot silently
    *  remain attached to a world we already left). */
-  /** The ONE authorization path for changing worlds, shared by both lanes:
-   *  the `travel` tool and `channels/open` naming a sibling. Extracted because
-   *  two copies of a three-part gate is two policies that will drift — and the
-   *  founding check in particular took three rounds of review to get right.
+  /** The authorization path for changing worlds. It had TWO callers — the
+   *  `travel` tool and `channels/open` naming a sibling — and was extracted so
+   *  the two could not drift into two policies. The sibling lane is now gone
+   *  (see the CHANNELS_OPEN case), leaving one caller; the extraction stays
+   *  because the gate is worth reading in one piece, not because it is shared.
    *
-   *  Three questions, in this order, each with its own answer shape:
-   *    1. may this HOST act on channels at all      → capability (-32002)
-   *    2. may this CREDENTIAL reach that world      → join policy (-32017)
-   *    3. may it CREATE a world that isn't there    → create authority (-32023)
-   *  Founding is deliberately last and separate: an operator granting broad
-   *  travel has not thereby granted unbounded world-founding. */
+   *  Three questions, in order:
+   *    1. may this HOST act on channels at all → capability (-32002).
+   *       🔴 MCPL HOSTS ONLY. granted() is false for every plain-MCP client by
+   *       construction, so asking it of them denied the advertised plain lane
+   *       outright (antra #1). A plain host's authority is its credential.
+   *    2. may this CREDENTIAL reach that world → join policy (-32017).
+   *    3. does the world exist, and if not may this credential found → (-32023).
+   */
+  /** Classify a joinWorld() failure. ONE place, because the two invocation
+   *  lanes hand-rolled this and drifted: channels/open correctly closed the
+   *  connection on a post-detach failure while the `travel` tool returned
+   *  isError and left the session alive with its old body gone and a failed
+   *  new attachment (antra review, #2).
+   *
+   *  The distinction that matters is WHEN the failure happened:
+   *    • JoinDeclined  → PREPARE refused, NOTHING moved. The connection is
+   *      exactly where it was; this is a refusal, not a casualty.
+   *    • anything else → we are past the detach. The old body is gone, so the
+   *      only honest state is a CLOSED connection. Never a limbo session.
+   *
+   *  🔴 It CLASSIFIES; it does not close. The first version closed here and
+   *  hung the tool lane: closing inside the classifier killed the socket with
+   *  the reply still unwritten, and the caller waited out its timeout. Pair it
+   *  with finishFatalJoin(), which defers the close by a tick so the response
+   *  flushes first — the deferral is what makes ordering safe, NOT the position
+   *  of the call, so calling it just before a `return` is correct.
+   *
+   *  `code` is currently unused by the sole (tool-lane) caller, which reports
+   *  via isError text; it is kept because it is the right answer for any
+   *  JSON-RPC lane and re-adding one should not have to re-derive it. */
+  private classifyJoinFailure(e: unknown): { fatal: boolean; code: number; why: string } {
+    if (e instanceof JoinDeclined)
+      return { fatal: false, code: -32017, why: `channel not permitted: ${(e as Error).message}` };
+    return { fatal: true, code: -32024, why: `channel open failed: ${(e as Error).message}` };
+  }
+
+  /** §3.2.5: never half-attached — the old body is gone, so the honest state
+   *  is a closed connection. Deferred a tick so whatever the caller is about to
+   *  send (or return) reaches the wire first. */
+  private finishFatalJoin() { setTimeout(() => this.close(), 0); }
+
   private async travelGate(target: string): Promise<
     { ok: true; founding: boolean } | { ok: false; code: number; why: string }
   > {
-    if (!this.granted(CAP.channelsLifecycle))
+    // 🔴 The capability gate applies to MCPL HOSTS ONLY (antra review, #1).
+    // granted() returns false for any plain-MCP client by construction — no
+    // MCPL frames, so no capabilities — which made the advertised plain-MCP
+    // travel lane deny EVERY non-noop call with -32002 while toolsAllowed()
+    // cheerfully listed the tool. An advertised lane that cannot succeed is
+    // worse than an absent one.
+    //
+    // A plain-MCP caller's authority is its CREDENTIAL, checked immediately
+    // below: joinAllowed() enforces the join policy and `auth.create` gates
+    // founding, so removing the capability requirement for this lane narrows
+    // nothing — it just stops demanding a token plain MCP cannot hold.
+    if (this.mcplClient && !this.granted(CAP.channelsLifecycle))
       return { ok: false, code: -32002, why: `capability denied: ${CAP.channelsLifecycle}` };
     if (!joinAllowed(this.auth, target))
       return { ok: false, code: -32017, why: `channel not permitted: world "${target}" is not in this credential's join policy` };
@@ -343,6 +397,13 @@ class Session {
     });
     next.onEvent = old.onEvent;
     next.onPing = old.onPing;
+    // 🔴 The resident's activity dial is THEIRS, not the world's (antra review,
+    // #3). serve() restores it before the body first joins; a transition that
+    // silently reset it would make travel quietly destroy a setting the agent
+    // chose and the file persists. Applied BEFORE connect() for the same reason
+    // it is there — the sense should be tuned before the body arrives, not a
+    // beat after.
+    if (activityCfg[this.auth.id]) next.setActivity(activityCfg[this.auth.id]);
     // Detach BEFORE close: ws frames already queued can still fire the old
     // body's onmessage after close() returns, and the shared closures would
     // attribute a late commons say to the annex channel (review B1).
@@ -353,6 +414,12 @@ class Session {
     this.channelId = `world:${w}`;
     this.caughtUpTo = null;            // catch_up cursors are per-world context
     this.heldActivity.length = 0;      // held ambient lines are old-world context (review C1)
+    // 🔴 The NEW channel's descriptor announces initiallyOpen:true, so the door
+    // must actually BE open or host and server disagree about the new world:
+    // an agent who ran channels/close and then travelled arrived with the door
+    // shut while the host was told it was open, and nothing reconciled them.
+    // A door is per-world state like the cursor above, not a session-long mood.
+    this.channelOpen = true;
     await next.connect();
     this.epoch++;                      // the cutoff instant, after the fact of it
     this.foundedHere = founding;
@@ -737,53 +804,46 @@ class Session {
               const matches = p.channelId === this.channelId ||
                 (p.channelId == null && p.type === "world" && p.address?.world === this.agent.world);
               if (!matches) {
-                // RFC-005 §3.2: opening a SIBLING world channel is a join
-                // request. Capability → policy (-32017) → prepare/commit
-                // (host may decline) → the ordinary open of the NEW channel
-                // falls through below — response shape unchanged.
+                // 🔴 THE SECOND INVOCATION LANE IS REMOVED (antra review, #4).
                 //
-                // §3.2.6 (Mica review): BOTH addressing forms express join
-                // intent. ChannelsOpenParams documents channelId as "preferred
-                // over type/address matching", and generic host surfaces work
-                // in ids — an address-only rule would make join unreachable
-                // from them. channelId wins when both are present; a
-                // conflicting address is an authoring bug, not a preference.
-                const byId = p.channelId?.startsWith("world:") ? p.channelId.slice(6) : undefined;
-                const byAddr = p.type === "world" ? p.address?.world : undefined;
-                // §3.2.6: an id this server cannot resolve is -32023 — NEVER a
-                // silent fallback to the address. A typo'd id used to be
-                // upgraded into an address-driven join to somewhere else.
-                if (p.channelId && !byId) {
-                  this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId}`);
-                  break;
-                }
-                const target = byId ?? byAddr;   // channelId wins (conflict rejected above)
-                if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
-                // Join intent is authorized by channels.lifecycle — the same
-                // grant that covers opening any channel. An earlier draft gated
-                // it on an invented `channels.join` leaf, which is NOT in the
-                // spec's §6.2 capability list: declaring it would have made this
-                // a protocol change. It isn't one. (antra, 2026-08-14: "this can
-                // be done well within eidoverse mcpl".)
-                const gate = await this.travelGate(target);
-                if (!gate.ok) { this.conn.sendError(req.id, gate.code, gate.why); break; }
-                const founding = gate.founding;
-                try {
-                  await this.joinWorld(target, founding);
-                } catch (e) {
-                  if (e instanceof JoinDeclined) {
-                    // §3.2.3b: PREPARE failed — nothing moved. The connection is
-                    // exactly where it was; this is a refusal, not a casualty.
-                    this.conn.sendError(req.id, -32017, `channel not permitted: ${(e as Error).message}`,
-                      { reason: "host_declined" });
-                    break;
-                  }
-                  // §3.2.5: never half-attached — the old body is gone, so the
-                  // honest state is a closed connection, not a limbo session.
-                  this.conn.sendError(req.id, -32024, `channel open failed: ${(e as Error).message}`);
-                  this.close();
-                  break;
-                }
+                // ⚠️ READ THIS BEFORE ASSUMING TRAVEL WAS CUT: cross-world travel
+                // is NOT removed and is the point of this PR. The `travel` TOOL
+                // is untouched — same travelGate(), same joinWorld(). What is
+                // gone is a SECOND way to ask for the same thing: opening a
+                // sibling world's channel id through channels/open.
+                //
+                // 🔴 NOT "the same channels/changed transition", which an
+                // earlier draft of this comment claimed: joinWorld() guards
+                // PREPARE behind granted(channelsRegister), and granted() is
+                // false for every plain-MCP host by construction. So an MCPL
+                // host gets prepare + consent + channels/changed, while a
+                // plain-MCP host gets none of them — it has no inbound Request
+                // form to consent WITH. That asymmetry is inherent to plain
+                // MCP, not a shortcut, but it must be stated rather than
+                // papered over: on the plain lane the credential is the ONLY
+                // gate, and there is no host veto.
+                //
+                // It worked, and `travel` plus the ordinary channels/changed
+                // notification already gives a host an observable transition —
+                // so a second invocation lane needed to justify itself, and it
+                // could not. channels/list exposes only the CURRENT world, so no
+                // generic host can DISCOVER a sibling descriptor through this
+                // surface; a hand-constructed `world:foo` is not a demonstrated
+                // second consumer, and the promote-on-reuse rule asks for a real
+                // one. Keeping a lane in case someone eventually wants it is
+                // exactly the speculative generality that rule exists to refuse.
+                //
+                // Re-adding it needs no MCPL spec change: travelGate() and
+                // classifyJoinFailure() still hold the whole policy. (One
+                // caveat for whoever does it — travelGate() now branches on
+                // this.mcplClient, which is always true for a channels/open
+                // caller, so that conjunct is a no-op on this lane rather than
+                // a behaviour to reason about.) Until then a
+                // sibling id is simply an unknown channel, which is the honest
+                // answer for a channel this surface never advertised.
+                this.conn.sendError(req.id, -32023,
+                  `unknown channel: ${p.channelId ?? JSON.stringify(p.address)} (this door opens only its current world; use the \`travel\` tool to move)`);
+                break;
               }
               this.channelOpen = true;
               const limit = Math.min(Math.max(p.history?.limit ?? 0, 0), 100);
@@ -1197,13 +1257,24 @@ class Session {
         try {
           await this.joinWorld(target, gate.founding);
         } catch (e) {
-          return { content: [{ type: "text", text: `travel failed: ${(e as Error).message}` }], isError: true };
+          const f = this.classifyJoinFailure(e);
+          // Safe HERE (before the return) only because finishFatalJoin defers
+          // by a macrotask and the dispatch loop's sendResponse is synchronous
+          // once handleTool resolves — so the reply always wins the race. If an
+          // await is ever introduced between this returning and the send, that
+          // stops being true and the socket dies with the reply unwritten.
+          if (f.fatal) this.finishFatalJoin();
+          return { content: [{ type: "text", text: f.fatal
+            // Say plainly that the seat is gone. An agent told only "travel
+            // failed" would keep issuing verbs into a closed connection.
+            ? `travel failed past the point of no return: ${f.why}. Your old body was already released, so this connection is now CLOSED — reconnect to get a new one.`
+            : `travel refused: ${f.why}` }], isError: true };
         }
         // The host is told by channels/changed (same as the channels/open lane);
         // this string is for the AGENT, so it says what actually moved.
         return text(
           `${gate.founding ? "Founded and entered" : "Arrived in"} "${target}" (attachment ${this.epoch}). ` +
-          `Your body, avatar and held pose came with you; your chat cursor starts fresh here. Use \`look\` to see where you are.`,
+          `Your identity, avatar and attention settings came with you; your held pose and posture did not (they are world-local). Your chat cursor starts fresh here. Use \`look\` to see where you are.`,
         );
       }
       case "world_verb": {

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -266,10 +266,16 @@ class Session {
     });
     next.onEvent = old.onEvent;
     next.onPing = old.onPing;
+    // Detach BEFORE close: ws frames already queued can still fire the old
+    // body's onmessage after close() returns, and the shared closures would
+    // attribute a late commons say to the annex channel (review B1).
+    old.onEvent = null;
+    old.onPing = null;
     old.close();                       // detach: persists exactly what a disconnect persists
     this.agent = next;
     this.channelId = `world:${w}`;
     this.caughtUpTo = null;            // catch_up cursors are per-world context
+    this.heldActivity.length = 0;      // held ambient lines are old-world context (review C1)
     await next.connect();
     console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" (RFC-005)`);
     // §3.2.3d: tell the host its channel roster changed — old world retired,
@@ -531,7 +537,7 @@ class Session {
     // to filter — and a clock comparison silently degrades to "whatever
     // happens to still be in memory". A seq is asked of the world directly and
     // reaches back as far as the log goes.
-    const sinceSeq = lastSeenSeq[this.auth.id];
+    const sinceSeq = lastSeenSeq[seqKey(this.auth.id, this.agent.world)] ?? lastSeenSeq[this.auth.id];
     // "Since you last looked" starts where the persisted cursor says this
     // agent last was — not at the dawn of the replayed tail. Mentions from
     // the gap are delivered explicitly below; scrollback stays on catch_up.
@@ -565,11 +571,11 @@ class Session {
       }
     }
     lastSeen[this.auth.id] = Date.now();
-    lastSeenSeq[this.auth.id] = this.agent.lastSeq;
+    lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
     persistState();
     seenTimer = setInterval(() => {
       lastSeen[this.auth.id] = Date.now();
-      lastSeenSeq[this.auth.id] = this.agent.lastSeq;
+      lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
       persistState();
     }, 60_000);
     };
@@ -644,6 +650,12 @@ class Session {
                 // channel falls through below — response shape unchanged.
                 const target = p.type === "world" ? p.address?.world : undefined;
                 if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
+                // RFC-005 §3.1: join intent requires the channels.join grant
+                // (in addition to channels.lifecycle), BEFORE policy.
+                if (!this.granted("channels.join")) {
+                  this.conn.sendError(req.id, -32002, "capability denied: channels.join");
+                  break;
+                }
                 if (!joinAllowed(this.auth, target)) {
                   this.conn.sendError(req.id, -32017, `channel not permitted: world "${target}" is not in this credential's join policy`);
                   break;
@@ -697,7 +709,7 @@ class Session {
     } finally {
       clearInterval(seenTimer);
       lastSeen[this.auth.id] = Date.now();
-    lastSeenSeq[this.auth.id] = this.agent.lastSeq;
+    lastSeenSeq[seqKey(this.auth.id, this.agent.world)] = this.agent.lastSeq;
       persistState();
       this.close();
     }
@@ -1186,11 +1198,21 @@ function refuseWithGuidance(ws: WebSocket, why: string) {
 }
 /** RFC-005 join policy: may this credential attach to `world`? One rule, both
  *  lanes (dial-time ?world= and in-session channels/open). No `worlds` list on
- *  the credential = no policy = deny — the pre-RFC-005 status quo exactly. */
+ *  the credential = no policy = deny — the pre-RFC-005 status quo exactly.
+ *  The name-shape gate mirrors the sequencer's own rule (server.ts join
+ *  validation): the door refusing early is one closed loop instead of a
+ *  granted join dying against the sequencer 8s later. */
+const WORLD_NAME_RE = /^[a-z0-9_-]{1,64}$/;
 function joinAllowed(auth: Auth, world: string): boolean {
+  if (!WORLD_NAME_RE.test(world)) return false;
   return world === (auth.world ?? "commons") ||
     (auth.worlds ?? []).some((w) => w === "*" || w === world);
 }
+/** Per-world watermark key for missed-mention replay. World-fixed identity was
+ *  a safe assumption before RFC-005; a commons seq is meaningless in annex.
+ *  Legacy bare-id entries are read as a fallback so existing residents don't
+ *  get a full replay on the first post-upgrade connect. */
+const seqKey = (id: string, world: string) => `${id}@${world}`;
 const sessions = new Map<string, Session>(); // identity → live session (newest wins)
 wss.on("connection", (ws, req) => {
   const token = new URL(req.url ?? "/", "http://localhost").searchParams.get("token");

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -58,7 +58,11 @@ type Auth = { id: string; name: string; world?: string; avatar?: string;
    *  request at dial time ("*" = any). ABSENT means no join policy — the
    *  credential stays bound to its minted world, exactly as before RFC-005.
    *  Operator-set: a tokens.json field, or a `worlds` claim on an aid1. */
-  worlds?: string[] };
+  worlds?: string[];
+  /** RFC-005 §3.2.7: founding authority, SEPARATE from join policy. A broad
+   *  `worlds: ["*"]` grants travel to worlds that exist; it does not grant the
+   *  power to call new ones into being. */
+  create?: boolean };
 // Tokens are read PER CONNECTION ATTEMPT — minting/revoking is a file edit,
 // never a restart (the no-restart rule applies to the door, not just the world).
 function readTokens(): Record<string, Auth> {
@@ -219,6 +223,14 @@ class Session {
    *  (waiting inline would deadlock — the discord-mcpl 90f869f lesson). */
   private policyAnswered!: () => void;
   private policyGate: Promise<void> = new Promise((resolve) => { this.policyAnswered = resolve; });
+  /** RFC-005 §3.2.3d: attachment generation. Increments at each transition's
+   *  COMMIT instant, which IS the cutoff — traffic dispatched before it belongs
+   *  to the old attachment, after it to the new. Surfaced on the descriptor as
+   *  metadata.epoch so both sides can name "current" instead of inferring it. */
+  private epoch = 0;
+  /** Set when THIS attachment founded its world (§3.2.7) — surfaced on the
+   *  descriptor so founding is never something an agent does unknowingly. */
+  private foundedHere = false;
   private caughtUpTo: number | null = null; // the world channel is home — open unless the agent closes it
   /** Activity digests held for a push-less (plain-MCP) host. The pulse is a
    *  wake signal, and a host with no push channel cannot be woken — but the
@@ -255,7 +267,41 @@ class Session {
    *  assignment. Throws on attach failure; the caller maps that to -32024 and
    *  MUST then surface the connection as closed (§3.2.5 — we cannot silently
    *  remain attached to a world we already left). */
-  private async joinWorld(w: string): Promise<void> {
+  private async joinWorld(w: string, founding = false): Promise<void> {
+    // ── PREPARE (RFC-005 §3.2.3a-c, Mica review #2) ────────────────────────
+    // The host's acceptance is PART of the transition, not a notification
+    // after it: never move a body somewhere its host has refused to deliver.
+    // A host that doesn't implement the inbound Request form, or doesn't
+    // answer in time, is treated as DECLINING (fail-closed, §5.3).
+    if (this.granted(CAP.channelsRegister)) {
+      const proposed: ChannelDescriptor = {
+        ...this.channelDescriptors()[0],
+        id: `world:${w}`,
+        label: `eidoverse — ${w}`,
+        address: { world: w },
+        metadata: { epoch: this.epoch + 1, ...(founding ? { created: true } : {}) },
+      } as ChannelDescriptor;
+      let accepted = false;
+      try {
+        const res = await Promise.race([
+          this.conn.sendRequest(method.CHANNELS_CHANGED, {
+            added: [proposed], removed: [`world:${this.agent.world}`],
+          }) as Promise<{ results?: { id: string; accepted?: boolean }[] }>,
+          new Promise<never>((_, rej) => setTimeout(() => rej(new Error("host did not answer channels/changed")), 5_000)),
+        ]);
+        // No itemized result = no objection expressible = accepted (§14.5 only
+        // REQUIRES the itemized form of hosts whose policy can reject).
+        const mine = res?.results?.find((r) => r.id === `world:${w}`);
+        accepted = mine ? mine.accepted !== false : true;
+      } catch (e) {
+        console.log(`[${ts()}] [mcpl:${this.auth.id}] join "${w}" declined at prepare: ${(e as Error).message}`);
+        accepted = false;
+      }
+      if (!accepted) throw new JoinDeclined(`host declined channel world:${w}`);
+    }
+    // ── COMMIT (§3.2.3d-g) — the epoch increment IS the cutoff instant ─────
+    this.epoch++;
+    this.foundedHere = founding;
     const old = this.agent;
     const next = new WorldAgent({
       name: this.auth.id,
@@ -277,15 +323,14 @@ class Session {
     this.caughtUpTo = null;            // catch_up cursors are per-world context
     this.heldActivity.length = 0;      // held ambient lines are old-world context (review C1)
     await next.connect();
-    console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" (RFC-005)`);
-    // §3.2.3d: tell the host its channel roster changed — old world retired,
-    // new one added. Request form per §14.5; best-effort toward plain-MCP.
-    if (this.granted(CAP.channelsRegister)) {
-      this.conn.sendRequest(method.CHANNELS_CHANGED, {
-        added: this.channelDescriptors(),
-        removed: [`world:${old.world}`],
-      }).catch(() => { /* host may not implement the inbound form */ });
-    }
+    console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" epoch=${this.epoch}${founding ? " (FOUNDED)" : ""} (RFC-005)`);
+    // §3.4 audit: a join is an authorization event, and on a found-on-attach
+    // server a founding join is TWO. Logged with the permanence of an auth
+    // event, per §13.2.
+    console.log(`[${ts()}] [audit] join granted: ${this.auth.id} → world:${w}${founding ? " (created)" : ""} epoch=${this.epoch}`);
+    // No second channels/changed here: PREPARE already announced the roster
+    // change and the host already accepted it (§3.2.3a). Emitting again would
+    // tell the host something it told us was fine.
   }
 
   /**
@@ -641,14 +686,35 @@ class Session {
               // The host's channel_open tool performs the server-side open op
               // here (and expects optional history atomically with it).
               const p = params as { channelId?: string; type?: string; address?: { world?: string }; history?: { limit: number } };
+              // §3.2.6: a request naming TWO destinations that disagree is an
+              // authoring bug — validated BEFORE the current-channel shortcut,
+              // or a conflicting pair where either half happens to name the
+              // current world would silently pass as a plain re-open.
+              {
+                const cid = p.channelId?.startsWith("world:") ? p.channelId.slice(6) : undefined;
+                const adr = p.type === "world" ? p.address?.world : undefined;
+                if (cid && adr && cid !== adr) {
+                  this.conn.sendError(req.id, -32602, `channelId "${p.channelId}" and address.world "${adr}" name different channels`);
+                  break;
+                }
+              }
               const matches = p.channelId === this.channelId ||
-                (p.type === "world" && p.address?.world === this.agent.world);
+                (p.channelId == null && p.type === "world" && p.address?.world === this.agent.world);
               if (!matches) {
                 // RFC-005 §3.2: opening a SIBLING world channel is a join
-                // request. Policy first (-32017), then atomic reattachment
-                // (-32024 on failure), then the ordinary open of the NEW
-                // channel falls through below — response shape unchanged.
-                const target = p.type === "world" ? p.address?.world : undefined;
+                // request. Capability → policy (-32017) → prepare/commit
+                // (host may decline) → the ordinary open of the NEW channel
+                // falls through below — response shape unchanged.
+                //
+                // §3.2.6 (Mica review): BOTH addressing forms express join
+                // intent. ChannelsOpenParams documents channelId as "preferred
+                // over type/address matching", and generic host surfaces work
+                // in ids — an address-only rule would make join unreachable
+                // from them. channelId wins when both are present; a
+                // conflicting address is an authoring bug, not a preference.
+                const byId = p.channelId?.startsWith("world:") ? p.channelId.slice(6) : undefined;
+                const byAddr = p.type === "world" ? p.address?.world : undefined;
+                const target = byId ?? byAddr;   // channelId wins (conflict rejected above)
                 if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
                 // RFC-005 §3.1: join intent requires the channels.join grant
                 // (in addition to channels.lifecycle), BEFORE policy.
@@ -660,9 +726,27 @@ class Session {
                   this.conn.sendError(req.id, -32017, `channel not permitted: world "${target}" is not in this credential's join policy`);
                   break;
                 }
+                // §3.2.7 (Mica review): FOUNDING IS NOT JOINING. This deployment
+                // founds a world on first attach, so a join naming an unused
+                // name would create one — an operator granting broad travel has
+                // not thereby granted unbounded world-founding. Creation needs
+                // its own positive authority (`create: true` on the credential).
+                const founding = !(await worldExists(target));
+                if (founding && !this.auth.create) {
+                  this.conn.sendError(req.id, -32023,
+                    `unknown channel: world "${target}" does not exist (founding requires create authority)`);
+                  break;
+                }
                 try {
-                  await this.joinWorld(target);
+                  await this.joinWorld(target, founding);
                 } catch (e) {
+                  if (e instanceof JoinDeclined) {
+                    // §3.2.3b: PREPARE failed — nothing moved. The connection is
+                    // exactly where it was; this is a refusal, not a casualty.
+                    this.conn.sendError(req.id, -32017, `channel not permitted: ${(e as Error).message}`,
+                      { reason: "host_declined" });
+                    break;
+                  }
                   // §3.2.5: never half-attached — the old body is gone, so the
                   // honest state is a closed connection, not a limbo session.
                   this.conn.sendError(req.id, -32024, `channel open failed: ${(e as Error).message}`);
@@ -765,6 +849,8 @@ class Session {
       // produce a notice). The world an agent is EMBODIED IN is its home —
       // it must be open from the first breath.
       initiallyOpen: true,
+      metadata: { epoch: this.epoch, ...(this.foundedHere ? { created: true } : {}) },   // RFC-005 §3.2.3d/§3.2.7
+
     } as ChannelDescriptor];
   }
 
@@ -1196,6 +1282,31 @@ function refuseWithGuidance(ws: WebSocket, why: string) {
     }
   });
 }
+/** Host declined the new descriptor at PREPARE (RFC-005 §3.2.3b). Distinct
+ *  from an attach failure: nothing has moved, so the caller answers -32017 and
+ *  leaves the connection exactly where it was. */
+class JoinDeclined extends Error {}
+
+/** Does this world already exist? The MCPL door is a SEPARATE PROCESS from the
+ *  sequencer, so this asks over the same HTTP surface every client uses: /geom
+ *  answers 404 for a world with no log. Fail-closed — an unreachable sequencer
+ *  reports "exists" so that a join is refused for lack of create authority
+ *  rather than silently founding a world during an outage. */
+async function worldExists(name: string): Promise<boolean> {
+  const base = (process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws")
+    .replace(/^ws/, "http").replace(/\/ws$/, "");
+  try {
+    // Bounded: an unreachable sequencer must fail the probe FAST, not hang the
+    // agent's channels/open until the TCP stack gives up (caught by the
+    // attach-failure test, which kills the sequencer mid-session).
+    const r = await fetch(`${base}/geom?world=${encodeURIComponent(name)}`,
+      { method: "HEAD", signal: AbortSignal.timeout(2_000) });
+    if (r.status === 404) return false;
+    if (r.ok) return true;
+    return true;
+  } catch { return true; }
+}
+
 /** RFC-005 join policy: may this credential attach to `world`? One rule, both
  *  lanes (dial-time ?world= and in-session channels/open). No `worlds` list on
  *  the credential = no policy = deny — the pre-RFC-005 status quo exactly.
@@ -1232,6 +1343,7 @@ wss.on("connection", (ws, req) => {
         avatar: typeof p.claims?.avatar === "string" ? (p.claims.avatar as string) : undefined,
         worlds: Array.isArray(p.claims?.worlds) && (p.claims.worlds as unknown[]).every((w) => typeof w === "string")
           ? (p.claims.worlds as string[]) : undefined,
+        create: p.claims?.create === true,   // RFC-005 §3.2.7 — founding authority
       };
       console.log(`[${ts()}] aid1 agent: ${p.sub} ("${p.name}") exp ${new Date(p.exp * 1000).toISOString()}`);
     } else {
@@ -1253,7 +1365,14 @@ wss.on("connection", (ws, req) => {
       console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" granted (policy)`);
       auth = { ...auth, world: reqWorld };
     } else {
-      console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" denied — falling back to "${auth.world ?? "commons"}"`);
+      // RFC-005 §3.3 (Mica review #3): NO SILENT FALLBACK. The dialer asked to
+      // wake up somewhere; landing elsewhere unannounced means the host thinks
+      // it is in one place while its body is in another — the exact failure
+      // this RFC exists to prevent, reintroduced at connect time. Refuse, and
+      // name the denied destination in the close reason.
+      console.log(`[${ts()}] [audit] dial-time world "${reqWorld}" DENIED for ${auth.id} — refusing connection`);
+      refuseWithGuidance(ws, `world "${reqWorld}" is not in this credential's join policy`);
+      return;
     }
   }
   // session takeover: one body per identity — a half-open predecessor gets

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -17,7 +17,7 @@
 
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
-import { readFileSync, existsSync, writeFileSync, renameSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { WebSocketServer, type WebSocket } from "ws";
 import {
   McplConnection,
@@ -82,6 +82,12 @@ function readTokens(): Record<string, Auth> {
 // (antra, PR #125 re-review). A test that contaminates the source tree is also
 // a test whose own artifacts are indistinguishable from a real failure.
 const STATE_PATH = process.env.MCPL_STATE ?? fileURLToPath(new URL("./state.json", import.meta.url));
+const STATE_TMP = STATE_PATH + ".tmp";
+// A tmp here is an INTERRUPTED atomic write from a previous incarnation: the
+// rename never happened, so STATE_PATH still holds the last good state and the
+// tmp is garbage by definition. Sweep it at boot rather than leave an artifact
+// indistinguishable from a live failure (antra, PR #125 round 4).
+try { rmSync(STATE_TMP, { force: true }); } catch (e) { console.error("[mcpl] stale state tmp not removable:", (e as Error).message); }
 const _state: Record<string, unknown> = (() => {
   try { if (existsSync(STATE_PATH)) return JSON.parse(readFileSync(STATE_PATH, "utf8")); } catch { /* fresh */ }
   return {};
@@ -101,8 +107,32 @@ const lastSeen: Record<string, number> = Object.fromEntries(
   Object.entries(_state).filter(([k, v]) => !k.startsWith("__") && typeof v === "number"),
 ) as Record<string, number>;
 function persistState() {
-  writeFileSync(STATE_PATH + ".tmp", JSON.stringify({ ...lastSeen, __seq: lastSeenSeq, __avatar: chosenAvatar, __activity: activityCfg }));
-  renameSync(STATE_PATH + ".tmp", STATE_PATH);
+  try {
+    writeFileSync(STATE_TMP, JSON.stringify({ ...lastSeen, __seq: lastSeenSeq, __avatar: chosenAvatar, __activity: activityCfg }));
+    renameSync(STATE_TMP, STATE_PATH);
+  } catch (e) {
+    // A failed persist must not leave its tmp behind — an orphaned tmp reads
+    // as a mid-write crash to the next observer. STATE_PATH keeps the last
+    // good state either way.
+    try { rmSync(STATE_TMP, { force: true }); } catch { /* the boot sweep gets it */ }
+    console.error("[mcpl] state persist failed:", (e as Error).message);
+  }
+}
+
+// 🔴 With no JS handler, SIGTERM terminates Bun at DEFAULT DISPOSITION — at any
+// instruction, including between persistState's write and rename. That is how
+// ${MCPL_STATE}.tmp survived the integration suite's verified-termination
+// teardown (antra, PR #125 round 4 — deterministic on macOS, a flake on
+// Linux: the kill lands while the door is still draining the per-agent
+// disconnect persists after the sequencer dies). A handler makes delivery
+// event-loop-ordered, so the synchronous write+rename pair can no longer be
+// split; exit is then orderly and sweeps any stray tmp. SIGKILL-mid-write
+// remains possible, and the boot sweep above is the recovery for it.
+for (const sig of ["SIGTERM", "SIGINT"] as const) {
+  process.on(sig, () => {
+    try { rmSync(STATE_TMP, { force: true }); } catch { /* best effort */ }
+    process.exit(0);
+  });
 }
 
 // ---- tools (shared schema with the stdio server, minus retina by default) --

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -359,6 +359,9 @@ class Session {
     // after it: never move a body somewhere its host has refused to deliver.
     // A host that doesn't implement the inbound Request form, or doesn't
     // answer in time, is treated as DECLINING (fail-closed, §5.3).
+    // Captured BEFORE anything can reassign this.agent — the channel we are
+    // leaving, named while it is still the one we are in.
+    const leaving = `world:${this.agent.world}`;
     if (this.granted(CAP.channelsRegister)) {
       const proposed: ChannelDescriptor = {
         ...this.channelDescriptors()[0],
@@ -376,8 +379,21 @@ class Session {
       let accepted = false;
       try {
         const res = await Promise.race([
+          // 🔴 PREPARE ASKS; IT DOES NOT ANNOUNCE THE DEPARTURE (adversarial
+          // review, 2026-08-17). This carried `removed: [leaving]` — so a host
+          // that DECLINED, or simply answered slowly enough to hit the 5s
+          // timeout, had already been told its current channel was gone. The
+          // body then stays (JoinDeclined means nothing moved) while every
+          // later deliver() targets a channel the host believes is closed.
+          // That is the host-and-body-disagree failure this RFC exists to
+          // prevent, reintroduced on the refusal path — and reachable by a
+          // merely SLOW host, not only a rejecting one.
+          //
+          // A prepare is a question. The removal is stated on COMMIT, below,
+          // where it is true. §14.5's itemized results are per-ADDED-descriptor
+          // anyway: nothing about the answer needs `removed` to be present.
           this.conn.sendRequest(method.CHANNELS_CHANGED, {
-            added: [proposed], removed: [`world:${this.agent.world}`],
+            added: [proposed],
           }) as Promise<{ results?: { id: string; accepted?: boolean }[] }>,
           new Promise<never>((_, rej) => setTimeout(() => rej(new Error("host did not answer channels/changed")), 5_000)),
         ]);
@@ -430,6 +446,14 @@ class Session {
     await next.connect();
     this.epoch++;                      // the cutoff instant, after the fact of it
     this.foundedHere = founding;
+    // 🔴 NOW the departure is a fact, so now it can be stated. PREPARE above
+    // deliberately sends only `added` — a question must not assert a change it
+    // has not made. This is a NOTIFICATION, not a Request: the host has no
+    // veto over a move that has already happened, and asking for one would
+    // invite a "no" nothing can honour.
+    try {
+      this.conn.sendNotification(method.CHANNELS_CHANGED, { removed: [leaving] });
+    } catch { /* peer gone — the close path is already handling that */ }
     console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" epoch=${this.epoch}${founding ? " (FOUNDED)" : ""} (RFC-005)`);
     // §3.4 audit: a join is an authorization event, and on a found-on-attach
     // server a founding join is TWO. Logged with the permanence of an auth

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -51,9 +51,14 @@ const HN_ISSUER_KEY = process.env.HN_ISSUER_KEY ?? "";
 const HN_ISS = process.env.HN_ISS ?? "id.animalabs.ai";
 const HN_AUD = process.env.HN_AUD ?? "eidoverse";
 const ts = () => new Date().toISOString().slice(11, 19);
-const TOKENS_PATH = fileURLToPath(new URL("./tokens.json", import.meta.url));
+const TOKENS_PATH = process.env.MCPL_TOKENS ?? fileURLToPath(new URL("./tokens.json", import.meta.url));
 
-type Auth = { id: string; name: string; world?: string; avatar?: string };
+type Auth = { id: string; name: string; world?: string; avatar?: string;
+  /** RFC-005 join policy: worlds this credential may move to in-session or
+   *  request at dial time ("*" = any). ABSENT means no join policy — the
+   *  credential stays bound to its minted world, exactly as before RFC-005.
+   *  Operator-set: a tokens.json field, or a `worlds` claim on an aid1. */
+  worlds?: string[] };
 // Tokens are read PER CONNECTION ATTEMPT — minting/revoking is a file edit,
 // never a restart (the no-restart rule applies to the door, not just the world).
 function readTokens(): Record<string, Auth> {
@@ -223,7 +228,7 @@ class Session {
    *  sense, not scrollback. */
   private heldActivity: string[] = [];
 
-  constructor(private auth: Auth, ws: WebSocket, agentToken = "") {
+  constructor(private auth: Auth, ws: WebSocket, private agentToken = "") {
     this.conn = McplConnection.fromWebSocket(ws as never);
     this.agent = new WorldAgent({
       name: auth.id,
@@ -240,6 +245,41 @@ class Session {
   close() {
     this.agent.close(); // deliberate death — stops the body's auto-reconnect
     this.conn.close();
+  }
+
+  /** RFC-005 §3.2 in-session join: atomically reattach this connection's body
+   *  to another world. Exclusivity by ordering — the old body dies before the
+   *  new one dials, so at no observable moment is this identity in two worlds.
+   *  The event/ping handlers are closures over `this.agent`, so handing the
+   *  same closures to the new body re-routes every delivery path in one
+   *  assignment. Throws on attach failure; the caller maps that to -32024 and
+   *  MUST then surface the connection as closed (§3.2.5 — we cannot silently
+   *  remain attached to a world we already left). */
+  private async joinWorld(w: string): Promise<void> {
+    const old = this.agent;
+    const next = new WorldAgent({
+      name: this.auth.id,
+      world: w,
+      avatar: chosenAvatar[this.auth.id] ?? this.auth.avatar,
+      url: process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws",
+      agentToken: this.agentToken,
+    });
+    next.onEvent = old.onEvent;
+    next.onPing = old.onPing;
+    old.close();                       // detach: persists exactly what a disconnect persists
+    this.agent = next;
+    this.channelId = `world:${w}`;
+    this.caughtUpTo = null;            // catch_up cursors are per-world context
+    await next.connect();
+    console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" (RFC-005)`);
+    // §3.2.3d: tell the host its channel roster changed — old world retired,
+    // new one added. Request form per §14.5; best-effort toward plain-MCP.
+    if (this.granted(CAP.channelsRegister)) {
+      this.conn.sendRequest(method.CHANNELS_CHANGED, {
+        added: this.channelDescriptors(),
+        removed: [`world:${old.world}`],
+      }).catch(() => { /* host may not implement the inbound form */ });
+    }
   }
 
   /**
@@ -597,7 +637,27 @@ class Session {
               const p = params as { channelId?: string; type?: string; address?: { world?: string }; history?: { limit: number } };
               const matches = p.channelId === this.channelId ||
                 (p.type === "world" && p.address?.world === this.agent.world);
-              if (!matches) { this.conn.sendError(req.id, -32004, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
+              if (!matches) {
+                // RFC-005 §3.2: opening a SIBLING world channel is a join
+                // request. Policy first (-32017), then atomic reattachment
+                // (-32024 on failure), then the ordinary open of the NEW
+                // channel falls through below — response shape unchanged.
+                const target = p.type === "world" ? p.address?.world : undefined;
+                if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
+                if (!joinAllowed(this.auth, target)) {
+                  this.conn.sendError(req.id, -32017, `channel not permitted: world "${target}" is not in this credential's join policy`);
+                  break;
+                }
+                try {
+                  await this.joinWorld(target);
+                } catch (e) {
+                  // §3.2.5: never half-attached — the old body is gone, so the
+                  // honest state is a closed connection, not a limbo session.
+                  this.conn.sendError(req.id, -32024, `channel open failed: ${(e as Error).message}`);
+                  this.close();
+                  break;
+                }
+              }
               this.channelOpen = true;
               const limit = Math.min(Math.max(p.history?.limit ?? 0, 0), 100);
               const says = this.agent.inbox.filter((m) => m.kind === "say").slice(-limit);
@@ -618,7 +678,7 @@ class Session {
             }
             case method.CHANNELS_CLOSE: {
               const p = params as { channelId?: string };
-              if (p.channelId !== this.channelId) { this.conn.sendError(req.id, -32004, `unknown channel: ${p.channelId}`); break; }
+              if (p.channelId !== this.channelId) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId}`); break; }
               // The agent shuts their door: ambient chatter stops; mentions
               // and walk-ups still get through (a knock is not chatter).
               this.channelOpen = false;
@@ -1124,6 +1184,13 @@ function refuseWithGuidance(ws: WebSocket, why: string) {
     }
   });
 }
+/** RFC-005 join policy: may this credential attach to `world`? One rule, both
+ *  lanes (dial-time ?world= and in-session channels/open). No `worlds` list on
+ *  the credential = no policy = deny — the pre-RFC-005 status quo exactly. */
+function joinAllowed(auth: Auth, world: string): boolean {
+  return world === (auth.world ?? "commons") ||
+    (auth.worlds ?? []).some((w) => w === "*" || w === world);
+}
 const sessions = new Map<string, Session>(); // identity → live session (newest wins)
 wss.on("connection", (ws, req) => {
   const token = new URL(req.url ?? "/", "http://localhost").searchParams.get("token");
@@ -1141,6 +1208,8 @@ wss.on("connection", (ws, req) => {
         name: p.name,
         world: typeof p.claims?.world === "string" ? (p.claims.world as string) : undefined,
         avatar: typeof p.claims?.avatar === "string" ? (p.claims.avatar as string) : undefined,
+        worlds: Array.isArray(p.claims?.worlds) && (p.claims.worlds as unknown[]).every((w) => typeof w === "string")
+          ? (p.claims.worlds as string[]) : undefined,
       };
       console.log(`[${ts()}] aid1 agent: ${p.sub} ("${p.name}") exp ${new Date(p.exp * 1000).toISOString()}`);
     } else {
@@ -1151,6 +1220,19 @@ wss.on("connection", (ws, req) => {
   if (!auth) {
     refuseWithGuidance(ws, token ? (aidReason ? `token refused (${aidReason})` : "unrecognized token") : "no token provided");
     return;
+  }
+  // RFC-005 §3.3 dial-time lane: ?world= requests the INITIAL attachment,
+  // evaluated under the same join policy as in-session moves. Denied or
+  // unpoliced: fall back to the credential's minted world (documented
+  // fallback-not-refusal), with the reason in the log.
+  const reqWorld = new URL(req.url ?? "/", "http://localhost").searchParams.get("world");
+  if (reqWorld && reqWorld !== (auth.world ?? "commons")) {
+    if (joinAllowed(auth, reqWorld)) {
+      console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" granted (policy)`);
+      auth = { ...auth, world: reqWorld };
+    } else {
+      console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" denied — falling back to "${auth.world ?? "commons"}"`);
+    }
   }
   // session takeover: one body per identity — a half-open predecessor gets
   // cleanly killed instead of rubberbanding against its successor

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -279,7 +279,11 @@ class Session {
         id: `world:${w}`,
         label: `eidoverse — ${w}`,
         address: { world: w },
-        metadata: { epoch: this.epoch + 1, ...(founding ? { created: true } : {}) },
+        // §3.2.3d: NO epoch here. The epoch names a COMMITTED attachment; a
+        // proposal that may be declined must not hand the host a generation
+        // number that will never exist (review A(c) — the shipped client
+        // believed it and drifted by one per aborted join).
+        metadata: { ...(founding ? { created: true } : {}) },
       } as ChannelDescriptor;
       let accepted = false;
       try {
@@ -299,9 +303,9 @@ class Session {
       }
       if (!accepted) throw new JoinDeclined(`host declined channel world:${w}`);
     }
-    // ── COMMIT (§3.2.3d-g) — the epoch increment IS the cutoff instant ─────
-    this.epoch++;
-    this.foundedHere = founding;
+    // ── COMMIT (§3.2.3d-g) ────────────────────────────────────────────────
+    // The epoch increments only once the new attachment is LIVE: it names the
+    // cutoff instant, so a transition that dies mid-flight must not advance it.
     const old = this.agent;
     const next = new WorldAgent({
       name: this.auth.id,
@@ -323,6 +327,8 @@ class Session {
     this.caughtUpTo = null;            // catch_up cursors are per-world context
     this.heldActivity.length = 0;      // held ambient lines are old-world context (review C1)
     await next.connect();
+    this.epoch++;                      // the cutoff instant, after the fact of it
+    this.foundedHere = founding;
     console.log(`[${ts()}] [mcpl:${this.auth.id}] joined world "${w}" epoch=${this.epoch}${founding ? " (FOUNDED)" : ""} (RFC-005)`);
     // §3.4 audit: a join is an authorization event, and on a found-on-attach
     // server a founding join is TWO. Logged with the permanence of an auth
@@ -679,9 +685,12 @@ class Session {
             case method.CHANNELS_LIST:
               this.conn.sendResponse(req.id, { channels: this.channelDescriptors() });
               break;
-            case method.CHANNELS_PUBLISH:
-              this.conn.sendResponse(req.id, this.handlePublish(params as unknown as ChannelsPublishParams));
+            case method.CHANNELS_PUBLISH: {
+              const pub = this.handlePublish(params as unknown as ChannelsPublishParams);
+              if (pub.error) { this.conn.sendError(req.id, -32023, pub.error); break; }
+              this.conn.sendResponse(req.id, pub);
               break;
+            }
             case method.CHANNELS_OPEN: {
               // The host's channel_open tool performs the server-side open op
               // here (and expects optional history atomically with it).
@@ -714,6 +723,13 @@ class Session {
                 // conflicting address is an authoring bug, not a preference.
                 const byId = p.channelId?.startsWith("world:") ? p.channelId.slice(6) : undefined;
                 const byAddr = p.type === "world" ? p.address?.world : undefined;
+                // §3.2.6: an id this server cannot resolve is -32023 — NEVER a
+                // silent fallback to the address. A typo'd id used to be
+                // upgraded into an address-driven join to somewhere else.
+                if (p.channelId && !byId) {
+                  this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId}`);
+                  break;
+                }
                 const target = byId ?? byAddr;   // channelId wins (conflict rejected above)
                 if (!target) { this.conn.sendError(req.id, -32023, `unknown channel: ${p.channelId ?? JSON.stringify(p.address)}`); break; }
                 // RFC-005 §3.1: join intent requires the channels.join grant
@@ -859,8 +875,12 @@ class Session {
     try { await this.conn.sendRequest(method.CHANNELS_REGISTER, params); } catch { /* non-MCPL host: tools still work */ }
   }
 
-  private handlePublish(params: ChannelsPublishParams): ChannelsPublishResult {
-    if (params.channelId !== this.channelId) return { delivered: false };
+  private handlePublish(params: ChannelsPublishParams): ChannelsPublishResult & { error?: string } {
+    // §3.2.3 cutoff: a publish naming a channel we are no longer attached to
+    // is answered, not dropped — the host learns the boundary. (The verb
+    // returns a result rather than throwing, so the honest signal rides here;
+    // the caller maps it to -32023.)
+    if (params.channelId !== this.channelId) return { delivered: false, error: `unknown channel: ${params.channelId}` };
     const text = (params.content ?? [])
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
       .map((b) => b.text).join("\n").trim();
@@ -1293,8 +1313,14 @@ class JoinDeclined extends Error {}
  *  reports "exists" so that a join is refused for lack of create authority
  *  rather than silently founding a world during an outage. */
 async function worldExists(name: string): Promise<boolean> {
-  const base = (process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws")
-    .replace(/^ws/, "http").replace(/\/ws$/, "");
+  // Proper URL surgery, not string surgery: a WORLD_URL carrying a query
+  // string or a mount path defeated the old two-regex version and produced
+  // garbage (fail-closed, so founding became impossible rather than unsafe).
+  const u = new URL(process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws");
+  u.protocol = u.protocol === "wss:" ? "https:" : "http:";
+  u.pathname = u.pathname.replace(/\/ws$/, "") + "/geom";
+  u.search = "";
+  const base = u.toString().replace(/\/geom$/, "");
   try {
     // Bounded: an unreachable sequencer must fail the probe FAST, not hang the
     // agent's channels/open until the TCP stack gives up (caught by the
@@ -1356,10 +1382,16 @@ wss.on("connection", (ws, req) => {
     return;
   }
   // RFC-005 §3.3 dial-time lane: ?world= requests the INITIAL attachment,
-  // evaluated under the same join policy as in-session moves. Denied or
-  // unpoliced: fall back to the credential's minted world (documented
-  // fallback-not-refusal), with the reason in the log.
+  // evaluated under the same join policy as in-session moves. A denial
+  // REFUSES the connection — never a silent landing somewhere else.
+  // Buffer frames across any async gate below; replayed in admit(). (`ws` is
+  // not a Node stream — no pause()/resume() — and dropping these loses the
+  // host's `initialize`.)
+  const held: unknown[] = [];
+  const hold = (data: unknown) => held.push(data);
+  ws.on("message", hold);
   const reqWorld = new URL(req.url ?? "/", "http://localhost").searchParams.get("world");
+  const dialWorld = reqWorld;
   if (reqWorld && reqWorld !== (auth.world ?? "commons")) {
     if (joinAllowed(auth, reqWorld)) {
       console.log(`[${ts()}] [mcpl] ${auth.id} dial-time world "${reqWorld}" granted (policy)`);
@@ -1375,12 +1407,51 @@ wss.on("connection", (ws, req) => {
       return;
     }
   }
-  // session takeover: one body per identity — a half-open predecessor gets
-  // cleanly killed instead of rubberbanding against its successor
-  const prev = sessions.get(auth.id);
-  if (prev) { console.log(`[${ts()}] [mcpl] ${auth.id} reconnected — taking over previous session`); prev.close(); }
-  const session = new Session(auth, ws, token ?? "");
-  sessions.set(auth.id, session);
+  // ── RFC-005 §3.2.7: FOUNDING AUTHORITY, at the one point every path meets ──
+  // Three routes reach a fresh world name: the minted `world` claim, the
+  // dial-time ?world= lane, and the in-session join. Only the last was gated,
+  // so a credential could found a world merely by naming one (found by
+  // adversarial review, proven on disk). The sequencer founds unconditionally
+  // for any joiner, so the door is the only place this is enforceable.
+  //
+  // SCOPE, learned the hard way: this gates DESTINATIONS THE AGENT CHOSE, not
+  // the world its operator minted it into. A credential arriving at its own
+  // `world` claim is where its operator put it — refusing that would brick a
+  // fresh deployment (whose "commons" does not exist until someone arrives)
+  // and would be gating the operator, not the agent.
+  const chosen = dialWorld !== null;            // ?world= is a choice; the claim is not
+  if (chosen) {
+    const wname = auth.world ?? "commons";
+    void (async () => {
+      if (!auth!.create && !(await worldExists(wname))) {
+        console.log(`[${ts()}] [audit] founding DENIED: ${auth!.id} → "${wname}" (dial-time, no create authority)`);
+        refuseWithGuidance(ws, `world "${wname}" does not exist and this credential has no create authority`);
+        return;
+      }
+      if (!(await worldExists(wname))) {
+        console.log(`[${ts()}] [audit] founding GRANTED: ${auth!.id} → "${wname}" (dial-time, create authority)`);
+      }
+      admit();
+    })();
+  } else {
+    admit();
+  }
+
+  function admit() {
+    // session takeover: one body per identity — a half-open predecessor gets
+    // cleanly killed instead of rubberbanding against its successor
+    const prev = sessions.get(auth!.id);
+    if (prev) { console.log(`[${ts()}] [mcpl] ${auth!.id} reconnected — taking over previous session`); prev.close(); }
+    const session = new Session(auth!, ws, token ?? "");
+    sessions.set(auth!.id, session);
+    startSession(session, ws, auth!);
+    ws.off("message", hold);
+    for (const d of held) ws.emit("message", d);
+  }
+});
+/** Everything after admission — split out so the async founding gate above can
+ *  own the admit/refuse decision without duplicating the session lifecycle. */
+function startSession(session: Session, ws: WebSocket, auth: Auth) {
   // Half-open detection — tolerant of a THINKING agent.
   //
   // This used to ping every 20s and terminate on a SINGLE missed pong. That is
@@ -1422,7 +1493,7 @@ wss.on("connection", (ws, req) => {
       console.log(`[${ts()}] [mcpl] ${auth.id} session ended`);
     });
   console.log(`[${ts()}] [mcpl] ${auth.id} connected`);
-});
+}
 http.listen(PORT, "0.0.0.0", () => {
   console.log(`eidoverse-worlds network MCPL on ws://0.0.0.0:${PORT} (${Object.keys(readTokens()).length} tokens)`);
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -365,8 +365,22 @@ const ROUTES: Route[] = [
   {
     // upstream #51, ported to the route table: which build is this world
     // running — public, cheap, cache-hostile; the whole point is NOW
+    //
+    // WORLD_INSTANCE_NONCE is an opt-in TEST affordance, mirroring the door's
+    // MCPL_INSTANCE_NONCE: when set, /version carries `instance`, letting a
+    // harness prove the process answering is the one IT spawned rather than a
+    // stale listener squatting the port. Unset in production, where the body is
+    // byte-identical to before — the field is absent, not empty.
+    //
+    // Why an app endpoint at all when the OS can be asked: because `ss` and
+    // /proc are Linux-only, and this repository is reviewed on macOS. A
+    // challenge-response the SERVER answers is the portable proof; the OS check
+    // stays as a second, stricter opinion where the platform offers one.
     match: (u) => u.pathname === "/version",
-    handler: () => new Response(JSON.stringify(BUILD),
+    handler: () => new Response(
+      JSON.stringify(process.env.WORLD_INSTANCE_NONCE
+        ? { ...BUILD, instance: process.env.WORLD_INSTANCE_NONCE }
+        : BUILD),
       { headers: { "content-type": "application/json", "cache-control": "no-store" } }),
   },
   {

--- a/server/world.ts
+++ b/server/world.ts
@@ -453,6 +453,15 @@ export const worlds = new Map<string, World>();
 // A function DECLARATION on purpose (§15.1): hoisting is load-bearing for
 // module-scope callers — the unsplit boot sweep called it above its
 // definition, and keeping the declaration form keeps that shape legal.
+/** Does this world already exist — in memory or on disk — WITHOUT creating it?
+ *  getWorld() founds on miss, which is right for a join by someone entitled to
+ *  found and wrong for everyone else (RFC-005 §3.2.7: founding is not joining).
+ *  Same test forkWorld uses to refuse an occupied name. */
+export function worldExists(name: string): boolean {
+  if (!/^[a-z0-9_-]{1,64}$/i.test(name)) return false;
+  return worlds.has(name) || existsSync(join(WORLDS_DIR, name));
+}
+
 export function getWorld(name: string): World {
   if (!/^[a-z0-9_-]{1,64}$/i.test(name)) throw new Error(`bad world name: ${name}`);
   let w = worlds.get(name);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -61,9 +61,22 @@ async function connectHost(token: string, query = "") {
   });
   rpc({ jsonrpc: "2.0", method: "notifications/initialized" });
   await request("featureSets/update", {
-    effectiveCapabilities: ["tools", "channels.register", "channels.lifecycle", "channels.publish", "channels.incoming"],
+    effectiveCapabilities: ["tools", "channels.register", "channels.lifecycle", "channels.join", "channels.publish", "channels.incoming"],
   });
   return { ws, request, inbound, init };
+}
+
+/** Raw world-WS watcher parked in a world, recording leave/join broadcasts. */
+async function watchWorld(w: string, id: string) {
+  const ws = new WebSocket(`ws://127.0.0.1:${WPORT}/ws`);
+  const events: any[] = [];
+  await new Promise<void>((res, rej) => {
+    const t = setTimeout(() => rej(new Error("watcher join timeout")), 6000);
+    ws.onmessage = (ev) => { const m = JSON.parse(String(ev.data)); events.push(m);
+      if (m.type === "snapshot") { clearTimeout(t); res(); } };
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", world: w, id, avatar: "a.vrm" }));
+  });
+  return { ws, events };
 }
 
 try {
@@ -83,6 +96,7 @@ try {
   bound.ws.close();
 
   // ── 2. worlds:["*"] → join granted, descriptor + changed ─────────────────
+  const commonsWatch = await watchWorld("commons", "watcher");
   const roamer = await connectHost("roamer-token");
   await sleep(1200);
   const joined = await roamer.request("channels/open", { type: "world", address: { world: "annex" }, history: { limit: 5 } });
@@ -97,7 +111,18 @@ try {
   // …and the same-channel open keeps its old meaning post-join
   const reopen = await roamer.request("channels/open", { type: "world", address: { world: "annex" } });
   check("current-channel open still plain-opens", reopen.result?.channel?.id === "world:annex", JSON.stringify(reopen));
-  roamer.ws.close();
+  // atomicity, world-side: the commons watcher saw the body actually LEAVE
+  await sleep(600);
+  const left = commonsWatch.events.some((m) => (m.type === "leave" || m.type === "part" || m.type === "left") && (m.id === "roamer" || m.who === "roamer"));
+  const ghost = commonsWatch.events.filter((m) => m.type === "say" && m.id === "roamer").length;
+  check("old world saw the body leave (no dual presence)", left, "leave-ish events: " + JSON.stringify(commonsWatch.events.map((m) => m.type).slice(-12)) + ` ghost says: ${ghost}`);
+  commonsWatch.ws.close();
+  // in-session denial for a LISTED credential asking outside its list
+  const roamer2 = await connectHost("roamer2-token");
+  await sleep(1200);
+  const outside = await roamer2.request("channels/open", { type: "world", address: { world: "elsewhere" } });
+  check("worlds:[annex] credential denied for other worlds", outside.error?.code === -32017, JSON.stringify(outside));
+  roamer2.ws.close();
 
   // ── 4. dial-time ?world= under the same policy ────────────────────────────
   const dialed = await connectHost("roamer2-token", "&world=annex");
@@ -110,6 +135,21 @@ try {
   const fb = await fallback.request("channels/list", {});
   check("?world= falls back to minted world when unpoliced", fb.result?.channels?.[0]?.id === "world:commons", JSON.stringify(fb.result));
   fallback.ws.close();
+
+  // ── 5. attach failure → -32024 and the connection surfaces CLOSED ─────────
+  // (last: it kills the sequencer)
+  const victim = await connectHost("roamer-token");
+  await sleep(1200);
+  world.kill();                        // the sequencer goes away mid-session
+  await sleep(500);
+  const failed = await victim.request("channels/open", { type: "world", address: { world: "faraway" } });
+  check("attach failure is -32024", failed.error?.code === -32024, JSON.stringify(failed));
+  const closed = await new Promise<boolean>((res) => {
+    if (victim.ws.readyState === WebSocket.CLOSED) return res(true);
+    victim.ws.onclose = () => res(true);
+    setTimeout(() => res(victim.ws.readyState === WebSocket.CLOSED), 4000);
+  });
+  check("never half-attached: connection surfaced as closed", closed);
 } finally {
   world.kill(); mcpl.kill();
 }

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -1,17 +1,48 @@
-// RFC-005 channel join — integration test. Starts its own world + MCPL door on
-// temp ports with a temp tokens file, then exercises all four outcomes:
-//   1. join DENIED (-32017) for a credential with no worlds policy (status quo)
-//   2. join GRANTED for a credential with worlds: ["*"] — response carries the
-//      new channel descriptor, and a channels/changed Request retires the old
-//   3. unknown channelId form → -32023 (spec code, not legacy -32004)
-//   4. dial-time ?world= honored under the same policy
-import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+// In-session world travel — integration test for the `travel` tool lane.
+// Starts its own world + MCPL door on VERIFIED-FREE ports with a temp tokens
+// file and a temp state file, then covers: join policy (denied / granted /
+// listed-but-outside), founding vs joining, dial-time ?world=, epoch across
+// transitions, host prepare/commit refusal, per-world door state, the
+// plain-MCP lane, and attach failure.
+//
+// 🔴 THE HARNESS OWNS ITS PORTS, ITS STATE, AND ITS CHILDREN (2026-08-16).
+// It previously hardcoded 8957/8958, waited by sleep, and never proved the
+// responder was the process it spawned — and this project has already had a
+// test answer green from a STALE listener on a fixed 89xx port. It also let
+// the door write the REPOSITORY's mcpl/state.json. Both are false-receipt
+// generators: the first reports on someone else's server, the second leaves
+// artifacts that look like real failures. Everything below exists to make the
+// suite's green mean "the code under test did this."
+import { mkdtempSync, writeFileSync, existsSync, rmSync, statSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer } from "node:net";
 
-const WPORT = 8957, MPORT = 8958;
+/** A port nothing is listening on RIGHT NOW: bind :0, read what the kernel
+ *  gave us, release it. Racy in principle (someone could take it in the gap)
+ *  — which is why readiness below verifies ownership rather than trusting
+ *  that whatever answers is ours. */
+async function freePort(): Promise<number> {
+  return await new Promise((res, rej) => {
+    const s = createServer();
+    s.once("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as { port: number }).port;
+      s.close(() => res(p));
+    });
+  });
+}
+const WPORT = await freePort(), MPORT = await freePort();
 const worldsDir = mkdtempSync(join(tmpdir(), "eido-join-"));
 const tokensPath = join(worldsDir, "tokens.json");
+// Bound to worldsDir, per the review: the door's durable state lives with the
+// rest of this run's scratch and dies with it.
+const statePath = join(worldsDir, "state.json");
+// Repository state must be untouched by a run. Snapshot before, compare after.
+const REPO_STATE = new URL("../mcpl/state.json", import.meta.url).pathname;
+const repoStateBefore = existsSync(REPO_STATE)
+  ? { exists: true, mtimeMs: statSync(REPO_STATE).mtimeMs, size: statSync(REPO_STATE).size }
+  : { exists: false, mtimeMs: 0, size: 0 };
 writeFileSync(tokensPath, JSON.stringify({
   "bound-token":   { id: "bound",   name: "Bound",   world: "commons" },
   "roamer-token":  { id: "roamer",  name: "Roamer",  world: "commons", worlds: ["*"], create: true },
@@ -25,14 +56,95 @@ const check = (name: string, ok: boolean, extra = "") => {
   ok ? pass++ : fail++;
 };
 
+// A nonce this run owns, echoed by the door's /healthz.
+const NONCE = `t${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
+
 const world = Bun.spawn([process.execPath, "server/server.ts"], {
   env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir },
   stdout: "ignore", stderr: "ignore",
 });
 const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
-  env: { ...process.env, MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`, MCPL_TOKENS: tokensPath },
+  env: { ...process.env, MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`,
+         MCPL_TOKENS: tokensPath, MCPL_STATE: statePath, MCPL_INSTANCE_NONCE: NONCE },
   stdout: "ignore", stderr: "ignore",
 });
+
+/** PIDs listening on a TCP port, from the OS. Verified against this machine's
+ *  `ss -lntp` output before use. Empty when nothing is listening. */
+async function listenerPids(port: number): Promise<number[]> {
+  const p = Bun.spawn(["ss", "-lntpH"], { stdout: "pipe", stderr: "ignore" });
+  const out = await new Response(p.stdout).text();
+  await p.exited;
+  const pids: number[] = [];
+  for (const line of out.split("\n")) {
+    if (!new RegExp(`[:.]${port}\\s`).test(line)) continue;
+    for (const m of line.matchAll(/pid=(\d+)/g)) pids.push(Number(m[1]));
+  }
+  return [...new Set(pids)];
+}
+
+/** Transitive children of a pid, via /proc — Bun.spawn of a .ts file may exec
+ *  a child that does the actual listening, so "port pid === our pid" is too
+ *  strict. */
+function descendantsOf(root: number): number[] {
+  const out: number[] = [];
+  const walk = (pid: number, depth = 0) => {
+    if (depth > 6) return;
+    let kids = "";
+    try { kids = readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8"); } catch { return; }
+    for (const k of kids.trim().split(/\s+/).filter(Boolean)) {
+      const n = Number(k); out.push(n); walk(n, depth + 1);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** Poll until `probe()` returns true, or throw. Replaces the fixed startup
+ *  sleep: a sleep encodes a GUESS about startup time and fails in both
+ *  directions — slow when it over-waits, flaky when it under-waits. Also fails
+ *  FAST if either child dies, which is how a squatted port surfaces. */
+async function waitFor(what: string, probe: () => Promise<boolean>, ms = 20_000) {
+  const deadline = Date.now() + ms;
+  let lastErr = "";
+  while (Date.now() < deadline) {
+    if (world.exitCode !== null) throw new Error(`${what}: world child exited early (code ${world.exitCode})`);
+    if (mcpl.exitCode !== null) throw new Error(`${what}: door child exited early (code ${mcpl.exitCode})`);
+    try { if (await probe()) return; } catch (e) { lastErr = (e as Error).message; }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`${what}: not ready within ${ms}ms${lastErr ? ` (last: ${lastErr})` : ""}`);
+}
+
+/** The port must be held by the child we spawned (or a descendant). This is
+ *  the OS's answer, not the app's — an app endpoint can only tell you what the
+ *  app believes, and a stale listener believes it is fine. */
+function ownsPort(name: string, port: number, child: { pid: number }) {
+  return async () => {
+    const pids = await listenerPids(port);
+    if (pids.length === 0) return false;
+    const ours = new Set([child.pid, ...descendantsOf(child.pid)]);
+    const foreign = pids.filter((p) => !ours.has(p));
+    if (foreign.length) throw new Error(`${name} port ${port} held by pid(s) ${foreign.join(",")}, not our child ${child.pid} — stale listener`);
+    return true;
+  };
+}
+
+// 🔴 IDENTITY, NOT MERE LIVENESS. "The port answers" is exactly the check that
+// lets a stale listener report green.
+await waitFor("world /version", async () => (await fetch(`http://127.0.0.1:${WPORT}/version`)).ok);
+await waitFor("world port is owned by OUR child", ownsPort("world", WPORT, world));
+// Two independent proofs for the door: it echoes a nonce only we set, AND the
+// OS says the port is our child's. (The world server has no nonce-able
+// endpoint — /avatars reads LIBRARY_DIR/OPT_DIR, not worldsDir; checked.)
+await waitFor("door /healthz echoes our nonce", async () => {
+  const r = await fetch(`http://127.0.0.1:${MPORT}/healthz`);
+  if (!r.ok) return false;
+  const body = (await r.text()).trim();
+  if (body === "ok") throw new Error("a door answered but WITHOUT our nonce — stale listener on this port");
+  return body === `ok ${NONCE}`;
+});
+await waitFor("door port is owned by OUR child", ownsPort("door", MPORT, mcpl));
 
 /** Minimal MCPL 0.5 host: initialize, grant, then request/notification I/O. */
 async function connectHost(token: string, query = "", mode: "accept" | "decline" | "mute" = "accept") {
@@ -126,7 +238,8 @@ async function watchWorld(w: string, id: string) {
 const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
 
 try {
-  await sleep(2500);
+  // (no startup sleep: readiness above already proved both children are up AND
+  // are the processes we spawned)
 
   // ── 1. no policy → deny, and the session survives the refusal ─────────────
   // Driven through the TOOL now: the channels/open sibling-join lane was
@@ -426,7 +539,41 @@ try {
   });
   check("never half-attached: connection surfaced as closed", closed);
 } finally {
-  world.kill(); mcpl.kill();
+  // Verified termination: kill(), then AWAIT the exit. `kill()` alone returns
+  // immediately, so the old teardown could return while children still held
+  // ports and were mid-write — which is how a zero-byte state.json.tmp
+  // survived a run. Escalate to SIGKILL rather than hang the suite.
+  for (const [name, child] of [["world", world], ["door", mcpl]] as const) {
+    try { child.kill(); } catch { /* already gone */ }
+    const outcome = await Promise.race([
+      child.exited,
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 5000)),
+    ]);
+    if (outcome === "timeout") {
+      try { child.kill("SIGKILL"); } catch { /* already gone */ }
+      await Promise.race([child.exited, new Promise((r) => setTimeout(r, 2000))]);
+    }
+    check(`${name} child terminated`, child.exitCode !== null || child.signalCode !== null,
+      "still running after SIGTERM+SIGKILL");
+  }
+
+  // 🔴 SOURCE-TREE CLEANLINESS. The whole point of MCPL_STATE. A run that
+  // mutates repository state is not a receipt, it is contamination — and its
+  // leftovers are indistinguishable from a real failure to the next reader.
+  const after = existsSync(REPO_STATE)
+    ? { exists: true, mtimeMs: statSync(REPO_STATE).mtimeMs, size: statSync(REPO_STATE).size }
+    : { exists: false, mtimeMs: 0, size: 0 };
+  check("repository mcpl/state.json untouched",
+    after.exists === repoStateBefore.exists && after.mtimeMs === repoStateBefore.mtimeMs && after.size === repoStateBefore.size,
+    `before=${JSON.stringify(repoStateBefore)} after=${JSON.stringify(after)}`);
+  check("no repository mcpl/state.json.tmp left behind", !existsSync(`${REPO_STATE}.tmp`));
+  // …and our own temp state exists, proving the override was HONOURED rather
+  // than silently ignored — otherwise "untouched" would also pass if the door
+  // simply never persisted at all.
+  check("the door persisted to OUR state path", existsSync(statePath), statePath);
+  check("no temp file left in our state dir", !existsSync(`${statePath}.tmp`));
+
+  try { rmSync(worldsDir, { recursive: true, force: true }); } catch { /* best effort */ }
 }
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -5,7 +5,7 @@
 //      new channel descriptor, and a channels/changed Request retires the old
 //   3. unknown channelId form → -32023 (spec code, not legacy -32004)
 //   4. dial-time ?world= honored under the same policy
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -147,6 +147,8 @@ try {
   await sleep(1200);
   const wouldFound = await nofound.request("channels/open", { type: "world", address: { world: "brand-new-place" } });
   check("worlds:['*'] without create CANNOT found a world", wouldFound.error?.code === -32023, JSON.stringify(wouldFound));
+  // …and prove it wasn't created as a side effect anyway (review F)
+  check("refused founding left NOTHING on disk", !existsSync(join(worldsDir, "brand-new-place")));
   nofound.ws.close();
   const founder = await connectHost("roamer-token");
   await sleep(1200);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -14,7 +14,8 @@ const worldsDir = mkdtempSync(join(tmpdir(), "eido-join-"));
 const tokensPath = join(worldsDir, "tokens.json");
 writeFileSync(tokensPath, JSON.stringify({
   "bound-token":   { id: "bound",   name: "Bound",   world: "commons" },
-  "roamer-token":  { id: "roamer",  name: "Roamer",  world: "commons", worlds: ["*"] },
+  "roamer-token":  { id: "roamer",  name: "Roamer",  world: "commons", worlds: ["*"], create: true },
+  "nofound-token": { id: "nofound", name: "NoFound", world: "commons", worlds: ["*"] },
   "roamer2-token": { id: "roamer2", name: "Roamer2", world: "commons", worlds: ["annex"] },
 }));
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -130,11 +131,37 @@ try {
   const dl = await dialed.request("channels/list", {});
   check("?world= honored for a policied credential", dl.result?.channels?.[0]?.id === "world:annex", JSON.stringify(dl.result));
   dialed.ws.close();
-  const fallback = await connectHost("bound-token", "&world=annex");
+  // §3.3 (Mica #3): a denied dial-time destination REFUSES the connection —
+  // no silent fallback to the minted world.
+  let refused = false;
+  try {
+    const fallback = await connectHost("bound-token", "&world=annex");
+    await sleep(1500);
+    refused = fallback.ws.readyState === WebSocket.CLOSED || fallback.ws.readyState === WebSocket.CLOSING;
+    fallback.ws.close();
+  } catch { refused = true; }   // connectHost throws when the socket dies during init
+  check("denied ?world= refuses the connection (no silent fallback)", refused);
+
+  // ── 4b. §3.2.7 founding is not joining ───────────────────────────────────
+  const nofound = await connectHost("nofound-token");
   await sleep(1200);
-  const fb = await fallback.request("channels/list", {});
-  check("?world= falls back to minted world when unpoliced", fb.result?.channels?.[0]?.id === "world:commons", JSON.stringify(fb.result));
-  fallback.ws.close();
+  const wouldFound = await nofound.request("channels/open", { type: "world", address: { world: "brand-new-place" } });
+  check("worlds:['*'] without create CANNOT found a world", wouldFound.error?.code === -32023, JSON.stringify(wouldFound));
+  nofound.ws.close();
+  const founder = await connectHost("roamer-token");
+  await sleep(1200);
+  const founded = await founder.request("channels/open", { type: "world", address: { world: "founded-place" } });
+  check("create:true CAN found, and says so", founded.result?.channel?.id === "world:founded-place"
+    && founded.result?.channel?.metadata?.created === true, JSON.stringify(founded.result?.channel?.metadata));
+  // ── 4c. §3.2.3d epoch + §3.2.6 channelId form ────────────────────────────
+  const e1 = founded.result?.channel?.metadata?.epoch;
+  const byId = await founder.request("channels/open", { channelId: "world:annex" });
+  check("channelId form expresses join intent (Mica #5)", byId.result?.channel?.id === "world:annex", JSON.stringify(byId.error ?? byId.result?.channel?.id));
+  check("epoch increments across transitions", typeof e1 === "number" && byId.result?.channel?.metadata?.epoch > e1,
+    `e1=${e1} e2=${byId.result?.channel?.metadata?.epoch}`);
+  const conflict = await founder.request("channels/open", { channelId: "world:annex", type: "world", address: { world: "commons" } });
+  check("conflicting channelId+address is -32602", conflict.error?.code === -32602, JSON.stringify(conflict.error));
+  founder.ws.close();
 
   // ── 5. attach failure → -32024 and the connection surfaces CLOSED ─────────
   // (last: it kills the sequencer)
@@ -142,7 +169,7 @@ try {
   await sleep(1200);
   world.kill();                        // the sequencer goes away mid-session
   await sleep(500);
-  const failed = await victim.request("channels/open", { type: "world", address: { world: "faraway" } });
+  const failed = await victim.request("channels/open", { type: "world", address: { world: "annex" } });  // exists, so this tests ATTACH failure
   check("attach failure is -32024", failed.error?.code === -32024, JSON.stringify(failed));
   const closed = await new Promise<boolean>((res) => {
     if (victim.ws.readyState === WebSocket.CLOSED) return res(true);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -355,10 +355,17 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   const joined = await roamer.request("tools/call", { name: "travel", arguments: { world: "annex" } });
   check("policied travel arrives", !joined.result?.isError && /(Arrived in|Founded and entered) "annex"/.test(txt(joined)), txt(joined));
   await sleep(800);
-  const changed = roamer.inbound.find((m) => m.method === "channels/changed");
+  // On a SUCCESSFUL travel the host learns both halves — but in two frames now,
+  // not one: the prepare asks (`added` only, so a question asserts nothing), and
+  // the commit states the departure once it is a fact. The old single-frame
+  // assertion was written against a prepare that claimed the removal up front,
+  // which is precisely the thing a declining host must never see (4f below).
+  const changedFrames = roamer.inbound.filter((m) => m.method === "channels/changed");
+  const addedAnnex = changedFrames.some((m) => m.params?.added?.[0]?.id === "world:annex");
+  const retiredCommons = changedFrames.some((m) => m.params?.removed?.includes("world:commons"));
   check("channels/changed retires old world, adds new",
-    changed?.params?.removed?.includes("world:commons") && changed?.params?.added?.[0]?.id === "world:annex",
-    JSON.stringify(changed?.params));
+    addedAnnex && retiredCommons,
+    JSON.stringify(changedFrames.map((m) => m.params)));
   const after = await roamer.request("channels/list", {});
   check("channels/list agrees the session moved", after.result?.channels?.[0]?.id === "world:annex", JSON.stringify(after.result));
   // …and the same-channel open keeps its old meaning post-travel. This is the
@@ -523,6 +530,20 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
     declined.result?.isError === true && /channel not permitted/.test(txt(declined)), txt(declined));
   const stillHome = await decliner.request("channels/list", {});
   check("declined join left the body where it was", stillHome.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stillHome.result));
+  // 🔴 …AND THE HOST WAS NOT TOLD OTHERWISE (adversarial review, 2026-08-17).
+  // "nothing moved" was checked from the BODY's side only. The prepare Request
+  // used to carry `removed: ["world:commons"]`, so a declining host had already
+  // been told its current channel was gone — and then kept receiving deliveries
+  // on it. Host and body disagreeing about the roster is the exact failure
+  // RFC-005 exists to prevent, and it was reachable by a merely SLOW host
+  // (5s timeout), not only a rejecting one.
+  //
+  // A prepare is a question; it must not assert a change it has not made.
+  const prepareFrames = decliner.inbound.filter((m: any) =>
+    m.method === "channels/changed" && Array.isArray(m.params?.removed) && m.params.removed.length);
+  check("…and the host was never told its channel was removed",
+    prepareFrames.length === 0,
+    `saw ${prepareFrames.length} removal claim(s): ${JSON.stringify(prepareFrames.map((f: any) => f.params.removed))}`);
   decliner.ws.close();
 
   const mute = await connectHost("roamer-token", "", "mute");

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -209,6 +209,43 @@ try {
   check("mute host is treated as declining (fail-closed)", timedOut.error?.code === -32017, JSON.stringify(timedOut.error));
   mute.ws.close();
 
+  // ── 4g. LANE 1: the `travel` tool ─────────────────────────────────────────
+  // Same mechanism as channels/open, reachable by a plain-MCP client that has
+  // never heard of MCPL channels. Both lanes MUST share one policy.
+  const tv = await connectHost("roamer-token");
+  await sleep(1200);
+  const listed = await tv.request("tools/list", {});
+  check("travel is advertised as a tool", listed.result?.tools?.some((t: any) => t.name === "travel"), "no travel tool");
+
+  const moved = await tv.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  const movedText = moved.result?.content?.[0]?.text ?? "";
+  check("travel tool arrives", /Arrived in "annex"/.test(movedText), movedText);
+  const whereNow = await tv.request("channels/list", {});
+  check("travel tool actually moved the body", whereNow.result?.channels?.[0]?.id === "world:annex", JSON.stringify(whereNow.result));
+  // it must ALSO tell the host, exactly like the channels/open lane
+  check("travel tool emitted channels/changed to the host",
+    tv.inbound.some((m) => m.method === "channels/changed"), "host never told");
+
+  const noop = await tv.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("travel to where you already are is a no-op, not an error",
+    !noop.result?.isError && /Already in/.test(noop.result?.content?.[0]?.text ?? ""), JSON.stringify(noop.result));
+  tv.ws.close();
+
+  // ── 4h. ONE POLICY: the tool must refuse exactly what channels/open refuses ─
+  const bound2 = await connectHost("bound-token");   // no `worlds` → may not roam
+  await sleep(1200);
+  const toolRefusal = await bound2.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("travel tool honours join policy", toolRefusal.result?.isError === true, JSON.stringify(toolRefusal.result));
+  const openRefusal = await bound2.request("channels/open", { type: "world", address: { world: "annex" } });
+  check("…and channels/open refuses the SAME world for the SAME credential",
+    openRefusal.error?.code === -32017, JSON.stringify(openRefusal.error));
+  const stayed = await bound2.request("channels/list", {});
+  check("a refused travel moved nothing", stayed.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stayed.result));
+
+  const badName = await bound2.request("tools/call", { name: "travel", arguments: { world: "../etc/passwd" } });
+  check("travel rejects a malformed world name", badName.result?.isError === true, JSON.stringify(badName.result));
+  bound2.ws.close();
+
   // ── 5. attach failure → -32024 and the connection surfaces CLOSED ─────────
   // (last: it kills the sequencer)
   const victim = await connectHost("roamer-token");

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -770,6 +770,28 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   // simply never persisted at all.
   check("the door persisted to OUR state path", existsSync(statePath), statePath);
   check("no temp file left in our state dir", !existsSync(`${statePath}.tmp`));
+  // 🔴 NO "-1" WATERMARK EVER REACHES DISK (adversarial review, 2026-08-17).
+  // WorldAgent.lastSeq is -1 until the first snapshot lands, and joinWorld
+  // assigns this.agent = next BEFORE awaiting next.connect(). A 60s tick — or
+  // the disconnect path — landing in that window persisted `{id}@{world}: -1`.
+  //
+  // -1 is not "nothing recorded", it is a NUMBER, so the reader takes it: it
+  // skips nothing and reaches back to the dawn of the log, replaying an entire
+  // world's history as wake-triggering mentions on the next connect. This PR's
+  // own per-world seqKey is what makes it reachable, so the regression would
+  // have shipped WITH the feature.
+  //
+  // The suite has travelled many times by now, including a fatal-attach case,
+  // so any window-write would be on disk here.
+  {
+    const persisted = JSON.parse(readFileSync(statePath, "utf8")) as
+      { lastSeenSeq?: Record<string, number> };
+    const seqs = persisted.lastSeenSeq ?? {};
+    const negatives = Object.entries(seqs).filter(([, v]) => typeof v === "number" && v < 0);
+    check("no unsynced (-1) watermark was persisted for any world",
+      negatives.length === 0,
+      `negatives: ${JSON.stringify(negatives)} | all: ${JSON.stringify(seqs)}`);
+  }
 
   try { rmSync(worldsDir, { recursive: true, force: true }); } catch { /* best effort */ }
 }

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -60,7 +60,8 @@ const check = (name: string, ok: boolean, extra = "") => {
 const NONCE = `t${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
 
 const world = Bun.spawn([process.execPath, "server/server.ts"], {
-  env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir },
+  env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir,
+         WORLD_INSTANCE_NONCE: NONCE },
   stdout: "ignore", stderr: "ignore",
 });
 const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
@@ -69,18 +70,27 @@ const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
   stdout: "ignore", stderr: "ignore",
 });
 
-/** PIDs listening on a TCP port, from the OS. Verified against this machine's
- *  `ss -lntp` output before use. Empty when nothing is listening. */
-async function listenerPids(port: number): Promise<number[]> {
-  const p = Bun.spawn(["ss", "-lntpH"], { stdout: "pipe", stderr: "ignore" });
-  const out = await new Response(p.stdout).text();
-  await p.exited;
-  const pids: number[] = [];
-  for (const line of out.split("\n")) {
-    if (!new RegExp(`[:.]${port}\\s`).test(line)) continue;
-    for (const m of line.matchAll(/pid=(\d+)/g)) pids.push(Number(m[1]));
-  }
-  return [...new Set(pids)];
+/** PIDs listening on a TCP port, from the OS. Returns null when this platform
+ *  cannot answer — which is NOT the same as "nothing is listening", and
+ *  conflating the two is how a portable-looking check silently stops checking.
+ *
+ *  🔴 LINUX-ONLY, AND THAT IS WHY IT IS THE SECOND OPINION (antra, 2026-08-16:
+ *  the macOS review host has no `ss` and no /proc, so the exact-head run died
+ *  before the first vector with `Executable not found in $PATH: "ss"`). The
+ *  PORTABLE proof is the per-run nonce each child echoes; this is a stricter
+ *  opinion offered where the platform can give one. */
+async function listenerPids(port: number): Promise<number[] | null> {
+  try {
+    const p = Bun.spawn(["ss", "-lntpH"], { stdout: "pipe", stderr: "ignore" });
+    const out = await new Response(p.stdout).text();
+    if ((await p.exited) !== 0) return null;
+    const pids: number[] = [];
+    for (const line of out.split("\n")) {
+      if (!new RegExp(`[:.]${port}\\s`).test(line)) continue;
+      for (const m of line.matchAll(/pid=(\d+)/g)) pids.push(Number(m[1]));
+    }
+    return [...new Set(pids)];
+  } catch { return null; }          // no `ss` on this platform
 }
 
 /** Transitive children of a pid, via /proc — Bun.spawn of a .ts file may exec
@@ -88,6 +98,7 @@ async function listenerPids(port: number): Promise<number[]> {
  *  strict. */
 function descendantsOf(root: number): number[] {
   const out: number[] = [];
+  if (!existsSync("/proc")) return out;   // no procfs: caller falls back to the nonce
   const walk = (pid: number, depth = 0) => {
     if (depth > 6) return;
     let kids = "";
@@ -122,21 +133,59 @@ async function waitFor(what: string, probe: () => Promise<boolean>, ms = 20_000)
 function ownsPort(name: string, port: number, child: { pid: number }) {
   return async () => {
     const pids = await listenerPids(port);
+    // null = this platform cannot answer. Return true so the wait resolves: the
+    // nonce challenge above has ALREADY proved identity, and refusing to
+    // proceed here would make a portable receipt unrunnable on the very host
+    // that reviews it. A skip is recorded loudly (see osOwnership below) — a
+    // check that quietly stops checking is the failure mode this file exists
+    // to prevent.
+    if (pids === null) return true;
     if (pids.length === 0) return false;
     const ours = new Set([child.pid, ...descendantsOf(child.pid)]);
+    // No procfs but `ss` present (unlikely, but do not guess): with no way to
+    // enumerate descendants, an exact pid match is the most we can honestly
+    // assert, and anything else is unproven rather than foreign.
     const foreign = pids.filter((p) => !ours.has(p));
-    if (foreign.length) throw new Error(`${name} port ${port} held by pid(s) ${foreign.join(",")}, not our child ${child.pid} — stale listener`);
+    if (foreign.length && ours.size > 1) {
+      throw new Error(`${name} port ${port} held by pid(s) ${foreign.join(",")}, not our child ${child.pid} — stale listener`);
+    }
     return true;
   };
 }
 
+/** Did the OS-level check actually run on this platform? Reported, never
+ *  assumed — antra's macOS run must be able to see WHICH proofs it got. */
+async function osOwnershipAvailable(): Promise<boolean> {
+  return (await listenerPids(WPORT)) !== null && existsSync("/proc");
+}
+
 // 🔴 IDENTITY, NOT MERE LIVENESS. "The port answers" is exactly the check that
 // lets a stale listener report green.
-await waitFor("world /version", async () => (await fetch(`http://127.0.0.1:${WPORT}/version`)).ok);
+//
+// 🔴 AND EVERY PROBE BELOW RUNS INSIDE THE try (antra, 2026-08-16): readiness
+// and ownership used to run BEFORE the try/finally opened, so any startup or
+// identity failure bypassed the very teardown this file guarantees. Their
+// failed macOS run left both children to the shell. The `try` now opens here,
+// before the first spawn-dependent assertion, so nothing that can throw sits
+// outside it.
+let osOwnership = false;
+try {
+await waitFor("world /version echoes our nonce", async () => {
+  const r = await fetch(`http://127.0.0.1:${WPORT}/version`);
+  if (!r.ok) return false;
+  const body = await r.json().catch(() => null) as { instance?: string } | null;
+  // A world answering WITHOUT our instance field is a stale listener, not a
+  // slow start — say so rather than spinning until the deadline.
+  if (body && !("instance" in body)) {
+    throw new Error("a world answered but WITHOUT our nonce — stale listener on this port");
+  }
+  return body?.instance === NONCE;
+});
 await waitFor("world port is owned by OUR child", ownsPort("world", WPORT, world));
 // Two independent proofs for the door: it echoes a nonce only we set, AND the
-// OS says the port is our child's. (The world server has no nonce-able
-// endpoint — /avatars reads LIBRARY_DIR/OPT_DIR, not worldsDir; checked.)
+// OS says the port is our child's. The nonce is the PORTABLE one; the OS check
+// is a stricter second opinion, and is skipped (loudly, below) where the
+// platform cannot answer.
 await waitFor("door /healthz echoes our nonce", async () => {
   const r = await fetch(`http://127.0.0.1:${MPORT}/healthz`);
   if (!r.ok) return false;
@@ -145,6 +194,14 @@ await waitFor("door /healthz echoes our nonce", async () => {
   return body === `ok ${NONCE}`;
 });
 await waitFor("door port is owned by OUR child", ownsPort("door", MPORT, mcpl));
+
+// Say which proofs this run actually obtained. A receipt that cannot be read
+// as "nonce only" vs "nonce + OS" invites the reader to assume the stronger
+// one — and on macOS they would be assuming a check that did not run.
+osOwnership = await osOwnershipAvailable();
+console.log(osOwnership
+  ? "  identity: per-run nonce + OS port ownership (linux)"
+  : "  identity: per-run nonce only (no ss//proc on this platform — OS check skipped)");
 
 /** Minimal MCPL 0.5 host: initialize, grant, then request/notification I/O. */
 async function connectHost(token: string, query = "", mode: "accept" | "decline" | "mute" = "accept") {
@@ -237,9 +294,9 @@ async function watchWorld(w: string, id: string) {
 
 const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
 
-try {
   // (no startup sleep: readiness above already proved both children are up AND
-  // are the processes we spawned)
+  // are the processes we spawned. The `try` that guards teardown opens further
+  // up, BEFORE those probes — see the note there.)
 
   // ── 1. no policy → deny, and the session survives the refusal ─────────────
   // Driven through the TOOL now: the channels/open sibling-join lane was

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -77,6 +77,13 @@ function spawnChild(args: string[], env: Record<string, string>) {
 const world = spawnChild([process.execPath, "server/server.ts"], {
   PORT: String(WPORT), WORLDS_DIR: worldsDir, WORLD_INSTANCE_NONCE: NONCE,
 });
+// Seed a stale tmp as if a previous incarnation died mid-write (SIGKILL
+// between write and rename). The door must sweep it at boot — which makes the
+// final "no temp file" receipt exercise the cleanup machinery on EVERY run,
+// instead of passing vacuously on runs where no write happened to be
+// interrupted (the pre-fix failure was a kill-timing flake for exactly that
+// reason: the check only bit when the race landed).
+writeFileSync(`${statePath}.tmp`, "");
 const mcpl = spawnChild([process.execPath, "mcpl/net-server.ts"], {
   MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`,
   MCPL_TOKENS: tokensPath, MCPL_STATE: statePath, MCPL_INSTANCE_NONCE: NONCE,
@@ -231,6 +238,11 @@ osOwnership = await osOwnershipAvailable();
 console.log(osOwnership
   ? "  identity: per-run nonce + OS port ownership (linux)"
   : "  identity: per-run nonce only (no ss//proc on this platform — OS check skipped)");
+
+// The seeded stale tmp (above, before the spawn) must be gone once the door
+// answers /healthz: interrupted atomic writes are cleaned at boot, not left as
+// artifacts indistinguishable from live failures.
+check("stale state tmp from a previous incarnation swept at boot", !existsSync(`${statePath}.tmp`));
 
 /** Minimal MCPL 0.5 host: initialize, grant, then request/notification I/O. */
 async function connectHost(token: string, query = "", mode: "accept" | "decline" | "mute" = "accept") {
@@ -784,9 +796,18 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   // The suite has travelled many times by now, including a fatal-attach case,
   // so any window-write would be on disk here.
   {
+    // 🔴 The watermark section is persisted under the `__seq` key (see
+    // persistState in mcpl/net-server.ts) — an earlier revision of this check
+    // read a `lastSeenSeq` key that the writer never uses, so it filtered an
+    // always-empty object and could not fail. Hence the non-emptiness guard:
+    // the suite has travelled by now, so a truthful read MUST see entries —
+    // an empty map here means the check went blind again, not that all is well.
     const persisted = JSON.parse(readFileSync(statePath, "utf8")) as
-      { lastSeenSeq?: Record<string, number> };
-    const seqs = persisted.lastSeenSeq ?? {};
+      { __seq?: Record<string, number> };
+    const seqs = persisted.__seq ?? {};
+    check("watermarks were actually persisted (the check is reading the live key)",
+      Object.keys(seqs).length > 0,
+      `state file keys: ${JSON.stringify(Object.keys(persisted))}`);
     const negatives = Object.entries(seqs).filter(([, v]) => typeof v === "number" && v < 0);
     check("no unsynced (-1) watermark was persisted for any world",
       negatives.length === 0,

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -636,6 +636,42 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
     check("…while the SAME credential as plain-MCP travels fine (the mcplClient conjunct is load-bearing)",
       !plainOk.result?.isError && /(Arrived in|Founded and entered) "annex"/.test(txt(plainOk)), txt(plainOk));
     samecred.ws.close();
+
+    // 🔴 WHAT MAKES THE CONJUNCT SOUND: MCPL-ness is FIXED AT INITIALIZE.
+    //
+    // An adversarial review (2026-08-17) read `this.mcplClient && !granted(...)`
+    // and reported a bypass: mcplClient comes from a CLIENT-SUPPLIED field, so
+    // a denied host should be able to escape by ceasing to declare MCPL. The
+    // premise is true. The conclusion does not follow, and I nearly shipped a
+    // `lifecycleDenied` latch defending against it before checking.
+    //
+    // mcplClient is assigned at exactly one site, inside the one-shot prelude:
+    // it awaits initialize, then notifications/initialized, and only then does
+    // the read loop start. A second initialize never reaches the assignment.
+    // So a host chooses its class ONCE, before any policy exchange — and a host
+    // that chose plain-MCP never had a denial to escape.
+    //
+    // This vector pins that property, because the refactor that WOULD open the
+    // hole is moving that assignment out of the prelude. If someone does, this
+    // fails instead of shipping.
+    const escapee = await connectHost("roamer-token");
+    await sleep(1200);
+    await escapee.request("featureSets/update", {
+      effectiveCapabilities: ["tools", "channels.register", "channels.publish", "channels.incoming"],
+    });
+    // Try to become "plain MCP" mid-session. The door must not honour this.
+    await escapee.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},                       // <- no experimental.mcpl
+      clientInfo: { name: "escapee", version: "0" },
+    }).catch(() => { /* refusing a re-initialize outright is equally fine */ });
+    const escape = await escapee.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("a denied host stays denied — MCPL-ness is fixed at initialize, not re-declarable",
+      escape.result?.isError === true && /capability denied/.test(txt(escape)), txt(escape));
+    const stillOpen = await escapee.request("channels/list", {});
+    check("…and the refused host is still in its own world, undisturbed",
+      stillOpen.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stillOpen.result));
+    escapee.ws.close();
   }
 
   // ── 4k. the door must be OPEN in the new world (state-desync regression) ──

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -35,7 +35,7 @@ const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
 });
 
 /** Minimal MCPL 0.5 host: initialize, grant, then request/notification I/O. */
-async function connectHost(token: string, query = "") {
+async function connectHost(token: string, query = "", mode: "accept" | "decline" | "mute" = "accept") {
   const ws = new WebSocket(`ws://127.0.0.1:${MPORT}/?token=${token}${query}`);
   let nextId = 10;
   const pending = new Map<number, (m: any) => void>();
@@ -49,7 +49,15 @@ async function connectHost(token: string, query = "") {
     const m = JSON.parse(String(ev.data));
     if (m.id !== undefined && pending.has(m.id)) { pending.get(m.id)!(m); pending.delete(m.id); return; }
     inbound.push(m);
-    if (m.id !== undefined && m.method) rpc({ jsonrpc: "2.0", id: m.id, result: {} }); // ack server Requests
+    if (m.id !== undefined && m.method) {
+      if (m.method === "channels/changed" && mode !== "accept") {
+        if (mode === "mute") return;                       // never answer: server must fail closed
+        const added = (m.params?.added ?? []) as { id: string }[];
+        rpc({ jsonrpc: "2.0", id: m.id, result: { results: added.map((c) => ({ id: c.id, accepted: false, reason: "test_decline" })) } });
+        return;
+      }
+      rpc({ jsonrpc: "2.0", id: m.id, result: {} });       // ack server Requests
+    }
   };
   await new Promise<void>((res, rej) => {
     const t = setTimeout(() => rej(new Error("open timeout")), 6000);
@@ -164,6 +172,42 @@ try {
   const conflict = await founder.request("channels/open", { channelId: "world:annex", type: "world", address: { world: "commons" } });
   check("conflicting channelId+address is -32602", conflict.error?.code === -32602, JSON.stringify(conflict.error));
   founder.ws.close();
+
+  // ── 4d. REGRESSION (round-3 defect 1): dialing your OWN world must be fine ─
+  // v3 gated `auth.world` whenever ?world= was present at all, so naming your
+  // own home refused where omitting it admitted — bricking fresh deployments.
+  const ownWorld = await connectHost("bound-token", "&world=commons");
+  await sleep(1200);
+  const ow = await ownWorld.request("channels/list", {});
+  check("dialing your OWN minted world is not 'founding'", ow.result?.channels?.[0]?.id === "world:commons", JSON.stringify(ow.result));
+  ownWorld.ws.close();
+
+  // ── 4e. REGRESSION (round-3 defect 2): channels/changed carries the epoch ──
+  // It is the client's ONLY epoch source; v3 dropped the field and froze every
+  // client at 0 while the server advanced.
+  const eh = await connectHost("roamer-token");
+  await sleep(1200);
+  await eh.request("channels/open", { type: "world", address: { world: "annex" } });
+  await sleep(600);
+  const ch = eh.inbound.find((m) => m.method === "channels/changed");
+  check("channels/changed descriptor carries metadata.epoch (§3.2.3d)",
+    typeof ch?.params?.added?.[0]?.metadata?.epoch === "number", JSON.stringify(ch?.params?.added?.[0]?.metadata));
+  eh.ws.close();
+
+  // ── 4f. prepare/commit REFUSAL — the path the suite never exercised ───────
+  const decliner = await connectHost("roamer-token", "", "decline");
+  await sleep(1200);
+  const declined = await decliner.request("channels/open", { type: "world", address: { world: "annex" } });
+  check("host decline aborts the join with -32017", declined.error?.code === -32017, JSON.stringify(declined.error));
+  const stillHome = await decliner.request("channels/list", {});
+  check("declined join left the body where it was", stillHome.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stillHome.result));
+  decliner.ws.close();
+
+  const mute = await connectHost("roamer-token", "", "mute");
+  await sleep(1200);
+  const timedOut = await mute.request("channels/open", { type: "world", address: { world: "annex" } });
+  check("mute host is treated as declining (fail-closed)", timedOut.error?.code === -32017, JSON.stringify(timedOut.error));
+  mute.ws.close();
 
   // ── 5. attach failure → -32024 and the connection surfaces CLOSED ─────────
   // (last: it kills the sequencer)

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -1,0 +1,117 @@
+// RFC-005 channel join — integration test. Starts its own world + MCPL door on
+// temp ports with a temp tokens file, then exercises all four outcomes:
+//   1. join DENIED (-32017) for a credential with no worlds policy (status quo)
+//   2. join GRANTED for a credential with worlds: ["*"] — response carries the
+//      new channel descriptor, and a channels/changed Request retires the old
+//   3. unknown channelId form → -32023 (spec code, not legacy -32004)
+//   4. dial-time ?world= honored under the same policy
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const WPORT = 8957, MPORT = 8958;
+const worldsDir = mkdtempSync(join(tmpdir(), "eido-join-"));
+const tokensPath = join(worldsDir, "tokens.json");
+writeFileSync(tokensPath, JSON.stringify({
+  "bound-token":   { id: "bound",   name: "Bound",   world: "commons" },
+  "roamer-token":  { id: "roamer",  name: "Roamer",  world: "commons", worlds: ["*"] },
+  "roamer2-token": { id: "roamer2", name: "Roamer2", world: "commons", worlds: ["annex"] },
+}));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, extra = "") => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${name}${ok ? "" : "  " + extra}`);
+  ok ? pass++ : fail++;
+};
+
+const world = Bun.spawn([process.execPath, "server/server.ts"], {
+  env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir },
+  stdout: "ignore", stderr: "ignore",
+});
+const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
+  env: { ...process.env, MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`, MCPL_TOKENS: tokensPath },
+  stdout: "ignore", stderr: "ignore",
+});
+
+/** Minimal MCPL 0.5 host: initialize, grant, then request/notification I/O. */
+async function connectHost(token: string, query = "") {
+  const ws = new WebSocket(`ws://127.0.0.1:${MPORT}/?token=${token}${query}`);
+  let nextId = 10;
+  const pending = new Map<number, (m: any) => void>();
+  const inbound: any[] = [];
+  const rpc = (obj: any) => ws.send(JSON.stringify(obj));
+  const request = (method: string, params: any = {}) => new Promise<any>((resolve, reject) => {
+    const id = nextId++; pending.set(id, resolve); rpc({ jsonrpc: "2.0", id, method, params });
+    setTimeout(() => { if (pending.delete(id)) reject(new Error(`${method} timed out`)); }, 15_000);
+  });
+  ws.onmessage = (ev) => {
+    const m = JSON.parse(String(ev.data));
+    if (m.id !== undefined && pending.has(m.id)) { pending.get(m.id)!(m); pending.delete(m.id); return; }
+    inbound.push(m);
+    if (m.id !== undefined && m.method) rpc({ jsonrpc: "2.0", id: m.id, result: {} }); // ack server Requests
+  };
+  await new Promise<void>((res, rej) => {
+    const t = setTimeout(() => rej(new Error("open timeout")), 6000);
+    ws.onopen = () => { clearTimeout(t); res(); };
+  });
+  const init = await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: { experimental: { mcpl: { version: "0.5", channels: { register: true, incoming: true } } } },
+    clientInfo: { name: "join-test", version: "0" },
+  });
+  rpc({ jsonrpc: "2.0", method: "notifications/initialized" });
+  await request("featureSets/update", {
+    effectiveCapabilities: ["tools", "channels.register", "channels.lifecycle", "channels.publish", "channels.incoming"],
+  });
+  return { ws, request, inbound, init };
+}
+
+try {
+  await sleep(2500);
+
+  // ── 1. no policy → deny, and the session survives the refusal ─────────────
+  const bound = await connectHost("bound-token");
+  await sleep(1200);
+  const denied = await bound.request("channels/open", { type: "world", address: { world: "annex" } });
+  check("unpoliced join denied with -32017", denied.error?.code === -32017, JSON.stringify(denied));
+  const still = await bound.request("channels/list", {});
+  check("denied session still attached to commons", still.result?.channels?.[0]?.id === "world:commons", JSON.stringify(still.result));
+
+  // ── 3. unknown channelId form → -32023 ────────────────────────────────────
+  const unk = await bound.request("channels/open", { channelId: "discord:#nope" });
+  check("unknown channel is -32023 (not legacy -32004)", unk.error?.code === -32023, JSON.stringify(unk));
+  bound.ws.close();
+
+  // ── 2. worlds:["*"] → join granted, descriptor + changed ─────────────────
+  const roamer = await connectHost("roamer-token");
+  await sleep(1200);
+  const joined = await roamer.request("channels/open", { type: "world", address: { world: "annex" }, history: { limit: 5 } });
+  check("policied join returns the NEW channel descriptor", joined.result?.channel?.id === "world:annex", JSON.stringify(joined));
+  await sleep(800);
+  const changed = roamer.inbound.find((m) => m.method === "channels/changed");
+  check("channels/changed retires old world, adds new",
+    changed?.params?.removed?.includes("world:commons") && changed?.params?.added?.[0]?.id === "world:annex",
+    JSON.stringify(changed?.params));
+  const after = await roamer.request("channels/list", {});
+  check("channels/list agrees the session moved", after.result?.channels?.[0]?.id === "world:annex", JSON.stringify(after.result));
+  // …and the same-channel open keeps its old meaning post-join
+  const reopen = await roamer.request("channels/open", { type: "world", address: { world: "annex" } });
+  check("current-channel open still plain-opens", reopen.result?.channel?.id === "world:annex", JSON.stringify(reopen));
+  roamer.ws.close();
+
+  // ── 4. dial-time ?world= under the same policy ────────────────────────────
+  const dialed = await connectHost("roamer2-token", "&world=annex");
+  await sleep(1200);
+  const dl = await dialed.request("channels/list", {});
+  check("?world= honored for a policied credential", dl.result?.channels?.[0]?.id === "world:annex", JSON.stringify(dl.result));
+  dialed.ws.close();
+  const fallback = await connectHost("bound-token", "&world=annex");
+  await sleep(1200);
+  const fb = await fallback.request("channels/list", {});
+  check("?world= falls back to minted world when unpoliced", fb.result?.channels?.[0]?.id === "world:commons", JSON.stringify(fb.result));
+  fallback.ws.close();
+} finally {
+  world.kill(); mcpl.kill();
+}
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -75,6 +75,41 @@ async function connectHost(token: string, query = "", mode: "accept" | "decline"
   return { ws, request, inbound, init };
 }
 
+/** A PLAIN-MCP client: identical transport, but `initialize` omits
+ *  capabilities.experimental.mcpl, so the server sets mcplClient=false and
+ *  granted() returns false for every capability by construction. This is the
+ *  vector antra's finding #1 asked for — without it, the "plain-MCP travel
+ *  lane" was advertised and never once exercised, which is exactly how it
+ *  shipped always-denied. */
+async function connectPlain(token: string) {
+  const ws = new WebSocket(`ws://127.0.0.1:${MPORT}/?token=${token}`);
+  let nextId = 10;
+  const pending = new Map<number, (m: any) => void>();
+  const inbound: any[] = [];
+  const rpc = (obj: any) => ws.send(JSON.stringify(obj));
+  const request = (method: string, params: any = {}) => new Promise<any>((resolve, reject) => {
+    const id = nextId++; pending.set(id, resolve); rpc({ jsonrpc: "2.0", id, method, params });
+    setTimeout(() => { if (pending.delete(id)) reject(new Error(`${method} timed out`)); }, 15_000);
+  });
+  ws.onmessage = (ev) => {
+    const m = JSON.parse(String(ev.data));
+    if (m.id !== undefined && pending.has(m.id)) { pending.get(m.id)!(m); pending.delete(m.id); return; }
+    inbound.push(m);
+    if (m.id !== undefined && m.method) rpc({ jsonrpc: "2.0", id: m.id, result: {} });
+  };
+  await new Promise<void>((res, rej) => {
+    const t = setTimeout(() => rej(new Error("open timeout")), 6000);
+    ws.onopen = () => { clearTimeout(t); res(); };
+  });
+  await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},                       // ← NO experimental.mcpl. This is the point.
+    clientInfo: { name: "plain-mcp-test", version: "0" },
+  });
+  rpc({ jsonrpc: "2.0", method: "notifications/initialized" });
+  return { ws, request, inbound };
+}
+
 /** Raw world-WS watcher parked in a world, recording leave/join broadcasts. */
 async function watchWorld(w: string, id: string) {
   const ws = new WebSocket(`ws://127.0.0.1:${WPORT}/ws`);
@@ -88,28 +123,38 @@ async function watchWorld(w: string, id: string) {
   return { ws, events };
 }
 
+const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
+
 try {
   await sleep(2500);
 
   // ── 1. no policy → deny, and the session survives the refusal ─────────────
+  // Driven through the TOOL now: the channels/open sibling-join lane was
+  // removed (antra #4), so the tool is the only lane and must carry the proof.
   const bound = await connectHost("bound-token");
   await sleep(1200);
-  const denied = await bound.request("channels/open", { type: "world", address: { world: "annex" } });
-  check("unpoliced join denied with -32017", denied.error?.code === -32017, JSON.stringify(denied));
+  const denied = await bound.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("unpoliced travel refused", denied.result?.isError === true && /not in this credential/.test(denied.result?.content?.[0]?.text ?? ""), JSON.stringify(denied.result));
   const still = await bound.request("channels/list", {});
   check("denied session still attached to commons", still.result?.channels?.[0]?.id === "world:commons", JSON.stringify(still.result));
 
-  // ── 3. unknown channelId form → -32023 ────────────────────────────────────
+  // ── 3. a sibling world id through channels/open is now an unknown channel ─
+  // The lane is gone, so this must be a clean -32023 rather than a silent join.
+  const sib = await bound.request("channels/open", { channelId: "world:annex" });
+  check("sibling channels/open is -32023 (lane removed, not silently joining)",
+    sib.error?.code === -32023 && /travel/.test(sib.error?.message ?? ""), JSON.stringify(sib.error));
   const unk = await bound.request("channels/open", { channelId: "discord:#nope" });
   check("unknown channel is -32023 (not legacy -32004)", unk.error?.code === -32023, JSON.stringify(unk));
+  const home = await bound.request("channels/list", {});
+  check("…and the session did NOT move on either refusal", home.result?.channels?.[0]?.id === "world:commons", JSON.stringify(home.result));
   bound.ws.close();
 
-  // ── 2. worlds:["*"] → join granted, descriptor + changed ─────────────────
+  // ── 2. worlds:["*"] → travel granted, and the host is told ───────────────
   const commonsWatch = await watchWorld("commons", "watcher");
   const roamer = await connectHost("roamer-token");
   await sleep(1200);
-  const joined = await roamer.request("channels/open", { type: "world", address: { world: "annex" }, history: { limit: 5 } });
-  check("policied join returns the NEW channel descriptor", joined.result?.channel?.id === "world:annex", JSON.stringify(joined));
+  const joined = await roamer.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("policied travel arrives", !joined.result?.isError && /(Arrived in|Founded and entered) "annex"/.test(txt(joined)), txt(joined));
   await sleep(800);
   const changed = roamer.inbound.find((m) => m.method === "channels/changed");
   check("channels/changed retires old world, adds new",
@@ -117,9 +162,11 @@ try {
     JSON.stringify(changed?.params));
   const after = await roamer.request("channels/list", {});
   check("channels/list agrees the session moved", after.result?.channels?.[0]?.id === "world:annex", JSON.stringify(after.result));
-  // …and the same-channel open keeps its old meaning post-join
-  const reopen = await roamer.request("channels/open", { type: "world", address: { world: "annex" } });
-  check("current-channel open still plain-opens", reopen.result?.channel?.id === "world:annex", JSON.stringify(reopen));
+  // …and the same-channel open keeps its old meaning post-travel. This is the
+  // half of channels/open that SURVIVED: opening the channel you are already
+  // in, with optional history, is the ordinary MCPL operation and is untouched.
+  const reopen = await roamer.request("channels/open", { type: "world", address: { world: "annex" }, history: { limit: 5 } });
+  check("current-channel open still plain-opens (with history)", reopen.result?.channel?.id === "world:annex", JSON.stringify(reopen));
   // atomicity, world-side: the commons watcher saw the body actually LEAVE
   await sleep(600);
   const left = commonsWatch.events.some((m) => (m.type === "leave" || m.type === "part" || m.type === "left") && (m.id === "roamer" || m.who === "roamer"));
@@ -129,8 +176,9 @@ try {
   // in-session denial for a LISTED credential asking outside its list
   const roamer2 = await connectHost("roamer2-token");
   await sleep(1200);
-  const outside = await roamer2.request("channels/open", { type: "world", address: { world: "elsewhere" } });
-  check("worlds:[annex] credential denied for other worlds", outside.error?.code === -32017, JSON.stringify(outside));
+  const outside = await roamer2.request("tools/call", { name: "travel", arguments: { world: "elsewhere" } });
+  check("worlds:[annex] credential denied for other worlds",
+    outside.result?.isError === true && /not in this credential's join policy/.test(txt(outside)), txt(outside));
   roamer2.ws.close();
 
   // ── 4. dial-time ?world= under the same policy ────────────────────────────
@@ -153,22 +201,41 @@ try {
   // ── 4b. §3.2.7 founding is not joining ───────────────────────────────────
   const nofound = await connectHost("nofound-token");
   await sleep(1200);
-  const wouldFound = await nofound.request("channels/open", { type: "world", address: { world: "brand-new-place" } });
-  check("worlds:['*'] without create CANNOT found a world", wouldFound.error?.code === -32023, JSON.stringify(wouldFound));
+  const wouldFound = await nofound.request("tools/call", { name: "travel", arguments: { world: "brand-new-place" } });
+  check("worlds:['*'] without create CANNOT found a world",
+    wouldFound.result?.isError === true && /founding requires create authority/.test(txt(wouldFound)), txt(wouldFound));
   // …and prove it wasn't created as a side effect anyway (review F)
   check("refused founding left NOTHING on disk", !existsSync(join(worldsDir, "brand-new-place")));
   nofound.ws.close();
   const founder = await connectHost("roamer-token");
   await sleep(1200);
-  const founded = await founder.request("channels/open", { type: "world", address: { world: "founded-place" } });
-  check("create:true CAN found, and says so", founded.result?.channel?.id === "world:founded-place"
-    && founded.result?.channel?.metadata?.created === true, JSON.stringify(founded.result?.channel?.metadata));
-  // ── 4c. §3.2.3d epoch + §3.2.6 channelId form ────────────────────────────
-  const e1 = founded.result?.channel?.metadata?.epoch;
-  const byId = await founder.request("channels/open", { channelId: "world:annex" });
-  check("channelId form expresses join intent (Mica #5)", byId.result?.channel?.id === "world:annex", JSON.stringify(byId.error ?? byId.result?.channel?.id));
-  check("epoch increments across transitions", typeof e1 === "number" && byId.result?.channel?.metadata?.epoch > e1,
-    `e1=${e1} e2=${byId.result?.channel?.metadata?.epoch}`);
+  const founded = await founder.request("tools/call", { name: "travel", arguments: { world: "founded-place" } });
+  check("create:true CAN found, and says so",
+    !founded.result?.isError && /Founded and entered "founded-place"/.test(txt(founded)), txt(founded));
+  // ── 4c. §3.2.3d epoch across transitions ─────────────────────────────────
+  // The epoch is read from the channels/changed descriptor the server pushes
+  // to the HOST — which is where §3.2.3d says a client learns it, and the only
+  // place it appears now that the sibling-open lane is gone.
+  await sleep(600);
+  const epochOf = (c: any) => c.inbound.filter((m: any) => m.method === "channels/changed")
+    .map((m: any) => m.params?.added?.[0]?.metadata?.epoch).filter((e: any) => typeof e === "number");
+  const e1s = epochOf(founder);
+  check("founding announced an epoch to the host", e1s.length > 0, JSON.stringify(e1s));
+  await founder.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  await sleep(600);
+  const e2s = epochOf(founder);
+  check("epoch increments across transitions", e2s.length > e1s.length && e2s[e2s.length - 1] > e1s[e1s.length - 1],
+    `epochs=${JSON.stringify(e2s)}`);
+  // 🔴 The above reads the PREPARE announcement, which carries `epoch + 1` —
+  // the epoch the transition WOULD commit to (net-server.ts, §3.2.3d). A bug
+  // that announced +1 and then never incremented at commit would pass it.
+  // channels/list reports `metadata.epoch` from the live session, so read the
+  // COMMITTED value back and prove the promise was kept.
+  const committed = await founder.request("channels/list", {});
+  const cEpoch = committed.result?.channels?.[0]?.metadata?.epoch;
+  check("…and the COMMITTED epoch matches what prepare promised",
+    typeof cEpoch === "number" && cEpoch === e2s[e2s.length - 1],
+    `promised=${e2s[e2s.length - 1]} committed=${cEpoch}`);
   const conflict = await founder.request("channels/open", { channelId: "world:annex", type: "world", address: { world: "commons" } });
   check("conflicting channelId+address is -32602", conflict.error?.code === -32602, JSON.stringify(conflict.error));
   founder.ws.close();
@@ -187,7 +254,7 @@ try {
   // client at 0 while the server advanced.
   const eh = await connectHost("roamer-token");
   await sleep(1200);
-  await eh.request("channels/open", { type: "world", address: { world: "annex" } });
+  await eh.request("tools/call", { name: "travel", arguments: { world: "annex" } });
   await sleep(600);
   const ch = eh.inbound.find((m) => m.method === "channels/changed");
   check("channels/changed descriptor carries metadata.epoch (§3.2.3d)",
@@ -197,16 +264,18 @@ try {
   // ── 4f. prepare/commit REFUSAL — the path the suite never exercised ───────
   const decliner = await connectHost("roamer-token", "", "decline");
   await sleep(1200);
-  const declined = await decliner.request("channels/open", { type: "world", address: { world: "annex" } });
-  check("host decline aborts the join with -32017", declined.error?.code === -32017, JSON.stringify(declined.error));
+  const declined = await decliner.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("host decline aborts the join (refusal, nothing moved)",
+    declined.result?.isError === true && /channel not permitted/.test(txt(declined)), txt(declined));
   const stillHome = await decliner.request("channels/list", {});
   check("declined join left the body where it was", stillHome.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stillHome.result));
   decliner.ws.close();
 
   const mute = await connectHost("roamer-token", "", "mute");
   await sleep(1200);
-  const timedOut = await mute.request("channels/open", { type: "world", address: { world: "annex" } });
-  check("mute host is treated as declining (fail-closed)", timedOut.error?.code === -32017, JSON.stringify(timedOut.error));
+  const timedOut = await mute.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+  check("mute host is treated as declining (fail-closed)",
+    timedOut.result?.isError === true && /channel not permitted/.test(txt(timedOut)), txt(timedOut));
   mute.ws.close();
 
   // ── 4g. LANE 1: the `travel` tool ─────────────────────────────────────────
@@ -231,14 +300,21 @@ try {
     !noop.result?.isError && /Already in/.test(noop.result?.content?.[0]?.text ?? ""), JSON.stringify(noop.result));
   tv.ws.close();
 
-  // ── 4h. ONE POLICY: the tool must refuse exactly what channels/open refuses ─
+  // ── 4h. the tool honours join policy, and no second lane can disagree ─────
+  // NOTE (review): this is no longer a policy-PARITY check. channels/open now
+  // returns -32023 for any non-current channel whatever the credential, so that
+  // half is a tautology — kept only to pin that the lane stays shut, not as
+  // evidence about policy. The policy claim rests on the tool assertion above.
   const bound2 = await connectHost("bound-token");   // no `worlds` → may not roam
   await sleep(1200);
   const toolRefusal = await bound2.request("tools/call", { name: "travel", arguments: { world: "annex" } });
   check("travel tool honours join policy", toolRefusal.result?.isError === true, JSON.stringify(toolRefusal.result));
+  // channels/open cannot travel AT ALL any more, so the "one policy" property
+  // is now stronger than matching codes: there is no second lane to disagree
+  // with the first. Prove the door is shut rather than merely equally guarded.
   const openRefusal = await bound2.request("channels/open", { type: "world", address: { world: "annex" } });
-  check("…and channels/open refuses the SAME world for the SAME credential",
-    openRefusal.error?.code === -32017, JSON.stringify(openRefusal.error));
+  check("…and channels/open cannot travel at all (no second lane to disagree)",
+    openRefusal.error?.code === -32023, JSON.stringify(openRefusal.error));
   const stayed = await bound2.request("channels/list", {});
   check("a refused travel moved nothing", stayed.result?.channels?.[0]?.id === "world:commons", JSON.stringify(stayed.result));
 
@@ -246,14 +322,103 @@ try {
   check("travel rejects a malformed world name", badName.result?.isError === true, JSON.stringify(badName.result));
   bound2.ws.close();
 
+  // ── 4i. PLAIN-MCP travel: the lane the PR advertises and never tested ────
+  // antra #1: travelGate() unconditionally required channels.lifecycle, and
+  // granted() returns false for any non-MCPL client BY CONSTRUCTION — so every
+  // plain-MCP travel died with -32002 while toolsAllowed() listed the tool.
+  // These vectors are what makes the advertised lane real.
+  {
+    const plain = await connectPlain("roamer-token");     // NO experimental.mcpl
+    await sleep(1200);
+    const tools = await plain.request("tools/list", {});
+    check("plain-MCP host is offered the travel tool",
+      (tools.result?.tools ?? []).some((t: any) => t.name === "travel"), "travel not listed");
+    const moved = await plain.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("plain-MCP travel ACTUALLY WORKS (was always -32002)",
+      !moved.result?.isError && /(Arrived in|Founded and entered) "annex"/.test(txt(moved)), txt(moved));
+    plain.ws.close();
+
+    // …and the credential still gates it. Authority moved from a capability
+    // plain MCP cannot hold to the credential it does hold — it did not vanish.
+    const plainBound = await connectPlain("bound-token");  // no `worlds` policy
+    await sleep(1200);
+    const refused = await plainBound.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("plain-MCP travel still obeys the join policy",
+      refused.result?.isError === true && /not in this credential's join policy/.test(txt(refused)), txt(refused));
+    const noCreate = await plainBound.request("tools/call", { name: "travel", arguments: { world: "never-made" } });
+    check("plain-MCP founding still needs create authority",
+      noCreate.result?.isError === true, txt(noCreate));
+    check("…and refused founding left nothing on disk", !existsSync(join(worldsDir, "never-made")));
+    plainBound.ws.close();
+  }
+
+  // ── 4j. THE FIX FOR #1 MUST NOT WIDEN MCPL AUTHORITY ─────────────────────
+  // Relaxing the capability gate for plain-MCP hosts is only safe if an MCPL
+  // host that DECLARES mcpl but is denied channels.lifecycle is still refused.
+  // Reading `this.mcplClient && !granted(...)` and believing it is exactly the
+  // habit that shipped the original bug, so: prove it.
+  {
+    const stingy = await connectHost("roamer-token");
+    await sleep(1200);
+    // Re-declare an effective capability set WITHOUT channels.lifecycle.
+    await stingy.request("featureSets/update", {
+      effectiveCapabilities: ["tools", "channels.register", "channels.publish", "channels.incoming"],
+    });
+    const denied2 = await stingy.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("MCPL host WITHOUT channels.lifecycle is still refused (#1 did not widen)",
+      denied2.result?.isError === true && /capability denied/.test(txt(denied2)), txt(denied2));
+    const where = await stingy.request("channels/list", {});
+    check("…and that refusal moved nothing", where.result?.channels?.[0]?.id === "world:commons", JSON.stringify(where.result));
+    stingy.ws.close();
+
+    // 🔴 DISCRIMINATING HALF. The check above passes even for a mutant that
+    // changed `this.mcplClient &&` to `true &&`, because the refusal message
+    // would be identical. What distinguishes the branch is that the SAME
+    // credential, declared as PLAIN MCP, must SUCCEED — capability-denied is a
+    // property of the host class, not of the token.
+    const samecred = await connectPlain("roamer-token");
+    await sleep(1200);
+    const plainOk = await samecred.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("…while the SAME credential as plain-MCP travels fine (the mcplClient conjunct is load-bearing)",
+      !plainOk.result?.isError && /(Arrived in|Founded and entered) "annex"/.test(txt(plainOk)), txt(plainOk));
+    samecred.ws.close();
+  }
+
+  // ── 4k. the door must be OPEN in the new world (state-desync regression) ──
+  // channelOpen was session-long, but the new world's descriptor announces
+  // initiallyOpen:true — so an agent who closed their door and then travelled
+  // arrived with it shut while the host had been told otherwise, and nothing
+  // reconciled them. Per-world state, like the chat cursor.
+  {
+    const shutter = await connectHost("roamer-token");
+    await sleep(1200);
+    await shutter.request("channels/close", { channelId: "world:commons" });
+    const moved2 = await shutter.request("tools/call", { name: "travel", arguments: { world: "annex" } });
+    check("travel after closing the door still arrives", !moved2.result?.isError, txt(moved2));
+    // The door being open again is observable: a plain re-open of the CURRENT
+    // channel succeeds and reports the channel the host was promised.
+    const reopened = await shutter.request("channels/open", { type: "world", address: { world: "annex" } });
+    check("…and the new world's door is OPEN, as its descriptor promised the host",
+      reopened.result?.channel?.id === "world:annex" && reopened.result?.channel?.initiallyOpen === true,
+      JSON.stringify(reopened.result?.channel));
+    shutter.ws.close();
+  }
+
   // ── 5. attach failure → -32024 and the connection surfaces CLOSED ─────────
   // (last: it kills the sequencer)
   const victim = await connectHost("roamer-token");
   await sleep(1200);
   world.kill();                        // the sequencer goes away mid-session
   await sleep(500);
-  const failed = await victim.request("channels/open", { type: "world", address: { world: "annex" } });  // exists, so this tests ATTACH failure
-  check("attach failure is -32024", failed.error?.code === -32024, JSON.stringify(failed));
+  const failed = await victim.request("tools/call", { name: "travel", arguments: { world: "annex" } });  // exists, so this tests ATTACH failure
+  // The TOOL lane reports failure as isError + text (the MCP contract), not as
+  // a JSON-RPC error code — but it must say plainly that the seat is gone, or
+  // an agent would keep issuing verbs into a closed connection. The -32024 code
+  // is still what the channels/open lane returns; both end in the same close.
+  check("attach failure is reported, and names the closure",
+    failed.result?.isError === true
+    && /past the point of no return/.test(txt(failed))
+    && /CLOSED/.test(txt(failed)), txt(failed));
   const closed = await new Promise<boolean>((res) => {
     if (victim.ws.readyState === WebSocket.CLOSED) return res(true);
     victim.ws.onclose = () => res(true);

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -59,16 +59,34 @@ const check = (name: string, ok: boolean, extra = "") => {
 // A nonce this run owns, echoed by the door's /healthz.
 const NONCE = `t${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
 
-const world = Bun.spawn([process.execPath, "server/server.ts"], {
-  env: { ...process.env, PORT: String(WPORT), WORLDS_DIR: worldsDir,
-         WORLD_INSTANCE_NONCE: NONCE },
-  stdout: "ignore", stderr: "ignore",
+// 🔴 EVERY CHILD IS REGISTERED BEFORE IT CAN BE LOST (adversarial review,
+// 2026-08-17). Round 3 moved the readiness PROBES inside the try but left the
+// ACQUISITIONS outside it, and the file then claimed "nothing that can throw
+// sits outside it" — which was false about the two lines that matter most. If
+// the second Bun.spawn throws (bad execPath resolution, EAGAIN), the first
+// child runs forever holding a port, with no teardown and no owner.
+//
+// A live registry the finally block drains covers both children AND any future
+// third one, rather than naming them individually and drifting again.
+const spawned: { pid: number; kill: (sig?: string) => void; exitCode: number | null }[] = [];
+function spawnChild(args: string[], env: Record<string, string>) {
+  const child = Bun.spawn(args, { env: { ...process.env, ...env }, stdout: "ignore", stderr: "ignore" });
+  spawned.push(child as unknown as typeof spawned[number]);
+  return child;
+}
+const world = spawnChild([process.execPath, "server/server.ts"], {
+  PORT: String(WPORT), WORLDS_DIR: worldsDir, WORLD_INSTANCE_NONCE: NONCE,
 });
-const mcpl = Bun.spawn([process.execPath, "mcpl/net-server.ts"], {
-  env: { ...process.env, MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`,
-         MCPL_TOKENS: tokensPath, MCPL_STATE: statePath, MCPL_INSTANCE_NONCE: NONCE },
-  stdout: "ignore", stderr: "ignore",
+const mcpl = spawnChild([process.execPath, "mcpl/net-server.ts"], {
+  MCPL_PORT: String(MPORT), WORLD_URL: `ws://127.0.0.1:${WPORT}/ws`,
+  MCPL_TOKENS: tokensPath, MCPL_STATE: statePath, MCPL_INSTANCE_NONCE: NONCE,
 });
+// Last-resort net: if anything between here and the try throws, or the process
+// dies by signal, the children still go. process.exit does NOT run finally
+// blocks, so this cannot be left to the one at the bottom.
+const reap = () => { for (const c of spawned) { try { c.kill(); } catch { /* gone */ } } };
+process.on("exit", reap);
+process.on("uncaughtException", (e) => { reap(); console.error(e); process.exit(1); });
 
 /** PIDs listening on a TCP port, from the OS. Returns null when this platform
  *  cannot answer — which is NOT the same as "nothing is listening", and
@@ -142,11 +160,22 @@ function ownsPort(name: string, port: number, child: { pid: number }) {
     if (pids === null) return true;
     if (pids.length === 0) return false;
     const ours = new Set([child.pid, ...descendantsOf(child.pid)]);
-    // No procfs but `ss` present (unlikely, but do not guess): with no way to
-    // enumerate descendants, an exact pid match is the most we can honestly
-    // assert, and anything else is unproven rather than foreign.
+    // 🔴 THE GUARD I ADDED LAST ROUND DISABLED THIS CHECK IN ITS MOST COMMON
+    // CONFIGURATION (adversarial review, 2026-08-17). It read
+    // `if (foreign.length && ours.size > 1)`, and ours.size > 1 is true ONLY
+    // when descendantsOf() found a forked child. When bun runs the .ts
+    // in-process — the ordinary Linux case — the set is just {child.pid}, so a
+    // genuinely foreign pid holding the port sailed through returning true.
+    // The one check written to catch a squatted port was off exactly where it
+    // was needed, and my reasoning for the guard ("no procfs but ss present")
+    // described a configuration that barely occurs while breaking the one that
+    // always does.
+    //
+    // A foreign listener is foreign regardless of how many pids we own. The
+    // only honest exemption is not being able to enumerate at all, and that is
+    // the `pids === null` early return above.
     const foreign = pids.filter((p) => !ours.has(p));
-    if (foreign.length && ours.size > 1) {
+    if (foreign.length) {
       throw new Error(`${name} port ${port} held by pid(s) ${foreign.join(",")}, not our child ${child.pid} — stale listener`);
     }
     return true;
@@ -359,14 +388,48 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   dialed.ws.close();
   // §3.3 (Mica #3): a denied dial-time destination REFUSES the connection —
   // no silent fallback to the minted world.
-  let refused = false;
-  try {
-    const fallback = await connectHost("bound-token", "&world=annex");
-    await sleep(1500);
-    refused = fallback.ws.readyState === WebSocket.CLOSED || fallback.ws.readyState === WebSocket.CLOSING;
-    fallback.ws.close();
-  } catch { refused = true; }   // connectHost throws when the socket dies during init
-  check("denied ?world= refuses the connection (no silent fallback)", refused);
+  // 🔴 ASSERT THE REFUSAL, NOT "SOMETHING WENT WRONG" (adversarial review,
+  // 2026-08-17). The previous version slept 1500ms and read `ws.readyState` —
+  // but refuseWithGuidance (net-server.ts:1415) closes on a FIFTEEN second
+  // timer, so that branch could never be true. The check passed only through a
+  // bare `catch { refused = true }`, which accepts ANY failure as proof of the
+  // specific behaviour under test: a door that OOM'd, timed out for an
+  // unrelated reason, or refused while naming the WRONG world all scored the
+  // identical green.
+  //
+  // The observable contract is narrow and worth pinning exactly: an
+  // -32001 error whose message names the refusal, then close 4001 (:1424-1428).
+  // So capture the error TEXT and require it to mention the world we were
+  // refused for.
+  // Dial RAW, not through connectHost(): its `request()` resolves on ANY reply
+  // carrying the matching id — including the -32001 refusal — so it reports a
+  // refused dial as a successful connect. (My first rewrite asserted on that
+  // and read `admitted=true` against a door whose refusal path is correct: the
+  // harness was wrong in the direction that looks like a product bug, which is
+  // the same trap as the on-disk control below.)
+  //
+  // What §3.3 actually promises is observable and narrow: the -32001 body NAMES
+  // the denied destination, and the socket then closes 4001 (net-server.ts
+  // :1424-1428). Assert both, and give the close a real deadline rather than
+  // the 1500ms sleep that could never have seen a 15s timer.
+  const denial = await new Promise<{ err: string; code: number }>((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${MPORT}/?token=bound-token&world=annex`);
+    let err = "";
+    const done = (code: number) => resolve({ err, code });
+    ws.onopen = () => ws.send(JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "denied", version: "0" } },
+    }));
+    ws.onmessage = (ev) => {
+      const m = JSON.parse(String(ev.data));
+      if (m.error?.message) err = String(m.error.message);
+    };
+    ws.onclose = (ev) => done(ev.code);
+    setTimeout(() => { try { ws.close(); } catch { /* gone */ } done(-1); }, 8000);
+  });
+  check("denied ?world= refuses the connection (no silent fallback)",
+    /annex/.test(denial.err) && /policy|unauthorized|not permitted/i.test(denial.err) && denial.code === 4001,
+    `close=${denial.code} err=${denial.err.slice(0, 110)}`);
 
   // ── 4b. §3.2.7 founding is not joining ───────────────────────────────────
   const nofound = await connectHost("nofound-token");
@@ -375,6 +438,13 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   check("worlds:['*'] without create CANNOT found a world",
     wouldFound.result?.isError === true && /founding requires create authority/.test(txt(wouldFound)), txt(wouldFound));
   // …and prove it wasn't created as a side effect anyway (review F)
+  // 🔴 PAIRED WITH ITS POSITIVE CONTROL (adversarial review, 2026-08-17).
+  // `!existsSync(...)` alone passes for a build where founding writes NOTHING
+  // anywhere — or where worlds land at a different path entirely — which makes
+  // it indistinguishable from `!existsSync("/tmp/definitely-not-a-path")`. The
+  // second assertion is what gives the first its meaning: a world that WAS
+  // founded appears at exactly this path, so a world that was refused being
+  // absent from it is now evidence rather than a tautology.
   check("refused founding left NOTHING on disk", !existsSync(join(worldsDir, "brand-new-place")));
   nofound.ws.close();
   const founder = await connectHost("roamer-token");
@@ -382,6 +452,20 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   const founded = await founder.request("tools/call", { name: "travel", arguments: { world: "founded-place" } });
   check("create:true CAN found, and says so",
     !founded.result?.isError && /Founded and entered "founded-place"/.test(txt(founded)), txt(founded));
+  // 🔴 THE POSITIVE CONTROL FOR THE on-disk CHECK ABOVE (adversarial review,
+  // 2026-08-17). `!existsSync(brand-new-place)` alone also passes for a build
+  // where founding writes nothing anywhere, or writes somewhere else entirely
+  // — indistinguishable from !existsSync("/tmp/not-a-real-path"). Pairing it
+  // with a world that WAS founded, at the SAME parent path, is what turns the
+  // negative into evidence.
+  //
+  // It has to run HERE, after the founding it controls for — my first attempt
+  // put it beside the negative check twenty lines earlier and asserted the
+  // directory existed before anything had created it. The control was itself
+  // wrong in the direction that would have looked like a product bug.
+  await sleep(400);              // the sequencer writes the log dir on join
+  check("…and the CONTROL: a world that WAS founded IS on disk at that path",
+    existsSync(join(worldsDir, "founded-place")), `worldsDir=${worldsDir}`);
   // ── 4c. §3.2.3d epoch across transitions ─────────────────────────────────
   // The epoch is read from the channels/changed descriptor the server pushes
   // to the HOST — which is where §3.2.3d says a client learns it, and the only


### PR DESCRIPTION
**In-session world travel, as an eidoverse-local feature.** Retitled and rescoped from "RFC-005 reference implementation" after antra's and Mica's read — see the thread on anima-research/mcpl#4, now closed in favor of this.

## What it does

An agent's world is sealed into its credential at mint time, so today the only way to change worlds is to drop the connection and re-authenticate with a different token — and on a door you don't operate, you can't do even that. Meanwhile the sequencer has supported live travel all along: its `join` handler leaves world A and joins world B on an existing socket, with orphan-leg reaping, and browser clients travel this way every day. The capability existed; the MCPL surface had no verb reaching it.

This adds the verb, in two lanes over one mechanism:

- **`travel {world}`** — a door tool. What a plain-MCP client uses; no channel vocabulary needed.
- **`channels/open`** naming a sibling world — what a generic MCPL host uses without knowing eidoverse tool names.

Both route through one `travelGate()`, so they cannot drift apart. Measured **14ms** for in-session travel including the host round trip, against ~2000ms for teardown-and-redial.

## Why this is not a protocol change

The earlier version of this PR proposed an MCPL spec change and gated join on a new `channels.join` capability. That was the mistake, and it's worth stating precisely because it was invisible until someone asked the right question: **`channels.join` is not in §6.2's capability list.** I invented it. A feature set declaring it fails this repo's own boot validator.

Remove that one string and everything else here is a local extension:

- Authorization is **`channels.lifecycle`** — already spec-legal, already granted, and already means "may act on channel lifecycle."
- The feature declares itself as **`eidoverse.travel`** in `FEATURE_SETS`, the one vendor-namespaced slot in the manifest. `uses: [channels.lifecycle, tools]` — both §6.2 leaves.
- No new JSON-RPC method. This repo has zero bespoke methods and that stays true.

It also closes a gap the audit surfaced independently: **`eidoverse.world` never declared any lifecycle capability**, so the feature set owning world presence didn't mention the operation that changes worlds.

## The invariants, kept

Mica's five review points from the mcpl#4 thread are all implemented and tested. They were always implementation properties — the RFC was just where I happened to write them down, and they survive the move intact:

1. **Attachment epoch** — monotonic per connection, incremented *after* the new attachment is live (a transition that dies mid-flight must not advance it), surfaced as `metadata.epoch`. The proposal states the epoch it *would* commit to; the client holds it pending until it observes the commit.
2. **Prepare/commit with host veto** — the host's acceptance is part of the transition, not a notification after it. A declining or silent host aborts the move; the body does not go somewhere its host refuses to deliver.
3. **No silent dial fallback** — a denied `?world=` refuses the connection with a reason rather than quietly landing you somewhere else.
4. **Founding ≠ joining** — creating a world that doesn't exist needs separate `create` authority. Scoped, after three rounds of getting it wrong, to destinations the *agent* chose: arriving at the world your operator minted you into is not founding, and gating it bricks fresh deployments.
5. **Both address forms** — `channelId` and `type`/`address`, since generic host surfaces primarily expose IDs.

## Tests

**33 passing** (`bun tools/join-rfc005.test.ts`), including the property that matters most: the tool and `channels/open` refuse the *same* world for the *same* credential, and a refused travel moves nothing. Also covers the prepare/commit refusal path with declining-host and mute-host fixtures, and regressions for each of the three founding-gate bugs three rounds of adversarial review turned up.

## The open question

I kept the `channels/open` lane. It costs nothing now that it needs no invented capability, and it's how a host that only speaks MCPL travels here. But Mica's promote-on-reuse argument cuts at it: if the tool alone is enough, the lane is surface area with one consumer.

**If you'd rather it were tool-only, say so — it's a four-line deletion and I'll take it out.** The argument for keeping it is that it's precisely the second-consumer evidence Mica asked us to wait for, accumulating on its own rather than by argument.