### PR TITLE
isolation headers: COOP/COEP credentialless, so piper TTS can go multithreaded

### DIFF
--- a/client/lib/conjure.js
+++ b/client/lib/conjure.js
@@ -4,7 +4,8 @@
 // Orrery (orrery.animalabs.ai) is the multistage 3D prompting service:
 // gpt-image turnarounds → Tripo mesh → texture/rig, stored as a version
 // tree. This panel drives its API directly, cross-origin with credentials
-// (Orrery ships CORS + a SameSite=None session for exactly this). The heavy
+// (Orrery ships CORS + a SameSite=None session for exactly this — including on
+// the asset endpoint, checked 2026-08-16). The heavy
 // bytes NEVER pass through this client: Orrery pushes finished GLBs to the
 // sequencer's /upload itself, and what we place is the returned store path.
 //
@@ -113,7 +114,20 @@ function progressOf(j) {
 
 function imageCandidates(j) {
   // the chain's first group = the image_gen siblings; thumbnails are their
-  // image assets, fetched straight from Orrery (plain <img>, cookie rides)
+  // image assets, fetched straight from Orrery.
+  //
+  // 🔴 NOT a plain <img> any more (2026-08-16). A bare <img> is a NO-CORS
+  // subresource, and under COEP `credentialless` — which this server now sends
+  // so wasm gets its threads — no-cors requests are sent WITHOUT credentials.
+  // These are private per-user assets, so they would have 404'd/403'd and the
+  // pick stage would have shown broken thumbnails with no explanation.
+  //
+  // crossorigin="use-credentials" moves them to CORS mode, which COEP does not
+  // touch. VERIFIED against the live service rather than assumed: the asset
+  // endpoint answers an eidoverse Origin with
+  //   access-control-allow-credentials: true
+  //   access-control-allow-origin: https://eidoverse.animalabs.ai
+  // (non-wildcard, as credentialed CORS requires).
   return (j.nodes ?? [])
     .filter((n) => n.op_type === 'image_gen' && n.status === 'completed')
     .map((n) => ({
@@ -142,15 +156,62 @@ async function paint(body) {
       try {
         const cfg = await api('/api/auth/config');
         const w = window.open(cfg.login_url, 'orrery-auth', 'width=520,height=680');
+        // 🔴 DO NOT DEPEND ON postMessage FROM THE POPUP (2026-08-16). Under
+        // COOP `same-origin` — which cross-origin isolation requires, and which
+        // this server now sends so wasm gets its threads — a cross-origin popup
+        // lands in a different browsing-context group: its `window.opener` is
+        // null, so it CANNOT message us back, and our handle `w` is a severed
+        // proxy whose close() is a no-op. Sign-in would hang forever with no
+        // error anywhere.
+        //
+        // So: keep the message path (it still works when isolation is off, and
+        // it is instant), but treat it as an optimisation over POLLING, which
+        // needs no opener relationship at all. /api/auth/me is a CORS fetch —
+        // credentialless does not touch cors-mode requests, only no-cors
+        // subresources (MDN: "requests made in cors mode won't be blocked by
+        // COEP"), so the session cookie still rides.
+        let done = false;
+        // ONE teardown, idempotent, shared by every exit (review on the
+        // isolation PR: the timeout branch used to clear only the interval —
+        // the message listener stayed installed and accumulated across retry
+        // attempts, `done` stayed false, and the abandoned flow had no
+        // visible completion or retry state).
+        const cleanup = () => {
+          if (done) return false;
+          done = true;
+          removeEventListener('message', onMsg);
+          clearInterval(poll);
+          try { w?.close(); } catch { /* severed under COOP, or already closed */ }
+          return true;
+        };
+        const finish = () => {
+          if (!cleanup()) return;
+          connected = null;                       // unknown → paint re-checks auth
+          paint(body).catch((e) => report('conjure', e));
+        };
+        const abandon = (reason) => {
+          if (!cleanup()) return;
+          connected = false;                      // retryable: the connect button paints again
+          console.warn(`[conjure] orrery login ${reason}`);
+          paint(body).catch((e) => report('conjure', e));
+        };
         const onMsg = (ev) => {
-          if (ev.data === 'orrery:signed-in') {
-            removeEventListener('message', onMsg);
-            connected = null;
-            try { w?.close(); } catch { /* it closes itself */ }
-            paint(body).catch((e) => report('conjure', e));
-          }
+          // The message path is an optimisation retained for non-isolated
+          // browsers — but the data string alone is not identity: any window
+          // that can obtain a reference could post it. Origin must match the
+          // configured Orrery.
+          if (ev.origin !== new URL(ORRERY).origin) return;
+          if (ev.data === 'orrery:signed-in') finish();
         };
         addEventListener('message', onMsg);
+        // 90s at 2s intervals: long enough for a slow Discord sign-in, bounded
+        // so a user who abandons the popup does not leave a timer running.
+        let tries = 0;
+        const poll = setInterval(async () => {
+          if (done) return;
+          if (++tries > 45) { abandon('timed out after 90s — connect again to retry'); return; }
+          try { await api('/api/auth/me'); finish(); } catch { /* not yet */ }
+        }, 2000);
       } catch (e) { report('orrery login', e); }
     };
     return;
@@ -163,7 +224,8 @@ async function paint(body) {
     let inner = '';
     if (j.status === 'waiting_selection') {
       inner = `<div class="cj-pick">${imageCandidates(j).map((c) => `
-        <img src="${ORRERY}/api/assets/${esc(c.img.id)}/file" data-star="${esc(c.node.id)}"
+        <img crossorigin="use-credentials"
+             src="${ORRERY}/api/assets/${esc(c.img.id)}/file" data-star="${esc(c.node.id)}"
              title="use this one (starts the mesh)">`).join('')
         || '<span class="sub">candidates finished but none readable — open orrery</span>'}</div>`;
     } else if (j.status === 'completed') {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -373,7 +373,12 @@ const ROUTES: Route[] = [
     // upstream #51, ported to the route table: which build is this world
     // running — public, cheap, cache-hostile; the whole point is NOW
     match: (u) => u.pathname === "/version",
-    handler: () => new Response(JSON.stringify(BUILD),
+    // EIDO_BOOT_NONCE: a per-run identity echo for tests that spawn a child
+    // server — "the first 89xx listener that answers" is not identity, and a
+    // stale server has bought a false green in this repo before (review on
+    // the isolation PR). Absent unless the spawner sets it.
+    handler: () => new Response(JSON.stringify(
+      process.env.EIDO_BOOT_NONCE ? { ...BUILD, nonce: process.env.EIDO_BOOT_NONCE } : BUILD),
       { headers: { "content-type": "application/json", "cache-control": "no-store" } }),
   },
   {
@@ -684,10 +689,59 @@ const ROUTES: Route[] = [
  *  unsplit fetch() had. The catch-all last row means every request gets a
  *  Response… except a successful /ws upgrade, which (as before) returns none
  *  and lets Bun own the socket. */
+// 🔴 CROSS-ORIGIN ISOLATION — why local speech synthesis runs single-threaded.
+//
+// engine-piper.js reads `crossOriginIsolated && SharedArrayBuffer` and pins
+// ort.env.wasm.numThreads to 1 when either is missing. This server sent no COOP
+// or COEP headers, so both were false and ONNX inference ran single-threaded on
+// every machine that loaded the page, however many cores it has. The client's
+// own console said so on every load ("SINGLE-THREADED — isolation headers
+// missing"); the diagnostic was already printing the answer.
+//
+// COEP is `credentialless` rather than `require-corp`: require-corp blocks any
+// cross-origin subresource that does not opt in with CORP headers, which would
+// break third-party assets the moment someone adds one. credentialless buys the
+// same isolation by stripping credentials instead of refusing the request.
+// 🔴 THE CLIENT DOES LOAD CROSS-ORIGIN THINGS. This comment used to claim it
+// "loads nothing cross-origin" — false, asserted without checking, and it was
+// the justification for the whole choice. What it loads, and how each fares:
+//
+//   • DRACO decoder wasm from gstatic (assets.js) — fine either way; gstatic
+//     sends `cross-origin-resource-policy: cross-origin`.
+//   • Orrery API via fetch(credentials:'include') (conjure.js) — UNAFFECTED.
+//     COEP governs no-cors SUBRESOURCES; a cors-mode fetch is not one
+//     ("requests made in cors mode won't be blocked by COEP" — MDN).
+//   • Orrery thumbnails via <img> — WAS affected: a bare <img> is no-cors, so
+//     credentialless would strip the session cookie. Fixed at the call site
+//     with crossorigin="use-credentials", moving it to cors mode.
+//
+// And COOP `same-origin` severs window.opener, which broke Orrery's OAuth
+// popup — it could not postMessage back and sign-in hung silently. conjure.js
+// now polls /api/auth/me as the primary signal, needing no opener at all.
+//
+// The headers must ride on EVERY response, not just the document: a worker
+// script served without them is not isolated and the whole context degrades.
+function isolate(res: Response): Response {
+  // 🔴 A SUCCESSFUL /ws UPGRADE RETURNS NOTHING — the ws route hands back
+  // `undefined as unknown as Response` and lets Bun own the socket. Touching it
+  // here would throw on every websocket connection, i.e. this header change
+  // would break the world rather than speed it up. Checked before shipping.
+  if (!res) return res;
+  // A 101 upgrade owns its own handshake — do not touch it.
+  if (res.status === 101) return res;
+  res.headers.set("cross-origin-opener-policy", "same-origin");
+  res.headers.set("cross-origin-embedder-policy", "credentialless");
+  return res;
+}
+
 export function route(req: Request, srv: Srv): Response | Promise<Response> {
   const url = new URL(req.url);
-  for (const r of ROUTES) if (r.match(url, req)) return r.handler({ req, url, srv });
+  for (const r of ROUTES) {
+    if (!r.match(url, req)) continue;
+    const out = r.handler({ req, url, srv });
+    return out instanceof Promise ? out.then(isolate) : isolate(out);
+  }
   // unreachable — the catch-all matches everything — but a table must not be
   // able to strand a request even if a future edit breaks that property.
-  return new Response("not found", { status: 404 });
+  return isolate(new Response("not found", { status: 404 }));
 }

--- a/tools/conjure-coop-contract-test.mjs
+++ b/tools/conjure-coop-contract-test.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+// The two client-side COOP-compatibility contracts the isolation PR depends
+// on, pinned (review: "the current 9 assertions cover server headers/socket
+// only; they do not protect the crossorigin thumbnail repair or the polling
+// cleanup that makes OAuth survive COOP").
+//
+// Source-contract style with corrupting negative controls (the door-media-
+// whitelist idiom, post-its-own-review): every predicate must also detect a
+// corruption of the REAL extracted text, so a drifted extraction anchor fails
+// loudly instead of passing vacuously.
+import { readFileSync } from 'fs';
+const src = readFileSync(new URL('../client/lib/conjure.js', import.meta.url), 'utf8');
+
+let pass = 0, fail = 0;
+const ok = (n, c) => { c ? (pass++, console.log(`ok   ${n}`)) : (fail++, console.log(`FAIL ${n}`)); };
+
+// ── contract 1: credentialed thumbnails ─────────────────────────────────────
+// Under COEP a bare <img> is fetched no-cors WITHOUT credentials — the Orrery
+// thumbnail 401s and the picker goes blank. The repair is crossorigin=
+// "use-credentials" on every candidate image.
+// (length filter: prose comments legitimately mention bare '<img>' — a real tag has attributes)
+const imgTags = [...src.matchAll(/<img\b[^>]*>/gs)].map((m) => m[0]).filter((t) => t.length > 12);
+const candidateImgs = imgTags.filter((t) => /cj-pick|imageCandidates|candidate/i.test(src.slice(Math.max(0, src.indexOf(t) - 300), src.indexOf(t) + t.length)));
+ok('at least one candidate <img> exists to protect', candidateImgs.length > 0);
+ok('every candidate <img> carries crossorigin="use-credentials"',
+   candidateImgs.length > 0 && candidateImgs.every((t) => t.includes('crossorigin="use-credentials"')));
+ok('control: the matcher detects a stripped crossorigin attr',
+   !candidateImgs.map((t) => t.replace(/\s*crossorigin="use-credentials"/, ''))
+     .every((t) => t.includes('crossorigin="use-credentials"')) || candidateImgs.length === 0);
+
+// ── contract 2: the login flow's single idempotent teardown ─────────────────
+// Under COOP the popup's postMessage rescue can never arrive, so the POLL owns
+// completion — and the timeout must run the SAME teardown as success: listener
+// removed, timer cleared, done latched, a retryable state painted. The old
+// shape (`clearInterval(poll); return;`) accumulated a `message` listener per
+// abandoned attempt.
+const login = src.slice(src.indexOf('let done = false'), src.indexOf('} catch (e) { report(\'orrery login\''));
+ok('login block extracted (anchors present)', login.length > 200);
+ok('one shared cleanup latches done + removes the listener + clears the timer',
+   /const cleanup = \(\) => \{[^}]*done = true;[\s\S]*?removeEventListener\('message', onMsg\);[\s\S]*?clearInterval\(poll\);/.test(login));
+ok('the timeout branch runs the teardown (abandon), not a bare clearInterval',
+   /tries > 45\) \{ abandon\(/.test(login) && !/tries > 45\) \{ clearInterval/.test(login));
+ok('abandon restores a RETRYABLE state (connected = false)',
+   /const abandon[\s\S]*?connected = false/.test(login));
+ok('the message path validates ev.origin against the configured Orrery',
+   /ev\.origin !== new URL\(ORRERY\)\.origin/.test(login));
+ok('control: the timeout-matcher detects the old leaky shape',
+   /tries > 45\) \{ clearInterval/.test(login.replace(/tries > 45\) \{ abandon\([^)]*\); return; \}/, 'tries > 45) { clearInterval(poll); return; }')));
+ok('control: the origin-matcher detects its removal',
+   !/ev\.origin !== new URL\(ORRERY\)\.origin/.test(login.replace(/if \(ev\.origin !== new URL\(ORRERY\)\.origin\) return;\n?/, '')));
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/isolation-headers-test.mjs
+++ b/tools/isolation-headers-test.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+// Isolation headers — does every response actually carry COOP/COEP?
+//
+// 🔴 WHY THIS EXISTS. The PR that adds these headers had NO test. Its whole
+// claim is "wasm gets its threads back", which depends on `crossOriginIsolated`
+// being true in the browser, which depends on BOTH headers riding EVERY
+// response — not just the document. A worker script served without them
+// silently degrades the entire context back to single-threaded, and the only
+// symptom is the thing being slow, which is exactly the symptom we started with.
+//
+// The failure this guards is REGRESSION BY ROUTE: someone adds a route that
+// returns early, or wraps the table, and the document keeps its headers while
+// /client/lib/*.js quietly loses them. Testing only `/` would pass.
+//
+// It boots a real server on a scratch port and reads real responses. It does
+// NOT test that threads got faster — that is a benchmark, and a separate claim.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const PORT = 8971 + Math.floor(Math.random() * 20);
+let pass = 0, fail = 0;
+const ok = (name, cond, detail = '') => {
+  if (cond) { pass++; console.log(`ok   ${name}`); }
+  else { fail++; console.log(`FAIL ${name}${detail ? ' — ' + detail : ''}`); }
+};
+
+// 🔴 IDENTITY, NOT JUST A LISTENER (review: "we have already had an old 89xx
+// listener buy a false green in this repository"). The child echoes this
+// per-run nonce on /version; readiness and every later probe are bound to it,
+// so a stale server that lost us to EADDRINUSE cannot answer for the child.
+const NONCE = randomUUID();
+const scratch = mkdtempSync(join(tmpdir(), 'iso-'));
+const srv = spawn(process.execPath, ['server/server.ts'], {
+  env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: 'iso-test',
+         WORLDS_DIR: scratch, EIDO_BOOT_NONCE: NONCE },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+srv.stdout.on('data', () => {});
+srv.stderr.on('data', () => {});
+
+const childAlive = () => srv.exitCode === null && !srv.killed;
+const identity = async () => {
+  const v = await (await fetch(`http://127.0.0.1:${PORT}/version`)).json();
+  return v.nonce === NONCE;
+};
+const up = async () => {
+  for (let i = 0; i < 60; i++) {
+    if (!childAlive()) return false;            // died (EADDRINUSE etc.) — never green
+    try { if (await identity()) return true; }  // an answer that isn't OURS is not readiness
+    catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+};
+
+try {
+  if (!await up()) { console.log(`FAIL server never came up as OURS (child ${childAlive() ? 'alive' : `exited ${srv.exitCode}`})`); process.exit(1); }
+
+  // The document itself.
+  const doc = await fetch(`http://127.0.0.1:${PORT}/`);
+  ok('document sends COOP',
+     doc.headers.get('cross-origin-opener-policy') === 'same-origin',
+     `got ${doc.headers.get('cross-origin-opener-policy')}`);
+  ok('document sends COEP credentialless',
+     doc.headers.get('cross-origin-embedder-policy') === 'credentialless',
+     `got ${doc.headers.get('cross-origin-embedder-policy')}`);
+
+  // 🔴 THE ONE THAT ACTUALLY MATTERS. A module script without COEP breaks
+  // isolation for the whole context even when the document has it.
+  // 🔴 REAL 200s, NOT 404s. The first draft asked for '/client/main.js', which
+  // the catch-all resolves under client/ — so it 404'd, and a 404 carrying the
+  // headers proves much less than a real module doing so. The static tree is
+  // rooted AT client/, so the module is '/main.js'. Checked the route table
+  // (routes.ts:677) rather than guessing a second time.
+  for (const path of ['/main.js', '/lib/core.js', '/nonexistent-404']) {
+    const r = await fetch(`http://127.0.0.1:${PORT}${path}`);
+    if (path !== '/nonexistent-404') ok(`${path} is really served (not a 404)`, r.status === 200, `status ${r.status}`);
+    ok(`${path} (${r.status}) carries both headers`,
+       r.headers.get('cross-origin-opener-policy') === 'same-origin'
+       && r.headers.get('cross-origin-embedder-policy') === 'credentialless',
+       `COOP=${r.headers.get('cross-origin-opener-policy')} COEP=${r.headers.get('cross-origin-embedder-policy')}`);
+  }
+
+  // credentialless, NOT require-corp: require-corp would block any cross-origin
+  // subresource that does not opt in, which is a different (breaking) product
+  // decision. Pin the exact value so a "stricter is safer" edit has to argue.
+  ok('COEP is credentialless, not require-corp',
+     doc.headers.get('cross-origin-embedder-policy') !== 'require-corp');
+
+  // The websocket upgrade must be untouched — isolate() returning a modified
+  // response (or throwing on undefined) would break every world connection.
+  // A 101 never reaches fetch(), so the observable is: the socket still opens.
+  const wsOk = await new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+    const t = setTimeout(() => { try { ws.close(); } catch {} resolve(false); }, 4000);
+    ws.onopen = () => { clearTimeout(t); ws.close(); resolve(true); };
+    ws.onerror = () => { clearTimeout(t); resolve(false); };
+  });
+  ok('websocket upgrade still succeeds under isolate()', wsOk);
+
+  // Bind the whole vector run to the child one last time: still alive, still
+  // answering with our nonce. A mid-run crash + stale listener would otherwise
+  // pass every header assertion above.
+  ok('child is still alive after the vectors', childAlive(), `exitCode=${srv.exitCode}`);
+  ok('responder is still OUR child (nonce echo)', await identity().catch(() => false));
+} finally {
+  // TERM first (let it close sockets), escalate to KILL, then remove scratch.
+  srv.kill('SIGTERM');
+  await new Promise((r) => { const t = setTimeout(() => { try { srv.kill('SIGKILL'); } catch {} r(); }, 3000); srv.once('exit', () => { clearTimeout(t); r(); }); });
+  try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Smallest PR of the #104 stack, first because everything else sits on it.

Adds `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: credentialless` so `crossOriginIsolated` holds and the piper TTS wasm (PR 4 of this stack) can use threads. Companion fixes in conjure.js (`<img crossorigin>` + auth-popup poll) keep the Orrery flows working under the new policy.

- `credentialless` over `require-corp`: DRACO from gstatic carries CORP, Orrery API calls are cors-mode fetches COEP never touches, everything else is same-origin. Verified against every cross-origin resource the client actually loads.
- Safari note: no `credentialless` support there — `crossOriginIsolated` stays false and piper stays single-threaded, gracefully. A Safari report is not a regression.
- Receipts: `tools/isolation-headers-test.mjs` (9 assertions — headers, module scripts, the ws upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)