### PR TITLE
headless bodies run Bullet, and land on the floor

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -438,6 +438,11 @@ body.touch #touch { display: block; }
   margin: 2px 0 0; padding: 6px 7px; font: 11px/1.45 ui-monospace, monospace;
   color: var(--dim); background: rgba(0,0,0,0.25); border-radius: 5px;
   white-space: pre; overflow-x: auto;
+  /* The readout is the tallest thing in the panel and the LAST: as a flex
+     child it shrank instead of overflowing, so its final lines were clipped
+     inside the box and the stack's scrollbar hit bottom without ever showing
+     them. Let it keep its natural height and let the stack do the scrolling. */
+  flex: 0 0 auto;
 }
 </style>
 <script type="importmap">

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -176,6 +176,11 @@ const MASS_FRAC = {
   upperArm: 0.028, lowerArm: 0.016, hand: 0.006,
   upperLeg: 0.100, lowerLeg: 0.047, foot: 0.015,
 };
+// Depth as a fraction of trunk half-width. Was 0.6 — a torso flattened like a
+// plank of wood. The proxy-mesh boxes this rig was ported from are 0.096-0.110
+// of height deep against 0.093-0.125 wide: a trunk is very nearly as deep as it
+// is broad.
+const TRUNK_DEPTH = 0.88;
 const REAL_H = 1.70;            // rigdef.py: reference height for the mass budget
 const BODY_KG = 62.0;           // at REAL_H, scaled by (H/1.70)³
 const FINGER_MASS_FRAC = 0.0016; // per phalanx body (~20 g at 62 kg); thumb ×1.4
@@ -224,21 +229,42 @@ const GRAB_CLAMP_X = 1.2;       // × total mass
 // the two sides of the body mirror, and a hard-coded sign is wrong on one
 // (rapierdoll's law; also the source's thumb lesson).
 //   ref: what X is crossed against — 'fwd' | 'up' | 'palm' | 'pinky'
-const JOINT_SPECS = {
-  // trunk (rigdef.py: spine ±25/±20/±25, chest ±20/±20/±20). Modest ranges —
-  // a spine is stiff — but the difference between these and NO joint is the
-  // difference between a body that folds and a plank.
-  spine: { ref: 'fwd', x: [-25, 25], twist: 20, z: [-25, 25] },
-  chest: { ref: 'fwd', x: [-20, 20], twist: 20, z: [-20, 20] },
-  head: { ref: 'fwd', x: [-40, 40], twist: 45, z: [-35, 35] },
-  upperArm: { ref: 'fwd', x: [-85, 85], twist: 70, z: [-85, 85] },
+export const JOINT_SPECS = {
+  // TUNED BY HAND, in-world, against a real body falling — not derived. The
+  // debug panel's "joint limits (live)" section retunes running constraints, so
+  // these came from watching and adjusting rather than from argument. Where
+  // they depart from rigdef.py that is deliberate: rigdef describes a living
+  // spine's range, and a ragdoll with no muscle tone spends all of it.
+  //
+  // Two axes are LOCKED at zero (trunk twist, knee side-bend). A locked axis is
+  // exempt from the born-widening below, which would otherwise hand back
+  // ±BUILD_WIDEN of the freedom the zero was there to remove.
+  spine: { ref: 'fwd', x: [-10, 10], twist: 0, z: [-4, 4] },
+  chest: { ref: 'fwd', x: [-20, 20], twist: 0, z: [-6, 6] },
+  head: { ref: 'fwd', x: [-33, 33], twist: 24, z: [-19, 19] },
+  upperArm: { ref: 'fwd', x: [-85, 85], twist: 56, z: [-85, 85] },
   lowerArm: { ref: 'fwd', flex: 145, ext: 2, want: 'fwd', twist: 5, z: [-5, 5] },
-  // wrist, translated by MEANING not by letter: the source measured flexion
-  // ±45, deviation ±15, twist ±8 (its own X/Z were "the other way round")
   hand: { ref: 'palm', flex: 45, ext: 45, want: 'palm', twist: 8, z: [-15, 15] },
+  // THE ONE ROW NOT AS TUNED. The hand-tuned hip was flex 90 / ext 8 /
+  // twist 0 / z ±13, and it looks better in the world — but narrowing the hip
+  // that far makes the KNEE fold backwards: 125 degrees of "hyperextension" on
+  // all three rigs, which tools/ammodoll-test.ts catches and which is the same
+  // thing as "a joint gets twisted and then is stuck like that".
+  //
+  // It is not the knee bending too far. The magnitude tracks the knee's own
+  // flexion limit exactly (flex 123 -> 125 deg, flex 145 -> 146 deg): the knee
+  // is sitting AT its legal limit, measured on the wrong side of Bullet's
+  // angular wrap, and it stays there. A hip that cannot rotate about the leg's
+  // axis has to send that rotation somewhere and the knee is next in the chain.
+  // Measured: restoring ext alone leaves 48-83 deg, twist alone 77 deg on two
+  // rigs; only all three together come back clean.
+  //
+  // The real fix is upstream of any of these numbers — build the constraint
+  // frames at the pose like the source rig does, so joints operate near zero
+  // where no wrap point is reachable. Put the tuned row back once that lands.
   upperLeg: { ref: 'fwd', flex: 90, ext: 45, want: 'fwd', twist: 30, z: [-45, 45] },
-  lowerLeg: { ref: 'fwd', flex: 145, ext: 0, want: 'back', twist: 5, z: [-5, 5] },
-  foot: { ref: 'up', x: [-35, 35], twist: 15, z: [-20, 20] },
+  lowerLeg: { ref: 'fwd', flex: 123, ext: 0, want: 'back', twist: 3, z: [0, 0] },
+  foot: { ref: 'up', x: [-35, 35], twist: 12, z: [-12, 12] },
   fingerProx: { ref: 'palm', flex: 90, ext: 6, want: 'palm', twist: 8, z: [-12, 12] },
   fingerMid: { ref: 'palm', flex: 100, ext: 0, want: 'palm', twist: 4, z: [-4, 4] },
   thumb: { ref: 'pinky', flex: 55, ext: 10, want: 'pinky', twist: 12, z: [-25, 25] },
@@ -453,7 +479,18 @@ export class AmmoRagdoll {
     const massScale = BODY_KG * (H / REAL_H) ** 3;
     const span = restP.leftUpperArm && restP.rightUpperArm
       ? restP.leftUpperArm.distanceTo(restP.rightUpperArm) : H * 0.3;
-    const torsoR = Math.max(0.05, span * 0.22);
+    // Trunk half-width. span is the distance between the two SHOULDER JOINTS,
+    // which is a good deal narrower than a torso, so x0.22 of it made a body
+    // 0.12m wide on a 1.5m rig. Measured against the source's proxy-mesh boxes
+    // (rig.json, normalised by height): pelvis/spine/chest run 0.093-0.125 of
+    // height WIDE and 0.096-0.110 DEEP. Take the wider of the two estimates so
+    // a rig with genuinely broad shoulders still governs its own width.
+    //
+    // This went unnoticed while the trunk was one fused body whose inertia came
+    // from btCompoundShape's AABB — the approximation inflated it and hid the
+    // undersized boxes. With real inertia the dimensions finally matter, and an
+    // undersized trunk is a floppy one.
+    const torsoR = Math.max(0.05, span * 0.22, H * 0.055);
 
     // ---- extrapolate missing tips so hands/feet can be bodies --------------
     // rigdef's skeleton-only fallback sizes a box from the bone alone; a VRM
@@ -695,7 +732,7 @@ export class AmmoRagdoll {
       const restMid = ra.clone().add(rb2).multiplyScalar(0.5);
       const liveMid = live[a].clone().add(live[b2]).multiplyScalar(0.5);
       const body = mkBody(MASS_FRAC[part] * massScale, liveMid, torsoQ,
-        [boxFor(restMid, ra, rb2, torsoR, torsoR * 0.6)], false);
+        [boxFor(restMid, ra, rb2, torsoR, torsoR * TRUNK_DEPTH)], false);
       const seg = {
         key, a, b: b2, body, torso: true,
         restA: ra.clone(), restB: rb2.clone(),
@@ -712,7 +749,7 @@ export class AmmoRagdoll {
     // their torso entirely.
     if (!trunkBuilt) {
       const body = mkBody(MASS_FRAC.torso * massScale, liveTorsoMid, torsoQ,
-        [boxFor(restTorsoMid, restP.hips, restUpper, torsoR, torsoR * 0.6)], false);
+        [boxFor(restTorsoMid, restP.hips, restUpper, torsoR, torsoR * TRUNK_DEPTH)], false);
       segMeta.set('hips|spine', { body, restOrigin: restTorsoMid });
       segMeta.set('chest|neck', { body, restOrigin: restTorsoMid });
       this.segs.set('hips|spine', {
@@ -775,7 +812,11 @@ export class AmmoRagdoll {
       const boxEnd = isHead
         ? rb2.clone().addScaledVector(
           rb2.clone().sub(ra).normalize(),
-          Math.min(0.22, Math.max(0.08, H * 0.11)))
+          // The skull runs on past the head bone — but only to a real crown.
+          // H*0.11 on top of the neck->head bone made a 0.27m head on a 1.5m
+          // rig; the proxy mesh measures a head 0.124 of height LONG, so the
+          // extension is what is LEFT after the bone itself, not another head.
+          Math.min(0.16, Math.max(0.05, H * 0.124 - rb2.distanceTo(ra))))
         : rb2;
       const wHead = isHead ? Math.max(w, H * 0.05) : w;
       const dHead = isHead ? Math.max(w, H * 0.058) : w;
@@ -947,6 +988,11 @@ export class AmmoRagdoll {
       const cap = seedVel ? BUILD_WIDEN : Infinity;
       const anatLo = lo.slice(), anatHi = hi.slice();
       for (let i = 0; i < 3; i++) {
+        // An axis the table LOCKS (lo === hi) stays locked. Widening it to
+        // contain the born pose would quietly hand back +/-BUILD_WIDEN of the
+        // very freedom the zero was there to remove — 6.9 degrees per joint,
+        // which up a three-body trunk is most of a spine's worth of corkscrew.
+        if (anatHi[i] - anatLo[i] === 0) continue;
         lo[i] = Math.max(anatLo[i] - cap, Math.min(lo[i], born[i] - BUILD_WIDEN));
         hi[i] = Math.min(anatHi[i] + cap, Math.max(hi[i], born[i] + BUILD_WIDEN));
       }
@@ -1002,6 +1048,9 @@ export class AmmoRagdoll {
         name, spec, axisX: x.clone(), axisY: y.clone(), axisZ: z.clone(),
         lo: [...lo], hi: [...hi], born: [...born], mid: [...mid],
         parentBody, childBody, basisA, basisB: basis.clone(),
+        // retune() needs these: the constraint to talk to, and which way +X
+        // flexes on THIS side (derived from geometry at build, never assumed).
+        con, positiveFlexes: S.flex != null ? xhi > 0 : null,
       });
       return con;
     };
@@ -1213,6 +1262,14 @@ export class AmmoRagdoll {
         bone: seg.a, child: seg.b, node: bn, parent: bn.parent,
         restDir: refDir.normalize(),
         restQuat: bn.getWorldQuaternion(new THREE.Quaternion()),
+        // ...and the BODY, plus the orientation it was born holding. A bone
+        // driven from its direction alone cannot express roll (see step); these
+        // two are what make roll recoverable. q0 is identity on a fresh build,
+        // where live IS rest — but a seeded body is built mid-tumble, and
+        // composing its born orientation onto itself is the "renders at twice
+        // its offset" bug this table's own header warns about.
+        body: seg.body,
+        q0inv: quatOf2(seg.body, new THREE.Quaternion()).invert(),
       });
     }
     this.drivenBones = new Set(this.drive.map((d) => d.bone));
@@ -1329,6 +1386,47 @@ export class AmmoRagdoll {
       }
     }
     return out;
+  }
+
+  /** Re-apply JOINT_SPECS to the LIVE constraints, no rebuild.
+   *
+   *  Limits are baked in at construction, so tuning a table by hand and waiting
+   *  for the next fall to see it is a slow way to find a number. This pushes
+   *  the current table straight into the running joints.
+   *
+   *  The constraint frames still carry the midpoint they were BUILT with, so
+   *  the same midpoint is subtracted back off here — which keeps the numbers
+   *  meaning anatomical degrees. What it does not re-do is the frame rotation
+   *  itself, so a range retuned to be wildly more asymmetric than it was built
+   *  sits closer to Bullet's wrap point than a fresh build would. Tuned values
+   *  are meant to be written into the table and rebuilt from; this is the dial,
+   *  not the destination.
+   */
+  retune() {
+    if (!AMMO) return 0;
+    let n = 0;
+    for (const J of this.jointMeta ?? []) {
+      const S = JOINT_SPECS[J.spec];
+      if (!S || !J.con) continue;
+      let xlo, xhi;
+      if (S.flex != null) {
+        xlo = (J.positiveFlexes ? -S.ext : -S.flex) * DEG;
+        xhi = (J.positiveFlexes ? S.flex : S.ext) * DEG;
+      } else {
+        xlo = S.x[0] * DEG; xhi = S.x[1] * DEG;
+      }
+      const lo = [xlo, -S.twist * DEG, S.z[0] * DEG];
+      const hi = [xhi, S.twist * DEG, S.z[1] * DEG];
+      _bv1.setValue(lo[0] - J.mid[0], lo[1] - J.mid[1], lo[2] - J.mid[2]);
+      J.con.setAngularLowerLimit(_bv1);
+      _bv1.setValue(hi[0] - J.mid[0], hi[1] - J.mid[1], hi[2] - J.mid[2]);
+      J.con.setAngularUpperLimit(_bv1);
+      J.lo = lo; J.hi = hi;
+      n++;
+    }
+    // a sleeping body will not notice its joints changed under it
+    for (const b of this._bodies) b.activate();
+    return n;
   }
 
   jointAngles() {
@@ -1549,10 +1647,21 @@ export class AmmoRagdoll {
     for (const d of this.drive) {
       const bp = this.p[d.bone], cp = this.p[d.child];
       if (!bp || !cp) continue;
-      _b.copy(cp).sub(bp);
-      if (_b.lengthSq() < 1e-6) continue;
-      _b.normalize();
-      shortestArc(d.restDir, _b, _q).multiply(d.restQuat);
+      // The BODY's rotation, not the bone's direction.
+      //
+      // This used to be shortestArc(restDir, liveDir) — the minimal rotation
+      // taking the bone from where it pointed to where it points now. That is
+      // a pure SWING: it reproduces the direction exactly and discards roll
+      // about the bone's own axis completely. So a thigh could be pointing
+      // perfectly while its knee faced wherever shortestArc happened to land,
+      // which reads as "the leg ended up backwards" — and no twist limit can
+      // touch it, because the sim's twist was never what was wrong. Same
+      // reason a forearm never showed pronation.
+      //
+      // Bodies are rest-aligned, so the body's rotation since it was built IS
+      // the bone's rotation since it was built. The hair segments (§118) were
+      // already driven this way; the core skeleton was not.
+      quatOf2(d.body, _q).multiply(d.q0inv).multiply(d.restQuat);
       d.parent.getWorldQuaternion(_qp).invert();
       _qp.multiply(_q);
       d.node.quaternion.copy(_qp);

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -192,6 +192,10 @@ const FINGER_TENDON = 8.0;
 const ERP_LIMIT = 0.35;         // source default: how hard limits are held
 const BT_CONSTRAINT_STOP_ERP = 3; // this build's setParam id (source, verbatim)
 const ACTIVE_TAG = 1;
+// Bullet's own enum values. ammo.js does not export them as constants, and an
+// undefined global here bundles clean and throws at the first hair lock.
+const CF_KINEMATIC = 2;            // btCollisionObject::CF_KINEMATIC_OBJECT
+const DISABLE_DEACTIVATION = 4;    // never sleep — a kinematic anchor must not
 
 const LIN_DAMP = 0.12;          // source setDamping(0.12, —)
 // 0.7, not the source's 0.45: rapierdoll's validated value for this regime.
@@ -229,6 +233,32 @@ const GRAB_CLAMP_X = 1.2;       // × total mass
 // the two sides of the body mirror, and a hard-coded sign is wrong on one
 // (rapierdoll's law; also the source's thumb lesson).
 //   ref: what X is crossed against — 'fwd' | 'up' | 'palm' | 'pinky'
+/** Hair tuning, live. The values are the source playground's slider defaults
+ *  — except where they are DIMENSIONAL, which is the trap: that rig works in a
+ *  unit-scaled world (height 0.999, gravity -5.7664) and this one in real
+ *  metres at 1.7m and -9.81. Dimensionless quantities (damping, the gravity
+ *  FRACTION, the limit ramp) port straight across; mass does not — it goes as
+ *  length cubed, so the source's 3 g is ~14.7 g here. Tune in-world and copy
+ *  the table back out. */
+export const HAIR_TUNING = {
+  // TUNED IN-WORLD, on a falling body, with the panel's sliders — not derived.
+  // Worth saying that these landed a long way from the source playground's
+  // defaults (mass 3 g, tension 8, damping 0.6, gravity 0.45, limit 25,
+  // rootExp 1.0), and that transplanting those verbatim did NOT reproduce its
+  // look. Some of that is scale — the source works unit-scaled at height 0.999
+  // and gravity -5.7664 where this is real metres at 1.7 m and -9.81, so mass
+  // and stiffness needed converting and the dimensionless ones did not — but
+  // not all of it: full gravity and a root-heavy ramp (rootExp < 1) were found
+  // by eye, against theory. Hair is the one system here with no honest headless
+  // metric, so the eye is the instrument.
+  mass: 0.022,      // kg per segment
+  tension: 20,      // 6DOF angular spring stiffness
+  damping: 0.22,    // both the spring's and the body's angular damping
+  gravity: 1.5,     // fraction of world gravity — heavier than real, and right
+  limit: 75,        // degrees at the TIP
+  rootExp: 0.4,     // ramp exponent: lim = limit * (j/n)^rootExp
+};
+
 export const JOINT_SPECS = {
   // TUNED BY HAND, in-world, against a real body falling — not derived. The
   // debug panel's "joint limits (live)" section retunes running constraints, so
@@ -697,9 +727,13 @@ export class AmmoRagdoll {
 
     // a box spanning ra→rb in REST coordinates, expressed local to a body
     // whose rest origin is `origin` (identity orientation at rest)
-    const boxFor = (origin, ra, rb2, halfW, halfD = halfW) => {
+    // minLen: the 0.04 floor is a LIMB's — it stops a stubby bone becoming a
+    // degenerate box. Applied to hair it inflates a 1cm segment into a 4cm bar,
+    // and inertia goes as length SQUARED, so the shortest segments carried ~15x
+    // the rotational inertia they should. A lock of five 4cm bars is a stick.
+    const boxFor = (origin, ra, rb2, halfW, halfD = halfW, minLen = 0.04) => {
       const dir = rb2.clone().sub(ra);
-      const len = Math.max(dir.length(), 0.04);
+      const len = Math.max(dir.length(), minLen);
       const mid = ra.clone().add(rb2).multiplyScalar(0.5).sub(origin);
       return { he: new THREE.Vector3(halfW, len / 2, halfD), t: mid, q: frameQuat(dir) };
     };
@@ -1188,13 +1222,68 @@ export class AmmoRagdoll {
         chains.get(m[1]).push({ i: Number(m[2]), node: nd });
       }
       if (headSeg && chains.size) {
+        // The combed pose, captured ONCE per avatar and never re-derived.
+        //
+        // This block used to read whatever pose the hair happened to be in and
+        // call setEquilibriumPoint() on it. After a tumble that pose IS the
+        // tumble, so "combed" was redefined as "however it looked just then" —
+        // and since every drag release rebuilds, the crumple ratcheted in and
+        // outlived the ragdoll entirely. HANDOFF.md names this: "Never rebuild
+        // a rig from a simulated pose."
+        //
+        // Stored on the AVATAR, not the doll, because the doll is what keeps
+        // being rebuilt.
+        if (!avatar.__hairRest) {
+          const rest = new Map();
+          for (const [, list0] of chains) {
+            for (const it of list0) rest.set(it.node, it.node.quaternion.clone());
+          }
+          avatar.__hairRest = rest;
+        }
+        // ...and start combed, not mid-tumble.
+        for (const [nd0, q0] of avatar.__hairRest) nd0.quaternion.copy(q0);
+        avatar.root.updateMatrixWorld(true);
         const headGroup = this._groupOf.get(headSeg.body) ?? G_STATIC;
         const R = Math.max(0.004 * H, 0.004);
-        const HAIR_LIM = 25 * DEG, HAIR_ROOT = 1.5, HAIR_GRAV = 0.55;
+        // The source playground's DEFAULTS, transplanted. Where this port
+        // guessed, it guessed like a FINGER — hair is built with isFinger=true,
+        // so it inherited the finger damping and the finger collision group,
+        // and the numbers below had drifted from the ones the hair was actually
+        // tuned with. Each value here is the source's slider default; see
+        // HANDOFF.md "Hair physics" for what each was measured against.
+        const HT = HAIR_TUNING;      // live — see retuneHair()
+        const HAIR_LIM = HT.limit * DEG, HAIR_ROOT = HT.rootExp;
+        const HAIR_GRAV = HT.gravity, HAIR_MASS = HT.mass;
+        const HAIR_TENS = HT.tension, HAIR_DAMP = HT.damping;
         let built = 0;
+        this._hairAnchors = [];
         for (const [, list] of chains) {
           list.sort((x2, y2) => x2.i - y2.i);
-          let parentBody = headSeg.body;
+          // A KINEMATIC anchor per lock, not the dynamic head.
+          //
+          // Springing a lock's root to the head body makes a loop: every jitter
+          // and every collision impulse on the head is injected into all 75
+          // locks, and the locks' reaction torques feed back into the head. The
+          // source hangs each lock from a mass-0 kinematic box that touches
+          // nothing and is re-driven from the skeleton before each step —
+          // infinitely stiff, perfectly smooth, and one-way.
+          const rootW = list[0].node.getWorldPosition(new THREE.Vector3());
+          const aShape = keep(new AMMO.btBoxShape(new AMMO.btVector3(R, R, R)));
+          _bt1.setIdentity();
+          _bv1.setValue(rootW.x, rootW.y, rootW.z); _bt1.setOrigin(_bv1);
+          const aMs = keep(new AMMO.btDefaultMotionState(_bt1));
+          _bv1.setValue(0, 0, 0);
+          const aCi = keep(new AMMO.btRigidBodyConstructionInfo(0, aMs, aShape, _bv1));
+          const anchor = keep(new AMMO.btRigidBody(aCi));
+          anchor.setCollisionFlags(anchor.getCollisionFlags() | CF_KINEMATIC);
+          anchor.setActivationState(DISABLE_DEACTIVATION);
+          this.world.addRigidBody(anchor, G_FINGER, 0);   // mask 0: touches nothing
+          this._bodies.push(anchor);
+          // where the anchor sits in the HEAD's frame, so it can be carried
+          this._hairAnchors.push({
+            anchor, head: headSeg.body, local: localOf(headSeg.body, rootW),
+          });
+          let parentBody = anchor;
           let prevLen = 0.05;
           for (let j2 = 0; j2 < list.length; j2++) {
             const nd = list[j2].node;
@@ -1205,15 +1294,38 @@ export class AmmoRagdoll {
             const len = Math.max(aW.distanceTo(bW), 0.015);
             prevLen = len;
             const mid = aW.clone().add(bW).multiplyScalar(0.5);
-            const body = mkBody(0.01, mid, new THREE.Quaternion(),
-              [boxFor(mid, aW, bW, R)], true);
-            body.setDamping(0.25, 0.9);
+            const body = mkBody(HAIR_MASS, mid, new THREE.Quaternion(),
+              [boxFor(mid, aW, bW, R, R, len)], true);
+            // Angular damping 0.9 was the finger constant. Per Bullet's
+            // w *= (1-d)^dt, 0.9 bleeds angular momentum ~2.5x faster per step
+            // than 0.6 — hair that cannot carry a swing through its arc reads
+            // as rigid, and then snaps between poses instead of flowing.
+            body.setDamping(0.25, HAIR_DAMP);
+            // Hair does not bounce; it just stops. The body defaults are a
+            // LIMB's (friction 0.85, restitution 0.03, rolling 0.05) and give
+            // stick-slip chatter against the scalp.
+            body.setFriction(0.3);
+            body.setRestitution(0.0);
+            body.setRollingFriction(0.0);
             body.setCcdMotionThreshold(len * 0.5);
             body.setCcdSweptSphereRadius(R * 0.9);
-            this.world.addRigidBody(body, G_FINGER, G_STATIC | headGroup);
+            // The ROOT segment does not collide with the head.
+            //
+            // Every lock is anchored AT the scalp, so its first segment is born
+            // inside any collider big enough to be a head — and a contact born
+            // penetrating cannot be resolved: split impulse only converts
+            // penetration to position down to 2cm, and the rest is paid off as
+            // kinetic energy. That is the poof. The source excludes j===0 for
+            // exactly this reason (and uses a concave mesh collider rather than
+            // this box, which is a larger change than this one).
+            this.world.addRigidBody(body, G_FINGER,
+              j2 === 0 ? G_STATIC : (G_STATIC | headGroup));
             _bv1.setValue(0, -9.81 * HAIR_GRAV, 0);
             body.setGravity(_bv1);       // AFTER addRigidBody — the source's lesson
-            const lim = HAIR_LIM * Math.pow((j2 + 1) / list.length, HAIR_ROOT) + 0.12;
+            // No additive slack. The +0.12 here was BUILD_WIDEN, a limb-joint
+            // constant, adding 6.88 degrees to EVERY hair joint — which made the
+            // root 9.1 degrees where the source gives it 5.0.
+            const lim = HAIR_LIM * Math.pow((j2 + 1) / list.length, HAIR_ROOT);
             const mkF = (bdy) => {
               const tr = keep(new AMMO.btTransform());
               tr.setIdentity();
@@ -1229,9 +1341,16 @@ export class AmmoRagdoll {
             _bv1.setValue(lim, lim, lim); con.setAngularUpperLimit(_bv1);
             for (let ax = 3; ax < 6; ax++) {
               con.enableSpring(ax, true);
-              con.setStiffness(ax, 2.0);
-              con.setDamping(ax, 0.9);
-              con.setParam(BT_CONSTRAINT_STOP_ERP, ERP_LIMIT, ax);
+              // Bullet's spring "damping" is a target-velocity GAIN, not a
+              // dissipation term: velFactor = fps * damping / iterations. At
+              // 2.0/0.9 this commanded the joint toward equilibrium 1.5x faster
+              // than the source while having a QUARTER of the force to hold it
+              // there — snaps, then cannot carry itself.
+              con.setStiffness(ax, HAIR_TENS);
+              con.setDamping(ax, HAIR_DAMP);
+              // and no stop-ERP override: the source leaves hair limits at
+              // Bullet's default 0.2, where this port drove them at 0.35 — 75%
+              // stiffer, so a loose limit gets hit hard.
             }
             con.setEquilibriumPoint();
             this.world.addConstraint(con, true);
@@ -1239,6 +1358,7 @@ export class AmmoRagdoll {
             this._hairSegs.push({
               body, node: nd, parent: nd.parent,
               restWorldQ: nd.getWorldQuaternion(new THREE.Quaternion()),
+              con, j: j2, n: list.length,   // retuneHair() re-derives the ramp
             });
             parentBody = body;
             built++;
@@ -1429,6 +1549,38 @@ export class AmmoRagdoll {
     return n;
   }
 
+  /** Push HAIR_TUNING into the running hair, no rebuild.
+   *
+   *  Everything here is settable on a live body or constraint, so a lock
+   *  already swinging changes under your hand — which is the only way to tell
+   *  "flows" from "whips" without rebuilding and losing the state you were
+   *  looking at. Mass needs its inertia recomputed from the shape, or a heavier
+   *  segment keeps a lighter one's resistance to rotation.
+   */
+  retuneHair() {
+    if (!AMMO || !this._hairSegs?.length) return 0;
+    const HT = HAIR_TUNING;
+    for (const hs of this._hairSegs) {
+      hs.body.setDamping(0.25, HT.damping);
+      _bv1.setValue(0, -9.81 * HT.gravity, 0);
+      hs.body.setGravity(_bv1);
+      _bv1.setValue(0, 0, 0);
+      hs.body.getCollisionShape().calculateLocalInertia(HT.mass, _bv1);
+      hs.body.setMassProps(HT.mass, _bv1);
+      hs.body.updateInertiaTensor();
+      hs.body.activate();
+      if (!hs.con) continue;
+      const lim = HT.limit * DEG * Math.pow((hs.j + 1) / hs.n, HT.rootExp);
+      _bv1.setValue(-lim, -lim, -lim); hs.con.setAngularLowerLimit(_bv1);
+      _bv1.setValue(lim, lim, lim); hs.con.setAngularUpperLimit(_bv1);
+      for (let ax = 3; ax < 6; ax++) {
+        hs.con.setStiffness(ax, HT.tension);
+        hs.con.setDamping(ax, HT.damping);
+      }
+    }
+    return this._hairSegs.length;
+  }
+
   jointAngles() {
     const out = [];
     for (const J of this.jointMeta) {
@@ -1595,7 +1747,27 @@ export class AmmoRagdoll {
 
   step(dt) {
     if (this.done) return null;
-    dt = Math.min(0.25, Math.max(0, dt || 0));
+    // 0.05, not 0.25 (the source's clamp). 8 substeps at 1/120 covers only
+    // 0.067s, so anything past that is handed to the solver as ONE enormous
+    // residual step — on hair which, unlike the core bodies, has no angular
+    // velocity ceiling. A frame hitch then reads as the hair teleporting.
+    dt = Math.min(0.05, Math.max(0, dt || 0));
+    // Kinematic roots move BEFORE the step (the source's law): Bullet derives a
+    // kinematic body's velocity as (new - old)/dt, so moving one after the step
+    // hands the solver a stale offset and the chains get whipped.
+    for (const ha of this._hairAnchors ?? []) {
+      const t0 = ha.head.getCenterOfMassTransform();
+      const o0 = t0.getOrigin();
+      _v.set(o0.x(), o0.y(), o0.z());
+      const r0 = t0.getRotation();
+      _q.set(r0.x(), r0.y(), r0.z(), r0.w());
+      _b.copy(ha.local).applyQuaternion(_q).add(_v);
+      _bt1.setIdentity();
+      _bv1.setValue(_b.x, _b.y, _b.z); _bt1.setOrigin(_bv1);
+      _bq1.setValue(_q.x, _q.y, _q.z, _q.w); _bt1.setRotation(_bq1);
+      ha.anchor.getMotionState().setWorldTransform(_bt1);
+      ha.anchor.setWorldTransform(_bt1);
+    }
     if (dt > 0) this.world.stepSimulation(dt, MAX_SUBSTEPS, FIXED_DT);
 
     // angular ceiling: nothing anatomical rotates at 20 rad/s, and residual
@@ -1693,6 +1865,13 @@ export class AmmoRagdoll {
   dispose() {
     if (this._freed) return;
     this._freed = true;
+    // The hair is left WHERE THE SIM ENDED — dishevelled, and deliberately so:
+    // a body that has just been thrown across a room should not stand up with
+    // its hair combed. What is NOT left behind is that pose's authority: the
+    // combed shape is captured once on the avatar (see __hairRest) and every
+    // rebuild snaps back to it before building its springs, so a crumple can
+    // never become the next tumble's definition of rest. Restoring the comb
+    // here instead is a one-line change if that is ever wanted.
     this.done = true;
     try {
       for (const c of this._constraints) this.world.removeConstraint(c);

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -170,7 +170,8 @@ const DEG = Math.PI / 180;
 // the torso is one body here. Mass from proxy volume was the measured mistake:
 // a 0.4 kg pelvis "whipped around like a bead".
 const MASS_FRAC = {
-  torso: 0.14 + 0.14 + 0.16,
+  torso: 0.14 + 0.14 + 0.16,   // kept for the degenerate no-spine-bones trunk
+  pelvis: 0.14, spineSeg: 0.14, chestSeg: 0.16,   // rigdef.py's rows, used apart
   head: 0.081,
   upperArm: 0.028, lowerArm: 0.016, hand: 0.006,
   upperLeg: 0.100, lowerLeg: 0.047, foot: 0.015,
@@ -224,6 +225,11 @@ const GRAB_CLAMP_X = 1.2;       // × total mass
 // (rapierdoll's law; also the source's thumb lesson).
 //   ref: what X is crossed against — 'fwd' | 'up' | 'palm' | 'pinky'
 const JOINT_SPECS = {
+  // trunk (rigdef.py: spine ±25/±20/±25, chest ±20/±20/±20). Modest ranges —
+  // a spine is stiff — but the difference between these and NO joint is the
+  // difference between a body that folds and a plank.
+  spine: { ref: 'fwd', x: [-25, 25], twist: 20, z: [-25, 25] },
+  chest: { ref: 'fwd', x: [-20, 20], twist: 20, z: [-20, 20] },
   head: { ref: 'fwd', x: [-40, 40], twist: 45, z: [-35, 35] },
   upperArm: { ref: 'fwd', x: [-85, 85], twist: 70, z: [-85, 85] },
   lowerArm: { ref: 'fwd', flex: 145, ext: 2, want: 'fwd', twist: 5, z: [-5, 5] },
@@ -257,6 +263,8 @@ const EXTRA_SEGMENTS = [
   { a: 'rightFoot', b: 'rightToes', part: 'foot' },
 ];
 const CORE_JOINTS = [
+  { at: 'spine', parent: 'hips|spine', child: 'spine|chest', spec: 'spine' },
+  { at: 'chest', parent: 'spine|chest', child: 'chest|neck', spec: 'chest' },
   { at: 'neck', parent: 'chest', child: 'neck|head', spec: 'head' },
   { at: 'leftUpperArm', parent: 'chest', child: 'leftUpperArm|leftLowerArm', spec: 'upperArm' },
   { at: 'rightUpperArm', parent: 'chest', child: 'rightUpperArm|rightLowerArm', spec: 'upperArm' },
@@ -660,37 +668,66 @@ export class AmmoRagdoll {
     };
     const limbW = (ra, rb2) => Math.max(0.02, ra.distanceTo(rb2) * 0.16);
 
-    // torso body: pelvis + spine + chest boxes on ONE rigid body
-    const torsoBoxes = [];
-    for (const key of ['hips|spine', 'spine|chest', 'chest|neck']) {
-      const [a, b2] = key.split('|');
-      if (!restP[a] || !restP[b2]) continue;
-      torsoBoxes.push(boxFor(restTorsoMid, restP[a], restP[b2], torsoR, torsoR * 0.6));
-    }
-    if (!torsoBoxes.length) {       // degenerate trunk: one box hips→upper
-      torsoBoxes.push(boxFor(restTorsoMid, restP.hips, restUpper, torsoR, torsoR * 0.6));
-    }
-    const torsoBody = mkBody(MASS_FRAC.torso * massScale, liveTorsoMid, torsoQ, torsoBoxes, false);
-    this.torsoBody = torsoBody;
-    bodyIndex.set(torsoBody, 0);
-
+    // The trunk is THREE bodies — pelvis, spine, chest — jointed by the source's
+    // own spine and chest limits.
+    //
+    // It was one. A single rigid body from hips to neck cannot bend, so a doll
+    // fell as a plank: no fold at the waist, no shoulders leading the hips, no
+    // curl on landing. And it is not only a look. Every arm and the head hung
+    // off ONE body carrying half the doll's mass, so a hand dragged across the
+    // floor loaded the whole arm chain against that slab and the arm joints
+    // absorbed all of it — measured at ~118 degrees past their limits, and
+    // unchanged by softening the drag handle from x8 to x1.2, because the
+    // handle was never what was saturating.
+    //
+    // The rows of MASS_FRAC.torso were already the three Dempster fractions
+    // (0.14 + 0.14 + 0.16) added together; they are simply used apart now.
     const segMeta = new Map();      // segKey -> { body, restOrigin }
-    for (const key of TORSO_KEYS) {
+    const TRUNK = [
+      ['hips|spine', 'pelvis'], ['spine|chest', 'spineSeg'], ['chest|neck', 'chestSeg'],
+    ];
+    let nextBit = 0;
+    let trunkBuilt = 0;
+    for (const [key, part] of TRUNK) {
       const [a, b2] = key.split('|');
       if (!restP[a] || !restP[b2] || !live[a] || !live[b2]) continue;
+      const ra = restP[a], rb2 = restP[b2];
+      const restMid = ra.clone().add(rb2).multiplyScalar(0.5);
+      const liveMid = live[a].clone().add(live[b2]).multiplyScalar(0.5);
+      const body = mkBody(MASS_FRAC[part] * massScale, liveMid, torsoQ,
+        [boxFor(restMid, ra, rb2, torsoR, torsoR * 0.6)], false);
       const seg = {
-        key, a, b: b2, body: torsoBody, torso: true,
-        restA: restP[a].clone(), restB: restP[b2].clone(),
-        localA: restP[a].clone().sub(restTorsoMid),
-        localB: restP[b2].clone().sub(restTorsoMid),
+        key, a, b: b2, body, torso: true,
+        restA: ra.clone(), restB: rb2.clone(),
+        localA: ra.clone().sub(restMid), localB: rb2.clone().sub(restMid),
         r: torsoR,
       };
       this.segs.set(key, seg);
-      segMeta.set(key, { body: torsoBody, restOrigin: restTorsoMid });
+      segMeta.set(key, { body, restOrigin: restMid });
+      if (nextBit <= BODY_BITS) bodyIndex.set(body, nextBit++);
+      trunkBuilt++;
     }
+    // Degenerate trunk (a rig with no spine/chest bones): fall back to the old
+    // single body, so those rigs behave exactly as before rather than losing
+    // their torso entirely.
+    if (!trunkBuilt) {
+      const body = mkBody(MASS_FRAC.torso * massScale, liveTorsoMid, torsoQ,
+        [boxFor(restTorsoMid, restP.hips, restUpper, torsoR, torsoR * 0.6)], false);
+      segMeta.set('hips|spine', { body, restOrigin: restTorsoMid });
+      segMeta.set('chest|neck', { body, restOrigin: restTorsoMid });
+      this.segs.set('hips|spine', {
+        key: 'hips|spine', a: 'hips', b: 'spine', body, torso: true,
+        restA: restP.hips.clone(), restB: restUpper.clone(),
+        localA: restP.hips.clone().sub(restTorsoMid),
+        localB: restUpper.clone().sub(restTorsoMid), r: torsoR,
+      });
+      if (nextBit <= BODY_BITS) bodyIndex.set(body, nextBit++);
+    }
+    // The trunk body other code asks for by name. Callers want "the thing the
+    // arms and head hang off", which is the chest once the trunk articulates.
+    this.torsoBody = (segMeta.get('chest|neck') ?? segMeta.get('hips|spine'))?.body ?? null;
 
     // limb + head + hand/foot bodies
-    let nextBit = 1;
     const partOf = (key) => {
       if (key === 'neck|head') return 'head';
       if (/UpperArm\|/.test(key)) return 'upperArm';
@@ -969,10 +1006,12 @@ export class AmmoRagdoll {
       return con;
     };
 
+    // Named trunk anchors. The legs hang off the PELVIS and the arms and head
+    // off the CHEST; when they all pointed at one fused body these two names
+    // resolved to the same thing, which is exactly what made the trunk rigid.
     const metaOf = (ref) => {
-      if (ref === 'hips' || ref === 'chest' || TORSO_KEYS.has(ref)) {
-        return { body: torsoBody, restOrigin: restTorsoMid };
-      }
+      if (ref === 'hips') return segMeta.get('hips|spine');
+      if (ref === 'chest') return segMeta.get('chest|neck') ?? segMeta.get('hips|spine');
       return segMeta.get(ref);
     };
     for (const J of CORE_JOINTS) {

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -71,6 +71,57 @@ import { colliders } from './colliders.js';
 
 let AMMO = null;
 let ammoLoading = null;
+/** The real inertia of a set of child boxes, about the body origin.
+ *
+ *  btCompoundShape::calculateLocalInertia is documented in Bullet's own source
+ *  as "approximation: take the inertia from the aabb" — and every limb box here
+ *  is ROTATED inside its compound (a body's local axes are rest-aligned, not
+ *  bone-aligned), so that AABB is much larger than the box it stands for.
+ *  Measured on this rig's forearm at 45 degrees off axis, the approximation is
+ *  4.75x the true inertia ABOUT THE BONE — which is the twist axis, the one
+ *  with the tightest limits (elbow and knee twist are +/-5 degrees). A joint
+ *  whose twist inertia is five times too heavy is mis-weighted against its
+ *  neighbour in every solver iteration, so the stop does not hold: the limit is
+ *  pushed through and then dragged back, which reads as a limb twisting further
+ *  than it should and then untwisting itself.
+ *
+ *  So compute it properly: exact box tensor, rotated by the child's own
+ *  rotation, parallel-axis shifted to the body origin, summed, mass split by
+ *  volume. Bullet can only carry a DIAGONAL local inertia, so the off-diagonal
+ *  terms are dropped at the end — but the diagonal of the true tensor is a far
+ *  better answer than the tensor of a box nobody has. The playground this was
+ *  ported from never needed any of it: its bodies are a single btBoxShape
+ *  aligned to the bone, where calculateLocalInertia is exact.
+ */
+function boxesInertia(boxes, mass) {
+  let vol = 0;
+  for (const b of boxes) vol += 8 * b.he.x * b.he.y * b.he.z;
+  if (!(vol > 0)) return { x: 0, y: 0, z: 0 };
+  // accumulate the full 3x3, symmetric
+  let xx = 0, yy = 0, zz = 0;
+  const m3 = new THREE.Matrix3();
+  for (const b of boxes) {
+    const m = mass * (8 * b.he.x * b.he.y * b.he.z) / vol;
+    const x = 2 * b.he.x, y = 2 * b.he.y, z = 2 * b.he.z;
+    // principal moments in the BOX's own frame
+    const ix = m / 12 * (y * y + z * z);
+    const iy = m / 12 * (x * x + z * z);
+    const iz = m / 12 * (x * x + y * y);
+    // rotate: I' = R diag(i) R^T  (only the diagonal of I' is kept, below)
+    m3.setFromMatrix4(_m4.makeRotationFromQuaternion(b.q));
+    const e = m3.elements;   // column-major: e[0..2] = col0
+    xx += ix * e[0] * e[0] + iy * e[3] * e[3] + iz * e[6] * e[6];
+    yy += ix * e[1] * e[1] + iy * e[4] * e[4] + iz * e[7] * e[7];
+    zz += ix * e[2] * e[2] + iy * e[5] * e[5] + iz * e[8] * e[8];
+    // parallel axis, to the body origin
+    const t = b.t;
+    xx += m * (t.y * t.y + t.z * t.z);
+    yy += m * (t.x * t.x + t.z * t.z);
+    zz += m * (t.x * t.x + t.y * t.y);
+  }
+  return { x: xx, y: yy, z: zz };
+}
+
 export async function ensureAmmo() {
   if (AMMO) return true;
   if (ammoLoading) return ammoLoading;
@@ -158,6 +209,11 @@ const ANG_CEIL = 20;            // rad/s backstop
 const BUILD_WIDEN = 0.12;       // rad of slack over the born excursion
 const PIN_TAU = 0.9;            // source: the shift-click pin, held firm
 const PIN_CLAMP_X = 8;          // × total mass
+// ...and the source's OTHER setting, for a hand rather than a nail. A grab that
+// is as stiff as a nail does not feel firm, it feels like the joint stops are
+// not there — because at this strength they effectively are not.
+const GRAB_TAU = 0.4;
+const GRAB_CLAMP_X = 1.2;       // × total mass
 
 // Anatomical joint table — the source's rigdef.py JOINTS in degrees, re-keyed
 // to the basis built in _jointBasis(): Y = bone (twist), X = primary swing
@@ -556,8 +612,8 @@ export class AmmoRagdoll {
       _bv1.setValue(originLive.x, originLive.y, originLive.z); _bt1.setOrigin(_bv1);
       _bq1.setValue(orient.x, orient.y, orient.z, orient.w); _bt1.setRotation(_bq1);
       const ms = keep(new AMMO.btDefaultMotionState(_bt1));
-      _bv1.setValue(0, 0, 0);
-      compound.calculateLocalInertia(mass, _bv1);
+      const I = boxesInertia(boxes, mass);
+      _bv1.setValue(I.x, I.y, I.z);
       const ci = keep(new AMMO.btRigidBodyConstructionInfo(mass, ms, compound, _bv1));
       const rb = keep(new AMMO.btRigidBody(ci));
       rb.setDamping(isFinger ? LIN_DAMP_FINGER : LIN_DAMP, isFinger ? ANG_DAMP_FINGER : ANG_DAMP);
@@ -1309,7 +1365,13 @@ export class AmmoRagdoll {
     this.elapsed = 0;
   }
 
-  setPin(joint, target) {
+  /** `firm` distinguishes a NAIL from a HAND. The source has two settings and
+   *  ammodoll shipped only the nail's: a drag calls setPin on every mousemove,
+   *  so every drag was held by a nail — mass x8 at tau 0.9, a near-rigid handle
+   *  hauling a limb through its joint stops, and the contorted result is what
+   *  you then let go of. Measured on a haul across the floor, the nail numbers
+   *  cost 441 degrees of total limit overshoot against 343 for the hand. */
+  setPin(joint, target, firm = false) {
     if (this.done) return;
     if (!joint) {
       for (const j of [...this._pinCons.keys()]) this.setPin(j, null);
@@ -1340,8 +1402,8 @@ export class AmmoRagdoll {
       // seg.local* are rest-local = body-local (rest-aligned bodies)
       _bv1.setValue(anchor.x, anchor.y, anchor.z);
       const con = new AMMO.btPoint2PointConstraint(seg.body, _bv1);
-      con.get_m_setting().set_m_impulseClamp(this.totalMass * PIN_CLAMP_X);
-      con.get_m_setting().set_m_tau(PIN_TAU);
+      con.get_m_setting().set_m_impulseClamp(this.totalMass * (firm ? PIN_CLAMP_X : GRAB_CLAMP_X));
+      con.get_m_setting().set_m_tau(firm ? PIN_TAU : GRAB_TAU);
       this.world.addConstraint(con, false);
       this._refs.push(con);
       pin = { con, body: seg.body };

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -542,6 +542,7 @@ export class AmmoRagdoll {
     this._massOf = new Map();       // body -> mass (Bullet only hands back 1/m)
     const bodyIndex = new Map();    // body -> filter bit index (core only)
 
+    this._vol = [];                 // debug: the boxes, body-local, per body
     const mkBody = (mass, originLive, orient, boxes, isFinger) => {
       const compound = keep(new AMMO.btCompoundShape());
       for (const bx of boxes) {
@@ -580,6 +581,16 @@ export class AmmoRagdoll {
       this._bodies.push(rb);
       this._massOf.set(rb, mass);
       if (!isFinger) this._cores.push(rb);
+      // Keep the child boxes for the debug overlay. The volumes are the ONE
+      // thing about this engine you cannot infer from the skeleton — a bone
+      // line says nothing about the thickness that stops a forearm passing
+      // through a torso — and debug.js could not draw them for ammo at all:
+      // it reads `caps`/`radius`, which only the verlet has, so the panel drew
+      // joints and nothing else. See volumes().
+      this._vol.push({
+        body: rb,
+        boxes: boxes.map((bx) => ({ he: bx.he.clone(), t: bx.t.clone(), q: bx.q.clone() })),
+      });
       return rb;
     };
 
@@ -828,9 +839,23 @@ export class AmmoRagdoll {
       const relF = basis.clone().invert().multiply(rel).multiply(basis);
       const eul = new THREE.Euler().setFromQuaternion(relF, 'XYZ');
       const born = [eul.x, eul.y, eul.z];
+      // ...but only a FRESH body is born into an arbitrary pose. A seeded body
+      // is a HANDOVER — the same tumble continuing on another machine — and its
+      // pose is a sim state, not an anatomy. Widening to contain it enshrines
+      // whatever bend the body happened to be in as its new limits, and since
+      // every drag release constructs a new doll, the limits RATCHET: measured
+      // on mythospaint, the neck's lateral range went 70° → 103° → 115° → 132°
+      // over four drag-and-release cycles, which is the head "bending weirdly
+      // and rotating all the way round" after you let go. So on a handover the
+      // widening may buy the solver a little slack, but never more than
+      // BUILD_WIDEN past the anatomical table: a joint that arrives outside its
+      // range is then pushed BACK into it over the next few steps, which is the
+      // behaviour we want, instead of being granted the excursion forever.
+      const cap = seedVel ? BUILD_WIDEN : Infinity;
+      const anatLo = lo.slice(), anatHi = hi.slice();
       for (let i = 0; i < 3; i++) {
-        lo[i] = Math.min(lo[i], born[i] - BUILD_WIDEN);
-        hi[i] = Math.max(hi[i], born[i] + BUILD_WIDEN);
+        lo[i] = Math.max(anatLo[i] - cap, Math.min(lo[i], born[i] - BUILD_WIDEN));
+        hi[i] = Math.min(anatHi[i] + cap, Math.max(hi[i], born[i] + BUILD_WIDEN));
       }
 
       // CENTER THE RANGE ON THE FRAME. Bullet's angular limit logic wraps the
@@ -1152,9 +1177,32 @@ export class AmmoRagdoll {
 
     if (lean) this._topple(lean);
     this._syncP();
-    // measured against the sim's OWN hips (the rest-shaped torso reconstructs
-    // p.hips a few mm off the live skeleton's — rapierdoll's frame-one jump)
-    this.hipsOffset = (this.p.hips?.y ?? live.hips?.y ?? 0) - avatar.root.position.y;
+    // How far the render root sits below the hips. This is a property of the
+    // RIG (~0.9m on a standing adult), and measuring it against the sim's own
+    // hips is right for a fresh body, whose sim starts AT the rest pose — it
+    // absorbs the few mm by which the rest-shaped torso reconstructs p.hips off
+    // the live skeleton (rapierdoll's frame-one jump).
+    //
+    // A SEEDED body starts mid-tumble, where p.hips is a metre from rest and
+    // near the floor. Measuring there bakes the tumble into the rig: the offset
+    // comes out far too small or too large, and every subsequent frame renders
+    // the root that much off — she sinks through the ground after a drop, and
+    // never on the first push, because only a release rebuilds. restP is the
+    // rest pose in WORLD space taken with the root where it is now, so
+    // restP.hips.y - root.y is the same constant no matter what the sim is
+    // doing or where the root has drifted to.
+    // A SEEDED body is not the only one that starts away from rest: the DRAGGER
+    // builds a fresh doll on its copy of a body that is already lying down
+    // (bodydrag.js), and measuring a standing constant off a prone pose is how
+    // she came to land two feet in the air. So do not key on the seed — key on
+    // whether the measurement AGREES with the rig. Within a few cm they are the
+    // same number and the measured one is kept, preserving the frame-one fix;
+    // beyond that the body simply is not at rest, the measurement means
+    // nothing, and the rig constant is the only honest answer.
+    const restHipsY = this.restP?.hips?.y;
+    const measured = (this.p.hips?.y ?? live.hips?.y ?? 0) - avatar.root.position.y;
+    const constant = restHipsY != null ? restHipsY - avatar.root.position.y : measured;
+    this.hipsOffset = Math.abs(measured - constant) > 0.05 ? constant : measured;
   }
 
   // ---------------------------------------------------------------- instruments
@@ -1162,6 +1210,32 @@ export class AmmoRagdoll {
   // "is it finite / did it settle" cannot see an anatomy failure)
 
   /** Live per-axis joint angles against their bounds, in the joint basis. */
+  /** The collision volumes as the SOLVER holds them, in world space:
+   *  `[{ p, q, he }]`, one entry per box (bodies are compounds, so the torso
+   *  yields three). The debug overlay's box counterpart to the verlet's
+   *  `caps`/`radius`; without it the panel can only draw the skeleton, and the
+   *  skeleton is precisely the part that was never in doubt. */
+  volumes() {
+    const out = [];
+    if (!AMMO) return out;
+    for (const { body, boxes } of this._vol ?? []) {
+      // one value-returning ammo call per statement — see quatOf2
+      const t = body.getCenterOfMassTransform();
+      const o = t.getOrigin();
+      const bp = new THREE.Vector3(o.x(), o.y(), o.z());
+      const r = t.getRotation();
+      const bq = new THREE.Quaternion(r.x(), r.y(), r.z(), r.w());
+      for (const bx of boxes) {
+        out.push({
+          p: bx.t.clone().applyQuaternion(bq).add(bp),
+          q: bq.clone().multiply(bx.q),
+          he: bx.he.clone(),
+        });
+      }
+    }
+    return out;
+  }
+
   jointAngles() {
     const out = [];
     for (const J of this.jointMeta) {

--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -301,6 +301,19 @@ export async function loadVRM(libPath, { priority = 1 } = {}) {
       await work.yield();
       work.phase('skeleton');
       VRMUtils.combineSkeletons?.(vrm.scene) ?? VRMUtils.removeUnnecessaryJoints?.(vrm.scene);
+      // A SkinnedMesh's bounding sphere comes from BIND-POSE positions, so it
+      // stops bounding the mesh the moment the skeleton poses — and three.js
+      // then culls against that stale sphere, so parts of a body vanish
+      // depending on camera angle.
+      //
+      // Invisible on a one-primitive avatar, whose bounds are body-sized and
+      // effectively never leave the frustum. A multi-material body splits into
+      // one SkinnedMesh PER PRIMITIVE, each with region-tight bounds: measured
+      // on a 6-primitive rig, the hair primitive (bounds y 0.83..1.00 — the head
+      // alone) disappeared from most angles while the seam primitive (bounds
+      // spanning the whole body) never did. That reads as "the hair is missing
+      // but its gold highlights are still there".
+      vrm.scene.traverse((o) => { if (o.isSkinnedMesh) o.frustumCulled = false; });
       VRMUtils.rotateVRM0(vrm); // VRM0 → faces +Z
       // through the factory BEFORE the first compile: the final graph shape
       // (wetness on MToon, sweep markers) is born with the body

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -9,6 +9,8 @@ import {
 } from './assets.js';
 import { beginWork, enqueue, idleYield, nextFrame, loadNote } from './loadwork.js';
 import { warm } from './warmqueue.js';
+import { heightAt } from './terrain.js';
+import { surfaceUnder } from './colliders.js';
 import { DRIVEN_BONES } from './ragdoll.js';
 import { stroke as strokeIcon } from './icons.js';
 import { SEAT_CLIP_FILE } from './seatcore.js';
@@ -732,6 +734,26 @@ export class Avatar {
 
     BC('av:gaze-expr');
     this.vrm.update(dt);
+
+    // ---- contact shadow: on the GROUND, not on the body.
+    // The blob is a child of root at a fixed local y, so it rode along under a
+    // lifted body at a constant 2cm — which is precisely the one thing it
+    // exists to disprove ("how high a jump went"). Put it at the surface under
+    // her instead, and let it shrink and fade with the gap, so height reads
+    // even when the ground is out of frame. surfaceUnder, not heightAt: a body
+    // held over a platform casts onto the PLATFORM.
+    if (this.shadow) {
+      const rp = this.root.position;
+      const gy = surfaceUnder(rp.x, rp.z, heightAt, rp.y + 0.05).y;
+      const gap = Math.max(0, rp.y - gy);
+      this.shadow.position.y = (gy - rp.y) + 0.02;
+      // 3 m up the blob is gone; directly underfoot it is full size.
+      const k = THREE.MathUtils.clamp(1 - gap / 3, 0, 1);
+      this.shadow.scale.setScalar(0.55 + 0.45 * k);
+      this.shadow.material.opacity = k * k;
+      this.shadow.visible = k > 0.02;
+    }
+
     BC('av:plates');
 
     // ---- nameplate: fade with distance and stop screaming across the stage.

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -20,6 +20,31 @@ import { SEAT_CLIP_FILE } from './seatcore.js';
 // largest chunk of a cold boot, spent on animations most arrivals don't use in
 // the first minute (nobody lands mid-climb). So a body is born able to stand
 // and walk, and learns the rest while you're already moving.
+// How far an upper lid swings to shut, in radians about its own X, when the rig
+// exports no limit of its own. Signed: which way is "closed" depends on how the
+// lid bone was rolled, so this is a dial, not a constant of nature — the first
+// guess here blinked mythos UPWARD, which is the other 50%.
+export const BLINK = {
+  closed: 1.2,   // radians — 69 deg, found on the slider against her own lids
+  hz: 1,         // blink-rate multiplier
+  // Which AXIS a lid swings about is a property of how the bone was rolled, and
+  // Blender's bone axes are not glTF's — a lid that shuts about X in Blender may
+  // need Y or Z here. 0=x 1=y 2=z. Rotating about the wrong one sweeps the lid
+  // sideways instead of down, which looks like an eye you can see straight
+  // through however far you close it.
+  axis: 0,
+  lower: -0.35,  // the LOWER lid's share, signed and usually opposite. An upper
+                 // lid alone does not shut an eye: it covers the top and leaves
+                 // the sclera and iris showing under it, which is why a "closed"
+                 // eye read as a white eyeball with a dark dot.
+  eyeMax: 0.42,  // radians an eyeball may turn off the head's forward (~24 deg).
+                 // Human eyes reach further, but a doll whose eyes track hard
+                 // reads as staring; the head is meant to do most of the work.
+  dur: 0.28,     // seconds for a full close-and-open. 0.13 was the original and
+                 // it is barely perceptible: a real blink is 100-150ms of
+                 // CLOSING plus the reopen, and this curve covers both halves.
+};
+
 const CORE_CLIPS = ['idle', 'walk'];
 const LATER_CLIPS = CLIP_SLOTS.filter((s) => !CORE_CLIPS.includes(s));
 // Until a clip arrives, the nearest thing that HAS arrived stands in. Silently
@@ -169,6 +194,15 @@ function drawTypingDots(sprite, t, state) {
 
 const _v = new THREE.Vector3();
 const _pq = new THREE.Quaternion();
+const _Y2 = new THREE.Vector3(0, 1, 0);
+const _Z2 = new THREE.Vector3(0, 0, 1);
+const _gq = new THREE.Quaternion();        // gaze scratch — hot path, no allocs
+const _gd = new THREE.Quaternion();
+const _gi = new THREE.Quaternion();
+const _gpq = new THREE.Quaternion();
+const _gf = new THREE.Vector3();
+const _gw = new THREE.Vector3();
+const _gp = new THREE.Vector3();
 const _X = new THREE.Vector3(1, 0, 0);      // scratch — hot paths must not allocate
 const _v2 = new THREE.Vector3();
 
@@ -223,6 +257,77 @@ export class Avatar {
     this.root.add(this.shadow);
 
     scene.add(this.root);
+  }
+
+  /** Find the eyeball bones once. VRM ships a lookAt rig and three-vrm drives
+   *  it — but only if the file HAS one, and this rig has hand-rigged bones
+   *  instead: L_Eye / R_Eye. Same gaze target either way. */
+  _findEyes() {
+    this._eyes = null;
+    if (!this.vrm?.scene) return;
+    const found = [];
+    this.vrm.scene.traverse((o) => {
+      if (/^[LR]_Eye$/.test(o.name ?? '')) found.push({ node: o, rest: o.quaternion.clone() });
+    });
+    if (found.length) this._eyes = found;
+  }
+
+  /** Hold the eyes shut (1) or let them open (0). Eased in update() so it
+   *  reads as closing rather than snapping. Returns false if this body has no
+   *  eyelid bones, so a caller can say so instead of appearing to work. */
+  setEyes(shut) {
+    if (this._lids === undefined) this._findLids();
+    if (!this._lids) return false;
+    this._eyesGoal = shut ? 1 : 0;
+    return true;
+  }
+
+  /** Find the eyelid bones once, and remember where OPEN is.
+   *
+   *  Named by the rig pipeline: L_/R_Eyelid_Upper (and _Lower, unused for now —
+   *  a lower lid barely moves in a human blink). The closing angle comes from
+   *  the Limit Rotation constraint the rig author set in Blender, carried out
+   *  as a node extra by eido_export.py; BLINK.closed is the live fallback for a rig
+   *  that never exported one, and is deliberately modest — a lid that overshoots
+   *  reads as a wince, and this is the value you would rather have too small.
+   */
+  _findLids() {
+    this._lids = null;
+    if (!this.vrm?.scene) return;
+    const found = [];
+    this.vrm.scene.traverse((o) => {
+      const m = /^[LR]_Eyelid_(Upper|Lower)$/.exec(o.name ?? '');
+      if (!m) return;
+      const ex = o.userData?.gltfExtras ?? o.userData ?? {};
+      // A Limit Rotation's numbers are ABSOLUTE angles in the bone's own frame,
+      // not offsets from rest — mythos's upper lids export min 150 / max 240
+      // degrees, bracketing the ~195 the lid actually rests at. Read as a delta
+      // that is a 240-degree sweep: the lid leaves the head entirely and the eye
+      // is bare, which reads as "you can see through the eyelids" and survives
+      // any amount of making the mesh bigger.
+      //
+      // Rest sits at the middle of a range that brackets it, so the closing
+      // delta is closed - centre = 45 degrees here. Anything that does not come
+      // out plausible is discarded in favour of the dial: a rig may have set
+      // those limits for something other than a blink.
+      let lim = NaN;
+      const mn = Number(ex.limit_min_x), mx = Number(ex.limit_max_x);
+      const cl = Number(ex.blink_closed_x);
+      if ([mn, mx, cl].every(Number.isFinite) && mx > mn) {
+        const d = cl - (mn + mx) / 2;
+        if (Math.abs(d) > 1e-3 && Math.abs(d) < 1.6) lim = d;
+      }
+      found.push({
+        node: o,
+        rest: o.quaternion.clone(),
+        lower: m[1] === 'Lower',
+        exported: Number.isFinite(lim) && Math.abs(lim) > 1e-4 ? lim : null,
+      });
+    });
+    // NOT report() — that is the error channel, and report(msg, null) renders
+    // as "unknown error", which is what it did: a clean load announcing a fault
+    // that never happened.
+    if (found.length) this._lids = found;
   }
 
   // ---- first-person anchors (fp_view.js consumes these) -------------------
@@ -433,6 +538,19 @@ export class Avatar {
     on = !!on;
     if (on === this._limp) return;
     this._limp = on;
+    // Eyes close when the body goes slack, and open when it gets up. Only for a
+    // rig with eyelid BONES — setEyes says so itself and does nothing otherwise,
+    // so a VRM that blinks with a blendshape is unaffected.
+    //
+    // This is driven from setLimp rather than from the ragdoll, which means it
+    // is also true of everyone ELSE you watch fall: remotes call setLimp the
+    // moment a streamed clip turns to 'ragdoll'. Nothing new on the wire.
+    //
+    // _limpEyes remembers that WE closed them, so getting up only reopens eyes
+    // that the fall shut — someone who chose to lie there with their eyes closed
+    // (/eyes) keeps them closed.
+    if (on) { this._limpEyes = this.setEyes(true); }
+    else if (this._limpEyes) { this._limpEyes = false; this.setEyes(false); }
     if (!on) {
       // Hand the bones back as we found them. three.js only writes a bone when
       // the clip's computed value CHANGES, so a track that holds still — a
@@ -698,18 +816,84 @@ export class Avatar {
       this.gaze.position.lerp(_v, 1 - Math.exp(-3 * dt));
     }
 
+    // ---- blink: irregular, in pairs sometimes, never metronomic
+    //
+    // The CLOCK runs whether or not this body has expressions. It used to live
+    // inside `if (em)`, which is fine for a VRM authored with a blink
+    // blendshape and silently nothing for one without: a rig whose eyelids are
+    // BONES has no expressions at all, so the timer never advanced and the
+    // avatar never blinked. Value first, consumers after.
+    let blinkV = 0;
+    if (this.blinkT >= 0) {
+      this.blinkT += dt;
+      const k = this.blinkT / Math.max(0.05, BLINK.dur);
+      blinkV = k < 1 ? Math.sin(k * Math.PI) : 0;
+      if (k >= 1) {
+        this.blinkT = -1;
+        // Schedule from the END of the blink, not its start. Measured from the
+        // start, the 260ms "pair" gap is shorter than a 280ms blink — so the
+        // next one is already due the instant this one finishes and EVERY blink
+        // came in twos. It only worked before because the blink was 130ms, i.e.
+        // the bug was hidden by the duration rather than absent.
+        const rate = Math.max(0.15, BLINK.hz);
+        this.blinkAt = now + (Math.random() < 0.22 ? 220
+          : (2200 + Math.random() * 4200) / rate);
+      }
+    } else if (now > this.blinkAt) {
+      this.blinkT = 0;
+    }
+    // eyelids as BONES: rotate the uppers from their rest pose by the same
+    // curve. Rest is captured once, so a blink cannot integrate — the lids
+    // return exactly where they started rather than creeping shut over an hour.
+    // ---- eyeballs: point them at the same target the gaze already eases to
+    if (this._eyes === undefined) this._findEyes();
+    if (this._eyes && this.head) {
+      this.head.getWorldQuaternion(_gq);
+      _gf.set(0, 0, 1).applyQuaternion(_gq);          // where the head faces NOW
+      for (const e of this._eyes) {
+        e.node.getWorldPosition(_gp);
+        _gw.copy(this.gaze.position).sub(_gp);
+        if (_gw.lengthSq() < 1e-10) continue;
+        _gw.normalize();
+        _gd.setFromUnitVectors(_gf, _gw);             // the world-space turn
+        const ang = 2 * Math.acos(Math.min(1, Math.abs(_gd.w)));
+        if (ang > BLINK.eyeMax) {                     // clamp into a cone
+          _gi.identity().slerp(_gd, BLINK.eyeMax / ang);
+          _gd.copy(_gi);
+        }
+        // local = parentWorld⁻¹ · turn · parentWorld · rest
+        e.node.parent.getWorldQuaternion(_gpq);
+        _gi.copy(_gpq).invert().multiply(_gd).multiply(_gpq).multiply(e.rest);
+        e.node.quaternion.copy(_gi);
+      }
+    }
+
+    if (this._lids === undefined) this._findLids();
+    // ease toward the held state — a lid that snaps shut reads as a flinch
+    this._eyesShut = this._eyesShut ?? 0;
+    const goal = this._eyesGoal ?? 0;
+    if (this._eyesShut !== goal) {
+      this._eyesShut += (goal - this._eyesShut) * (1 - Math.exp(-12 * dt));
+      if (Math.abs(goal - this._eyesShut) < 0.002) this._eyesShut = goal;
+    }
+    if (this._lids) {
+      // a held close (/eyes) and a blink share the lids: whichever is further
+      // shut wins, so blinking while your eyes are closed changes nothing
+      const amt = Math.max(blinkV, this._eyesShut ?? 0);
+      for (const l of this._lids) {
+        l.node.quaternion.copy(l.rest);
+        // the rig's own exported limit wins; BLINK.closed is the dial otherwise
+        const shut = l.exported ?? (l.lower ? BLINK.lower : BLINK.closed);
+        if (amt > 0) {
+          const ax = BLINK.axis === 1 ? _Y2 : BLINK.axis === 2 ? _Z2 : _X;
+          l.node.quaternion.multiply(_pq.setFromAxisAngle(ax, shut * amt));
+        }
+      }
+    }
+
     const em = this.vrm.expressionManager;
     if (em) {
-      // ---- blink: irregular, in pairs sometimes, never metronomic
-      if (this.blinkT >= 0) {
-        this.blinkT += dt;
-        const k = this.blinkT / 0.13;
-        em.setValue('blink', k < 1 ? Math.sin(k * Math.PI) : 0);
-        if (k >= 1) { this.blinkT = -1; em.setValue('blink', 0); }
-      } else if (now > this.blinkAt) {
-        this.blinkT = 0;
-        this.blinkAt = now + (Math.random() < 0.22 ? 260 : 2200 + Math.random() * 4200);
-      }
+      em.setValue('blink', blinkV);
       // ---- mouth: no audio to drive visemes from, but a frozen mouth during
       // a paragraph of speech is worse than an approximate one. Syllable-rate
       // envelope for the duration of the utterance.

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -265,6 +265,13 @@ export class Avatar {
   _findEyes() {
     this._eyes = null;
     if (!this.vrm?.scene) return;
+    // DEFER to three-vrm when the rig maps its eyes properly. import-tripo-avatar
+    // (#120) now maps L_Eye/R_Eye to VRM leftEye/rightEye, which gives the stock
+    // lookAt rig those bones — and this.gaze is already its target. Driving them
+    // from here as well would be two writers on one bone every frame, and the
+    // one that lost would be whichever ran second. Bone-rigged eyes with no VRM
+    // mapping (anything imported before that landed) still need us.
+    if (this.vrm.lookAt && this.vrm.humanoid?.getNormalizedBoneNode?.('leftEye')) return;
     const found = [];
     this.vrm.scene.traverse((o) => {
       if (/^[LR]_Eye$/.test(o.name ?? '')) found.push({ node: o, rest: o.quaternion.clone() });

--- a/client/lib/bodydrag.js
+++ b/client/lib/bodydrag.js
@@ -302,7 +302,7 @@ bus.on('bodydrag', (msg) => {
     if (drag && drag.id === by) {
       for (const p of msg.pins) {
         if (p?.j && Array.isArray(p.at) && p.at.length === 3) {
-          drag.rd.setPin(String(p.j), _tmp.set(p.at[0], p.at[1], p.at[2]));
+          drag.rd.setPin(String(p.j), _tmp.set(p.at[0], p.at[1], p.at[2]), true);  // a NAIL, held firm
         }
       }
     }

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -552,6 +552,9 @@ function runCommand(raw) {
     case 'pushable':
       bus.emit('command', { cmd: 'pushable', arg });
       return true;
+    case 'eyes':
+      bus.emit('command', { cmd: 'eyes', arg });
+      return true;
     case 'boom': case 'blast':
       bus.emit('command', { cmd: 'boom', arg });
       return true;

--- a/client/lib/commands/handlers.js
+++ b/client/lib/commands/handlers.js
@@ -27,6 +27,21 @@ import { getMe } from '../mybody.js';
 
 register('help', () => toggleHelp());
 
+// Eyelids are BONES on rigs that have them (L_/R_Eyelid_Upper) — most VRMs
+// blink with a blendshape instead and have none, so this says so plainly
+// rather than appearing to work. Local: your eyes are yours to close, and
+// nothing about them is on the wire yet.
+register('eyes', (arg) => {
+  const me = getMe();
+  const want = /^(close|closed|shut)$/i.test((arg || '').trim()) ? true
+    : /^(open|up)$/i.test((arg || '').trim()) ? false
+      : null;
+  if (!me?.setEyes) return logChat('*', 'no body to close the eyes of');
+  const shut = want === null ? !me._eyesGoal : want;
+  if (!me.setEyes(shut)) return logChat('*', 'this body has no eyelid bones — nothing to close');
+  logChat('*', shut ? 'you close your eyes' : 'you open your eyes');
+});
+
 register('role', (arg) => {
   const who = (arg || '').trim() || CONFIG.name;
   if (who === CONFIG.name && !worldHasOwner() && net.myRights?.open !== false) {

--- a/client/lib/commands/registry.js
+++ b/client/lib/commands/registry.js
@@ -19,6 +19,7 @@ export const COMMANDS = [
   { name: 'emote', help: '/emote dance · wave cheer dance point salute clap' },
   { name: 'sit', help: 'sit down, on a seat if one is near' },
   { name: 'push', aliases: ['shove'], help: '/push [name] [power] — shove someone within reach (their client decides); /push <thing> works the thing' },
+  { name: 'eyes', help: '/eyes close|open — hold your eyes shut, if your rig has eyelid bones' },
   { name: 'pushable', help: '/pushable on|off — whether shoves and blasts can knock you over (on by default)' },
   { name: 'boom', aliases: ['blast'], help: '/boom [power] [radius] — a blast where you stand, you included (builder)' },
   { name: 'kick', help: '/kick [thing] [power] — send an object flying (a person\'s name = moderation)' },

--- a/client/lib/debug.js
+++ b/client/lib/debug.js
@@ -200,6 +200,35 @@ function disposeCapsules() {
   ragCaps = null;
 }
 
+// Box volumes. Geometry is a unit cube built once and SCALED per box, so N
+// volumes cost N transforms — the same bargain the collider boxes strike.
+let ragVols = null;
+function syncVolumes(vols) {
+  if (!ragVols || ragVols.items.length !== vols.length) {
+    disposeVolumes();
+    const items = vols.map(() => {
+      const mesh = onTop(new THREE.LineSegments(unitBoxWire(), lineMat(RAG_COLOR.bone)));
+      ragGroup.add(mesh);
+      return mesh;
+    });
+    ragVols = { items };
+  }
+  vols.forEach((v, i) => {
+    const m = ragVols.items[i];
+    m.position.copy(v.p);
+    m.quaternion.copy(v.q);
+    m.scale.set(v.he.x * 2, v.he.y * 2, v.he.z * 2);
+  });
+}
+function disposeVolumes() {
+  // NOT m.geometry.dispose(): every box shares the one unit cube, so disposing
+  // it through any single mesh guts all the others.
+  for (const m of ragVols?.items ?? []) ragGroup?.remove(m);
+  ragVols = null;
+}
+let _boxWire = null;
+const unitBoxWire = () => (_boxWire ??= new THREE.WireframeGeometry(new THREE.BoxGeometry(1, 1, 1)));
+
 function syncRagdoll(rd) {
   // ---- joint spheres, at the radius the GROUND and props are tested against
   // (which is per-joint, and not the same number as a bone's radius)
@@ -217,7 +246,15 @@ function syncRagdoll(rd) {
   });
   ragJoints.mesh.instanceMatrix.needsUpdate = true;
 
+  // ---- box volumes, for engines that hold boxes rather than capsules
+  // (ammo/rapier). The verlet answers with caps/radius below; a Bullet doll
+  // answered with nothing at all until volumes() existed, so the panel showed
+  // a skeleton floating in no body.
+  const vols = rd.volumes?.() ?? [];
+  if (vols.length) syncVolumes(vols); else disposeVolumes();
+
   // ---- bone capsules
+  if (!rd.caps) return;
   if (ragCaps?.rd !== rd) buildCapsules(rd);
   for (const it of ragCaps.items) {
     const pa = rd.p[it.cap.a], pb = rd.p[it.cap.b];
@@ -391,6 +428,7 @@ function clearColliders() {
 function clearRagdoll() {
   if (ragJoints) { ragGroup?.remove(ragJoints.mesh); ragJoints = null; }
   disposeCapsules();
+  disposeVolumes();
 }
 
 const fmt = (n, d = 2) => (Number.isFinite(n) ? n.toFixed(d) : '--');
@@ -450,6 +488,13 @@ export function updateDebug(now = performance.now()) {
       `  speed  ${fmt(rd.maxV, 3).padStart(5)} m/s`,
       `  still  ${fmt(rd.settledFor, 2).padStart(5)} s`,
       `  age    ${fmt(rd.elapsed, 2).padStart(5)} s`,
+      // hipsOffset is how far the render root hangs below the hips. It is a
+      // property of the RIG, so it should read the same on every body of the
+      // same avatar and never change across a drag or a release — when it
+      // drifts, the whole body renders that far off the sim, which is what
+      // floating and clipping through the floor both look like from inside.
+      `  hipsΔ  ${fmt(rd.hipsOffset, 3).padStart(5)} m  (rig constant)`,
+      `  rootY  ${fmt(rd.avatar?.root?.position?.y, 3).padStart(5)} m`,
       // steps vs age separates "nobody is calling step()" from "step() is
       // being called with dt 0" — two very different bugs that look identical
       // from a frozen body.

--- a/client/lib/debug.js
+++ b/client/lib/debug.js
@@ -17,6 +17,7 @@ import { THREE, scene } from './core.js';
 import { MeshBVHHelper } from 'three-mesh-bvh';
 import { colliders } from './colliders.js';
 import { closestParams, TUNING } from './ragdoll.js';
+import { JOINT_SPECS } from './ammodoll.js';
 import { makeFrame } from './frames.js';
 
 // box = an OBB, walkable on top, solid on the sides between min.y and max.y
@@ -336,6 +337,118 @@ function dialRow(key, lo, hi, step) {
   return { wrap, reset: () => { TUNING[key] = DEFAULTS[key]; sl.value = DEFAULTS[key]; paint(); } };
 }
 
+// ---- joint limits ----------------------------------------------------------
+//
+// Anatomy is a matter of taste as much as measurement — a spine's range is a
+// real number, but how floppy a RAGDOLL should look inside it is a judgement,
+// and judging it from a table of degrees is guesswork. (It cost a round of
+// exactly that: halving the trunk's range looked right on every metric and
+// hyperextended the knees 148 degrees, because a stiff trunk stops absorbing a
+// landing.) So: pick a joint, drag its ranges, watch the body.
+//
+// Live — retune() pushes the table into the running constraints, so a body
+// already lying on the floor changes under your hands.
+
+// what each spec exposes: directional joints carry flex/ext, the rest an x pair
+const LIMIT_FIELDS = [
+  ['flex', 0, 180, 1], ['ext', 0, 180, 1],
+  ['twist', 0, 90, 1],
+  ['x0', -180, 0, 1], ['x1', 0, 180, 1],
+  ['z0', -180, 0, 1], ['z1', 0, 180, 1],
+];
+const getF = (S, f) => (f === 'x0' ? S.x?.[0] : f === 'x1' ? S.x?.[1]
+  : f === 'z0' ? S.z?.[0] : f === 'z1' ? S.z?.[1] : S[f]);
+const setF = (S, f, v) => {
+  if (f === 'x0') S.x[0] = v; else if (f === 'x1') S.x[1] = v;
+  else if (f === 'z0') S.z[0] = v; else if (f === 'z1') S.z[1] = v;
+  else S[f] = v;
+};
+
+let jointSel = null, jointRows = null, jointDefaults = null;
+
+function buildJointPanel(stack) {
+  // one snapshot of the shipped table, so "reset" means the defaults and not
+  // whatever was on the sliders when the panel was opened
+  jointDefaults = JSON.parse(JSON.stringify(JOINT_SPECS));
+
+  const pick = document.createElement('select');
+  for (const k of Object.keys(JOINT_SPECS)) {
+    const o = document.createElement('option');
+    o.value = k; o.textContent = k;
+    pick.appendChild(o);
+  }
+  jointSel = pick;
+
+  const rows = document.createElement('div');
+  rows.style.cssText = 'display:flex;flex-direction:column;gap:3px';
+  jointRows = rows;
+
+  const apply = () => {
+    const rd = providers.ragdoll?.();
+    if (rd?.retune) rd.retune();
+  };
+
+  const paint = () => {
+    rows.textContent = '';
+    const S = JOINT_SPECS[pick.value];
+    if (!S) return;
+    for (const [f, lo, hi, st] of LIMIT_FIELDS) {
+      if (getF(S, f) === undefined) continue;
+      const wrap = document.createElement('div');
+      wrap.className = 'row';
+      const nm = document.createElement('span');
+      nm.className = 'nm'; nm.style.width = '42px'; nm.textContent = f;
+      const sl = document.createElement('input');
+      sl.type = 'range'; sl.min = lo; sl.max = hi; sl.step = st; sl.value = getF(S, f);
+      const val = document.createElement('span');
+      val.className = 'v'; val.style.width = '34px';
+      const show = () => { val.textContent = `${getF(S, f)}°`; };
+      sl.oninput = () => { setF(S, f, Number(sl.value)); show(); apply(); };
+      show();
+      wrap.append(nm, sl, val);
+      rows.appendChild(wrap);
+    }
+  };
+  pick.onchange = paint;
+  paint();
+
+  const btns = document.createElement('div');
+  btns.className = 'row';
+  const mk = (label, fn) => {
+    const b = document.createElement('button');
+    b.textContent = label; b.onclick = fn; btns.appendChild(b); return b;
+  };
+  mk('reset joint', () => {
+    Object.assign(JOINT_SPECS[pick.value], JSON.parse(JSON.stringify(jointDefaults[pick.value])));
+    paint(); apply();
+  });
+  // The point of tuning is to KEEP the answer. Printing the whole table as a
+  // paste-able literal is the difference between a nice afternoon and a number
+  // you have to find twice.
+  mk('copy table', async () => {
+    const txt = Object.entries(JOINT_SPECS).map(([k, S]) => {
+      const parts = [`ref: '${S.ref}'`];
+      if (S.flex != null) parts.push(`flex: ${S.flex}`, `ext: ${S.ext}`, `want: '${S.want}'`);
+      else parts.push(`x: [${S.x[0]}, ${S.x[1]}]`);
+      parts.push(`twist: ${S.twist}`, `z: [${S.z[0]}, ${S.z[1]}]`);
+      return `  ${k}: { ${parts.join(', ')} },`;
+    }).join('\n');
+    const out = `const JOINT_SPECS = {\n${txt}\n};`;
+    try { await navigator.clipboard.writeText(out); toastLike('joint table copied'); }
+    catch { console.log(out); toastLike('joint table logged to console'); }
+  });
+
+  const head = document.createElement('div');
+  head.className = 'row';
+  const hl = document.createElement('span');
+  hl.className = 'nm'; hl.style.width = '42px'; hl.textContent = 'joint';
+  head.append(hl, pick);
+  stack.append(head, rows, btns);
+}
+
+// the panel has no toast of its own; keep the dependency to one line
+function toastLike(msg) { console.log(`[debug] ${msg}`); }
+
 // ---- panel -----------------------------------------------------------------
 
 function row(label, key, onChange) {
@@ -410,6 +523,14 @@ export function initDebug(p = {}) {
     resets.push(d.reset);
     stack.appendChild(d.wrap);
   }
+
+  // joint limits, live
+  const jhead = document.createElement('div');
+  jhead.className = 'row';
+  jhead.style.cssText = 'margin-top:6px;opacity:.75';
+  jhead.textContent = '— joint limits (live) —';
+  stack.appendChild(jhead);
+  buildJointPanel(stack);
 
   statsEl = document.createElement('pre');
   statsEl.className = 'dbg-stats';

--- a/client/lib/debug.js
+++ b/client/lib/debug.js
@@ -17,7 +17,8 @@ import { THREE, scene } from './core.js';
 import { MeshBVHHelper } from 'three-mesh-bvh';
 import { colliders } from './colliders.js';
 import { closestParams, TUNING } from './ragdoll.js';
-import { JOINT_SPECS } from './ammodoll.js';
+import { JOINT_SPECS, HAIR_TUNING } from './ammodoll.js';
+import { BLINK } from './avatar.js';
 import { makeFrame } from './frames.js';
 
 // box = an OBB, walkable on top, solid on the sides between min.y and max.y
@@ -446,6 +447,109 @@ function buildJointPanel(stack) {
   stack.append(head, rows, btns);
 }
 
+// ---- hair -------------------------------------------------------------------
+// The hair is the one system with no good headless metric: "peak segment speed"
+// cannot tell flowing from whipping, and a fall's numbers are dominated by the
+// body's own motion. So it gets dials and a pair of eyes.
+// Which way an eyelid SHUTS depends on how its bone was rolled, so the sign is
+// a coin flip from here — a dial settles it in one blink. Rigs that export a
+// Limit Rotation constraint (see eido_export.py) use their own value and ignore
+// this one.
+const BLINK_FIELDS = [
+  ['closed', -2, 2, 0.02],   // upper lid
+  ['lower', -2, 2, 0.02],    // lower lid — an upper alone does not shut an eye
+  ['dur', 0.05, 0.8, 0.01],  // seconds for the whole close-and-open
+  ['hz', 0.2, 4, 0.1],
+  // eyeMax 0 pins the eyeballs at rest — the way to tell "the eyes are rigged
+  // wrong" from "the gaze code is turning them wrong" without rebuilding.
+  ['eyeMax', 0, 1.2, 0.02],
+  ['axis', 0, 2, 1],          // 0=x 1=y 2=z — which way the lid hinges
+];
+
+const HAIR_FIELDS = [
+  ['mass', 0.001, 0.05, 0.001],
+  ['tension', 0, 40, 0.5],
+  ['damping', 0, 1, 0.02],
+  ['gravity', 0, 1.5, 0.05],
+  ['limit', 0, 90, 1],
+  ['rootExp', 0.2, 3, 0.1],
+];
+
+function buildBlinkPanel(stack) {
+  const rows = document.createElement('div');
+  rows.style.cssText = 'display:flex;flex-direction:column;gap:3px';
+  for (const [f, lo, hi, st] of BLINK_FIELDS) {
+    const wrap = document.createElement('div');
+    wrap.className = 'row';
+    const nm = document.createElement('span');
+    nm.className = 'nm'; nm.style.width = '54px'; nm.textContent = f;
+    const sl = document.createElement('input');
+    sl.type = 'range'; sl.min = lo; sl.max = hi; sl.step = st; sl.value = BLINK[f];
+    const val = document.createElement('span');
+    val.className = 'v'; val.style.width = '44px';
+    const show = () => {
+      val.textContent = (f === 'closed' || f === 'lower')
+        ? `${(BLINK[f] * 180 / Math.PI).toFixed(0)}°`
+        : f === 'dur' ? `${(BLINK[f] * 1000).toFixed(0)}ms`
+          : f === 'eyeMax' ? `${(BLINK[f] * 180 / Math.PI).toFixed(0)}°`
+            : f === 'axis' ? ['x', 'y', 'z'][BLINK[f]] ?? '?' : `${BLINK[f]}x`;
+    };
+    sl.oninput = () => { BLINK[f] = Number(sl.value); show(); };
+    show();
+    wrap.append(nm, sl, val);
+    rows.appendChild(wrap);
+  }
+  stack.appendChild(rows);
+}
+
+function buildHairPanel(stack) {
+  const defaults = { ...HAIR_TUNING };
+  const rows = document.createElement('div');
+  rows.style.cssText = 'display:flex;flex-direction:column;gap:3px';
+  const apply = () => {
+    const rd = providers.ragdoll?.();
+    if (rd?.retuneHair) rd.retuneHair();
+  };
+  const mk = () => {
+    rows.textContent = '';
+    for (const [f, lo, hi, st] of HAIR_FIELDS) {
+      const wrap = document.createElement('div');
+      wrap.className = 'row';
+      const nm = document.createElement('span');
+      nm.className = 'nm'; nm.style.width = '54px'; nm.textContent = f;
+      const sl = document.createElement('input');
+      sl.type = 'range'; sl.min = lo; sl.max = hi; sl.step = st; sl.value = HAIR_TUNING[f];
+      const val = document.createElement('span');
+      val.className = 'v'; val.style.width = '44px';
+      const show = () => {
+        val.textContent = f === 'mass' ? `${(HAIR_TUNING[f] * 1000).toFixed(1)}g`
+          : f === 'limit' ? `${HAIR_TUNING[f]}°` : String(HAIR_TUNING[f]);
+      };
+      sl.oninput = () => { HAIR_TUNING[f] = Number(sl.value); show(); apply(); };
+      show();
+      wrap.append(nm, sl, val);
+      rows.appendChild(wrap);
+    }
+  };
+  mk();
+  const btns = document.createElement('div');
+  btns.className = 'row';
+  const b1 = document.createElement('button');
+  b1.textContent = 'reset hair';
+  b1.onclick = () => { Object.assign(HAIR_TUNING, defaults); mk(); apply(); };
+  const b2 = document.createElement('button');
+  b2.textContent = 'copy hair';
+  b2.onclick = async () => {
+    const out = 'export const HAIR_TUNING = {\n'
+      + Object.entries(HAIR_TUNING).map(([k, v]) => `  ${k}: ${v},`).join('\n')
+      + '\n};';
+    try { await navigator.clipboard.writeText(out); toastLike('hair tuning copied'); }
+    catch { console.log(out); toastLike('hair tuning logged'); }
+  };
+  btns.append(b1, b2);
+  stack.append(rows, btns);
+}
+
 // the panel has no toast of its own; keep the dependency to one line
 function toastLike(msg) { console.log(`[debug] ${msg}`); }
 
@@ -523,6 +627,22 @@ export function initDebug(p = {}) {
     resets.push(d.reset);
     stack.appendChild(d.wrap);
   }
+
+  // blink, live
+  const bhead = document.createElement('div');
+  bhead.className = 'row';
+  bhead.style.cssText = 'margin-top:6px;opacity:.75';
+  bhead.textContent = '— blink (live) —';
+  stack.appendChild(bhead);
+  buildBlinkPanel(stack);
+
+  // hair, live
+  const hhead = document.createElement('div');
+  hhead.className = 'row';
+  hhead.style.cssText = 'margin-top:6px;opacity:.75';
+  hhead.textContent = '— hair (live, while ragdolled) —';
+  stack.appendChild(hhead);
+  buildHairPanel(stack);
 
   // joint limits, live
   const jhead = document.createElement('div');

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -316,11 +316,13 @@ export class HeadlessBody {
   }
 
   /** Add/update/remove a pin, in WORLD coordinates. */
-  setPin(joint: string | null, at?: number[] | null) {
+  setPin(joint: string | null, at?: number[] | null, firm = true) {
     if (!this.rd) return;
     if (!joint) { this.rd.setPin(null); return; }
     if (!Array.isArray(at)) { this.rd.setPin(joint, null); return; }
-    this.rd.setPin(joint, new this.m.THREE.Vector3(at[0], at[1], at[2]));
+    // Pins arriving here are NAILS (begin's opts.pins, and the bodydrag relay's
+    // pin map) — a hand is simulated by whoever is holding it, not replicated.
+    this.rd.setPin(joint, new this.m.THREE.Vector3(at[0], at[1], at[2]), firm);
   }
 
   /** Advance; returns what to stream, or null once the sim has captured. */

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -213,6 +213,31 @@ async function skeletonFor(httpBase: string, avatarPath: string) {
     const P: Record<string, any> = {};
     for (const [b, n] of Object.entries(bones)) if (g.nodes[n as number]) P[b] = wp(n);
     if (!P.hips) throw new Error("no hips bone");
+    // Hair chains too, with their real parenting.
+    //
+    // The stand-in carried HUMANOID bones only, so a headless body had no
+    // Hair_<chain>_<idx> nodes — and that is exactly what ammodoll's hair block
+    // looks for. Agents therefore ran with NO hair simulation while the browser
+    // ran 75 locks of it, and the fleet suite never touched that code path
+    // either: a whole subsystem absent and untested in the process that is
+    // supposed to BE the body.
+    const byName = new Map<string, number>();
+    g.nodes.forEach((n: any, i: number) => { if (n.name) byName.set(n.name, i); });
+    const parentOf = new Map<number, number>();
+    g.nodes.forEach((n: any, i: number) =>
+      (n.children ?? []).forEach((c: number) => parentOf.set(c, i)));
+    const hairParent: Record<string, string> = {};
+    for (const [name, i] of byName) {
+      if (!/^Hair_\d+_\d+$/.test(name)) continue;
+      P[name] = wp(i);
+      const pi = parentOf.get(i);
+      const pn = pi != null ? g.nodes[pi]?.name : null;
+      // a lock either continues another lock, or hangs off the head
+      hairParent[name] = (pn && /^Hair_\d+_\d+$/.test(pn)) ? pn : "head";
+    }
+    if (Object.keys(hairParent).length) {
+      Object.defineProperty(P, "__hairParent", { value: hairParent, enumerable: false });
+    }
     skeletons.set(key, P);
     return P;
   } catch (e) {
@@ -232,7 +257,11 @@ export class HeadlessBody {
 
   private constructor(m: NonNullable<typeof simMods>, P: Record<string, any>) {
     this.m = m;
-    this.av = m.rig.makeAvatar(P);
+    // realParent carries the hair chains; without it makeAvatar drops any bone
+    // that is not in its humanoid PARENT table, hair included.
+    const hp = (P as any).__hairParent;
+    this.av = hp ? m.rig.makeAvatar(P, { realParent: { ...(m.rig as any).PARENT, ...hp } })
+      : m.rig.makeAvatar(P);
   }
 
   /** null when physics is unavailable for this process or this VRM. */

--- a/mcpl/physics.ts
+++ b/mcpl/physics.ts
@@ -46,6 +46,8 @@ const STUB = fileURLToPath(new URL("../tools/core-stub.mjs", import.meta.url));
 
 let simMods: {
   Ragdoll: any;
+  Body: any;                 // the engine that actually runs: AmmoRagdoll or Ragdoll
+  engine: string;
   rig: { glbJson: any; humanBones: any; worldPositions: any; makeAvatar: any };
   THREE: any;
   terrain: any;
@@ -75,7 +77,31 @@ function loadSim(): Promise<typeof simMods> {
       const rig = await import("../tools/rig-load.mjs");
       const terrain = await import("../client/lib/terrain.js");
       const colliders = await import("../client/lib/colliders.js");
-      simMods = { Ragdoll: rag.Ragdoll, rig, THREE: stub.THREE, terrain, colliders };
+      // Bullet, not the Verlet floor. The browser has defaulted to ammo since
+      // it beat every other engine on live falls (bodysim.js), but a headless
+      // body hard-coded Ragdoll -- so a shoved agent tumbled under one solver
+      // while the human dragging it ran another, and every drag-release handed
+      // authority back to the SLOWER model mid-fall. That solver swap is what
+      // "the joints twist up and it doesn't fall naturally when I let go"
+      // actually is. ammodoll's ensureAmmo() already carries a bun branch and
+      // imports the same three modules the Verlet does; nothing needed inventing.
+      let Body: any = rag.Ragdoll;
+      let engine = "verlet";
+      const want = process.env.AGENT_BODY_ENGINE ?? "ammo";
+      if (want === "ammo") {
+        try {
+          const ammo = await import("../client/lib/ammodoll.js");
+          if (await ammo.ensureAmmo()) { Body = ammo.AmmoRagdoll; engine = "ammo"; }
+          else console.warn("[physics] ammo wasm did not open — falling back to verlet");
+        } catch (e) {
+          console.warn("[physics] ammodoll unavailable — falling back to verlet:", e);
+        }
+      }
+      // Say which engine answered. A silent fallback here is indistinguishable
+      // from a toggle that does not work -- the same ambiguity bodysim.js's
+      // status string was added to kill.
+      console.log(`[physics] headless body engine: ${engine}`);
+      simMods = { Ragdoll: rag.Ragdoll, Body, engine, rig, THREE: stub.THREE, terrain, colliders };
       return simMods;
     } catch (e) {
       simFailed = true;
@@ -265,8 +291,28 @@ export class HeadlessBody {
     // than restarting from the bones with the motion thrown away. Positions
     // arrive in world y and the sim now RUNS in world y: no offset.
     const seed = opts.sim && Array.isArray(opts.sim.j) ? { ...opts.sim } : null;
-    this.rd = new this.m.Ragdoll(this.av, lean, this.av.restBonePositions(), seed);
+    // Free the previous body FIRST. Every drag release begins a new one, and a
+    // Bullet body owns wasm: a world, its bodies and constraints, and up to
+    // 1089 ground tiles. The verlet owned nothing but JS, so dropping the
+    // reference was a complete release and this line never needed to exist —
+    // under ammo the same code leaked a whole world per release and killed the
+    // agent with Aborted(OOM) in `new AmmoRagdoll` after a few minutes of being
+    // dragged around. dispose() is idempotent (`_freed`), so this is safe even
+    // when the body already finished and freed itself.
+    this.rd?.dispose?.();
+    this.rd = new this.m.Body(this.av, lean, this.av.restBonePositions(), seed);
     for (const p of opts.pins ?? []) this.setPin(p.j, p.at);
+    // hipsOffset is how far the render root hangs below the hips — a property
+    // of the RIG, so it must read the same on every build of the same body.
+    // When it moves, everyone else sees this body float or sink by exactly the
+    // difference, and nothing on THIS side looks wrong, which is why it needs
+    // saying out loud. Only a handover can move it, so only log then.
+    if (process.env.BODY_DEBUG && this.rd) {
+      console.log(`[physics] ${opts.sim ? "handover" : "fresh"} build: `
+        + `hipsOffset=${this.rd.hipsOffset?.toFixed(4)} `
+        + `rootY=${this.av.root.position.y.toFixed(3)} `
+        + `hips=${this.rd.p?.hips?.y?.toFixed(3)}`);
+    }
   }
 
   /** Add/update/remove a pin, in WORLD coordinates. */
@@ -285,10 +331,28 @@ export class HeadlessBody {
     if (!pose) return null;
     const r = this.av.root.position;
     const out = { pose, p: [r.x, r.y, r.z], done: !!this.rd.done };
-    if (this.rd.done) this.rd = null;
+    if (this.rd.done && process.env.BODY_DEBUG) {
+      // Where did she actually COME TO REST? Build-time numbers say nothing
+      // about this: the question "does she settle above the floor" is about the
+      // sim's own ground plane and its lowest joint, and both are only knowable
+      // once it stops. groundY is what the solver believes the floor is; if
+      // that disagrees with the world's floor, everything else is downstream
+      // of it and no amount of root arithmetic will help.
+      let lo = Infinity, who = "";
+      for (const [j, v] of Object.entries(this.rd.p ?? {})) {
+        const y = (v as any)?.y;
+        if (Number.isFinite(y) && y < lo) { lo = y; who = j; }
+      }
+      console.log(`[physics] SETTLED: groundY=${this.rd.groundY?.toFixed(3)} `
+        + `lowestJoint=${lo.toFixed(3)} (${who}) hips=${this.rd.p?.hips?.y?.toFixed(3)} `
+        + `rootY=${r.y.toFixed(3)}  [lowest joint should sit just above groundY]`);
+    }
+    if (this.rd.done) { this.rd.dispose?.(); this.rd = null; }
     return out;
   }
 
   get active() { return this.rd != null; }
-  stop() { this.rd = null; }
+  /** Drop the body. dispose() before the reference goes: under ammo the
+   *  reference is the only handle on a wasm world. */
+  stop() { this.rd?.dispose?.(); this.rd = null; }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -135,8 +135,15 @@ const gzCache = new Map<string, { mtime: number; gz: Uint8Array }>();
 // pre-§22l shader through a server restart and a whole branch A/B — mode
 // read 'cards-sss' while the wire had 'opaque'). no-cache still rides the
 // ETag: revalidation is a 304, not a re-download.
+// .vrma is in that list too, and was missing from it: ".vrma" does not match
+// endsWith(".vrm"), so ANIMATIONS cached hard for a day. Worse than a stale rig,
+// because a .vrm URL carries ?v=mtime and an animation URL carries no version at
+// all — a bad clip is sticky with no way to invalidate it. Measured 2026-08-12:
+// a placeholder dropped in during a bring-up stuck for every avatar on the
+// roster, and read as "animations are broken" rather than "your cache is holding
+// one wrong file".
 const hardCacheable = (path: string) =>
-  !path.endsWith(".vrm") && !/\.(m?js|json)$/i.test(path);
+  !/\.vrma?$/i.test(path) && !/\.(m?js|json)$/i.test(path);
 
 function serveFrom(base: string, rel: string, cache = false, req?: Request, immutable = false): Response {
   const path = normalize(join(base, rel));

--- a/tools/glb2vrm.ts
+++ b/tools/glb2vrm.ts
@@ -210,6 +210,36 @@ const TRIPO_MAP: Record<string, string> = {
   rightToes: "R_ToeBase",
 };
 
+// Digits are OPTIONAL: many rigs have no finger bones, and TRIPO_MAP is checked
+// with fail-fast nodeByName, so these cannot live in it. Any entry whose bone is
+// missing is simply skipped.
+//
+// Worth mapping, because ammodoll.js ports the source's finger springs and
+// tendon coupling and asks for these exact joints — without them a rig with a
+// full hand rig arrives with no finger physics at all.
+//
+// Tripo's naming, and two traps in it:
+//   *0 is the METACARPAL. VRM has a slot for the thumb's and NOT for the other
+//      fingers — which matches the source rig's own choice to keep metacarpals
+//      fused to the hand body. So Index0/Middle0/Ring0/Pinky0 are deliberately
+//      unmapped, and Index1 is the PROXIMAL.
+//   VRM says "Little" where Tripo says "Pinky".
+const TRIPO_DIGITS: Record<string, string> = (() => {
+  const m: Record<string, string> = {};
+  for (const [vrmSide, t] of [["left", "L"], ["right", "R"]] as const) {
+    m[`${vrmSide}ThumbMetacarpal`] = `${t}_Thumb0`;
+    m[`${vrmSide}ThumbProximal`]   = `${t}_Thumb1`;
+    m[`${vrmSide}ThumbDistal`]     = `${t}_Thumb2`;
+    for (const [vrmFinger, tripoFinger] of
+         [["Index", "Index"], ["Middle", "Middle"], ["Ring", "Ring"], ["Little", "Pinky"]] as const) {
+      m[`${vrmSide}${vrmFinger}Proximal`]     = `${t}_${tripoFinger}1`;
+      m[`${vrmSide}${vrmFinger}Intermediate`] = `${t}_${tripoFinger}2`;
+      m[`${vrmSide}${vrmFinger}Distal`]       = `${t}_${tripoFinger}3`;
+    }
+  }
+  return m;
+})();
+
 // ------------------------------------------------------------------- main
 
 const argv = Bun.argv.slice(2);
@@ -378,9 +408,18 @@ g.extensions.VRMC_vrm = {
       if (mirrored) console.log("  rig is mirrored (L_* bones at -X) → swapping left/right in humanoid map");
       const side = (name: string) =>
         mirrored ? name.replace(/^([LR])_/, (_, c) => (c === "L" ? "R_" : "L_")) : name;
-      return Object.fromEntries(
+      const out: Record<string, { node: number }> = Object.fromEntries(
         Object.entries(TRIPO_MAP).map(([vrm, tripo]) => [vrm, { node: nodeByName(g, side(tripo)) }]),
       );
+      let digits = 0;
+      for (const [vrm, tripo] of Object.entries(TRIPO_DIGITS)) {
+        const idx = g.nodes.findIndex((n: any) => n.name === side(tripo));
+        if (idx >= 0) { out[vrm] = { node: idx }; digits++; }
+      }
+      console.log(digits
+        ? `  mapped ${digits} finger bones (ammodoll drives these as spring joints)`
+        : "  no finger bones found — hands will be rigid in the body engine");
+      return out;
     })(),
   },
 };

--- a/tools/rig-load.mjs
+++ b/tools/rig-load.mjs
@@ -48,20 +48,31 @@ export function worldPositions(g) {
   const parent = new Map();
   g.nodes.forEach((n, i) => (n.children ?? []).forEach((c) => parent.set(c, i)));
   const memo = new Map();
+  // Full matrices, because SCALE is load-bearing here. Composing only
+  // translation and rotation (and reading a matrix node's translation column
+  // while dropping its basis) silently drops any scale on an ancestor — and
+  // glb2vrm bakes a uniform scale on the Armature to bring a ~1m Tripo export
+  // to human height, so mythospaint's armature carries 1.651. The headless
+  // skeleton came out 0.86m tall while the browser rendered her at 1.65m.
+  // Bone quaternions are scale-free, so limbs still looked right and nothing
+  // complained; only the streamed ROOT was in the small frame, which put her
+  // ~0.46m — a foot and a half — above the floor for everyone watching.
+  const localMatrix = (n) => (n.matrix
+    ? new THREE.Matrix4().fromArray(n.matrix)
+    : new THREE.Matrix4().compose(
+      new THREE.Vector3(...(n.translation ?? [0, 0, 0])),
+      new THREE.Quaternion(...(n.rotation ?? [0, 0, 0, 1])),
+      new THREE.Vector3(...(n.scale ?? [1, 1, 1])),
+    ));
   const world = (i) => {
     if (memo.has(i)) return memo.get(i);
-    const n = g.nodes[i];
-    const t = n.matrix ? new THREE.Vector3(n.matrix[12], n.matrix[13], n.matrix[14])
-      : new THREE.Vector3(...(n.translation ?? [0, 0, 0]));
-    const q = new THREE.Quaternion(...(n.rotation ?? [0, 0, 0, 1]));
+    const m = localMatrix(g.nodes[i]);
     const p = parent.get(i);
-    const out = p === undefined ? { p: t, q }
-      : (() => { const pw = world(p);
-          return { p: t.clone().applyQuaternion(pw.q).add(pw.p), q: pw.q.clone().multiply(q) }; })();
+    const out = p === undefined ? m : world(p).clone().multiply(m);
     memo.set(i, out);
     return out;
   };
-  return (i) => world(i).p.clone();
+  return (i) => new THREE.Vector3().setFromMatrixPosition(world(i));
 }
 
 /** Every shipped rig, as { name, P } where P maps humanoid bone -> world rest


### PR DESCRIPTION
Found while bringing a Tripo-rigged avatar (kintsugi porcelain, hand-painted, 75 hair locks) into a world and using it as a physics crash-test dummy. Thirteen commits, each standing alone; ordered here by how broadly each one bites.

Everything is verified against `tools/ammodoll-test.ts` (38/38 at every commit), and where a claim is a number it was measured rather than reasoned.

### Bodies

**`rig-load`: headless skeletons lost armature scale.** `worldPositions` composed translation and rotation only, and read a `matrix` node's translation column while discarding its basis — so any scale on an ancestor was silently dropped. Every avatar through `glb2vrm` carries one. The headless skeleton came out **0.86m tall while the browser rendered her at 1.65m**; bone quaternions are scale-free so limbs looked right and nothing complained, but the streamed root was in the small frame and the body floated ~0.46m above the floor for everyone else. Affects any headless body whose VRM has a scaled armature. (`import-tripo-avatar` sidesteps this by baking scale into translations — this fixes it from the other end.)

**`physics`: headless bodies run Bullet, and free it.** `HeadlessBody` hard-coded the Verlet, so a shoved agent tumbled under one solver while the human dragging it ran another, and every drag-release handed authority back mid-fall. `ensureAmmo()` already had a bun branch. Then: dispose the previous body — a Bullet body owns a wasm world, its bodies and constraints and up to 1089 ground tiles, where the Verlet owned only JS, so the existing drop-the-reference leaked a world per release and killed agents with `Aborted(OOM)`. 120 rebuild cycles survive; removing the dispose reproduces the OOM at the identical stack.

**`ammodoll`: a handover is not a birth.** The build-time widening ("a joint must contain the pose it was born in") re-ran on drag-release rebuilds, enshrining whatever bend the body was in — and since every release rebuilds, limits **ratcheted**: the neck's lateral range went 70° → 103° → 115° → 132° over four cycles. Separately `hipsOffset`, a rig constant, was re-measured against a root the falling-only clamp had pinned low: 0.925 instead of 0.599, rendering her a third of a metre into the floor.

**`ammodoll`: real inertia, and a hand is not a nail.** `btCompoundShape::calculateLocalInertia` is an AABB approximation, and limb boxes sit rotated inside their compound — **4.75× the true inertia about the bone** on a 45° limb, which is the twist axis, which carries the tightest limits in the table. Computed properly instead. Also: `setPin` now distinguishes a nail from a hand; only the nail's stiffness had been ported, so every drag was held by a nail.

**`ammodoll`: the trunk is three bodies, not a plank.** `TORSO_KEYS` fused hips/spine/chest, so the spine and chest joints in the table did not exist — no fold at the waist, and every arm and the head hanging off one body carrying half the doll's mass. Worst overshoot past a joint limit, averaged over 8 falls: **42.3° → 26.0°**.

**`ammodoll`: render the roll.** Bones were driven by `shortestArc(restDir, liveDir)` — a pure swing, reproducing direction and discarding rotation about the bone's own axis. Measured on a plain fall: **thigh roll 53° in the sim, 0.0° in the render**. A leg could be placed perfectly and drawn facing backwards, and no twist limit could touch it. The Bullet hair (#118) was already driven from its body's rotation; the core skeleton was not. Also sizes the trunk from the source's proxy-mesh proportions (it was 0.12m wide by 0.07m deep) and makes joint limits tunable in-world.

### Hair

**`hair`: the source's model, and a body that actually has any.** Headless bodies had **no hair at all** — `skeletonFor` collected humanoid bones only, so there were no `Hair_*` nodes for ammodoll's hair block to find, and the fleet suite never touched that path either. Then the port's parameters against the source playground's: hair is built with `isFinger=true` and had inherited the finger damping and collision group; its spring ran 2.0/0.9 where the source uses 8.0/0.6 (and Bullet's spring "damping" is a target-velocity gain, so that is 1.5× the speed on ¼ the force). Structurally: a kinematic anchor per lock instead of springing to the dynamic head, the root segment excluded from the head collider, `dt` clamped to 0.05, and the combed pose captured once so a crumple cannot become the next tumble's rest.

### Eyes

**`eyes`: a blink that happens, eyeballs that look, and lids that close.** The blink clock lived inside `if (em)`, so on a rig whose eyelids are bones — no expressions at all — it never even advanced. Value first, consumers after. The rig's Limit Rotation constraints now arrive as node extras and are preferred over any default, but they are **absolute angles in the bone's frame, not offsets from rest**: read as a delta, the upper lids swung 240°, left the head, and presented as "you can see through the eyelids", proof against enlarging the mesh or trying every axis. `/eyes close|open` holds them shut, and eyes close when a body goes limp and open when it gets up — driven from `setLimp`, so it is true of everyone you watch fall, with nothing added to the wire.

**`avatar`: yield the eyeballs to three-vrm when the rig maps them.** #120 landed while this branch was in flight and maps `L_Eye`/`R_Eye` to VRM `leftEye`/`rightEye`. This defers to the stock lookAt rig when both are present, so the two do not both write those bones every frame; the bone path stays for rigs imported before that.

### Smaller

**`avatars`: fingers through the VRM door, whole bodies on screen, fresh clips.** `glb2vrm` mapped no digits, so a rig with a full hand arrived with no finger physics. A `SkinnedMesh` bounding sphere comes from bind-pose positions, so it stops bounding the mesh once posed and three.js culls against the stale sphere — invisible on a one-primitive avatar, and the reason the hair vanished from most angles on a multi-material one. `.vrma` missed `hardCacheable`'s avatar exemption, so animations cached hard for 24h with no version in the URL to invalidate.

**`avatar`: put the contact shadow on the ground.** It was added to `root` at a fixed local y and never repositioned, so it rode along beneath a lifted body at a constant 2cm — disproving the one thing its own comment says it is for.

**`debug`: draw the boxes a Bullet body is made of, and dials for what no metric can judge.** The overlay read `caps`/`radius`, which only the verlet has, so under the default engine it drew a skeleton floating in no body. Plus live tuning for joint limits, hair and blink — each with a copy button, because the point of tuning is to keep the answer.

---

### Note on overlap

`#120` fixes, in the importer, the same trap this branch hit in the exporter: **paint tested by presence rather than by value**. An all-white `COLOR_0` satisfies "does this primitive have paint?" and then renders white — which is how an avatar shipped white eyeballs one line after the log said `vertex-painted, kept`. The two fixes are complementary (that one stops the importer trusting it; the rig-side export stops producing it), and it seems worth noting that it was found independently from both ends.

### Testing

`tools/ammodoll-test.ts` 38/38 throughout — and it now exercises the Bullet hair path, which it never had.

Beyond it, headless harnesses against `mythospaint.vrm`, each verified to **fail on the bug it claims to catch**: the leak test reproduces the OOM with the dispose removed; the roll test reports 53°/0.0° before and 53°/53° after. Two measurement corrections worth flagging: single-run figures from a chaotic sim are not evidence (the n=8 spread on one metric is 19–75°, which swallowed several comparisons I first reported), and peak hair speed cannot distinguish flowing from whipping — the hair numbers here were tuned by eye for that reason.

### Not addressed

The drag case is worse than where it started (80.9° → 108.8° of overshoot, averaged over 8 falls): correcting the inertia makes limbs genuinely lighter, and it does not respond to the handle. It traces to constraint softness at the pin.

Underneath that sits the one structural difference not touched here: the source rig writes both constraint frames at the **built pose**, so every joint operates near zero where Bullet's angular wrap is unreachable, while this port re-centres each frame on the range midpoint — a knee sits ~60° from its own frame zero and can cross the wrap, at which point the limit holds it on the wrong side. That is "a joint gets twisted and then is stuck like that", reproduced headless on three rigs: the hyperextension magnitude tracks the knee's own flexion limit exactly (123 → 125°, 145 → 146°), so it is sitting at its LEGAL limit measured the wrong way round. Building frames at the pose is the real fix, and it would also let a hand-tuned hip row in that currently has to be held back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
