### PR TITLE
Wings that fly, and the hair write that never reached the renderer

### DIFF
--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -251,12 +251,110 @@ export const HAIR_TUNING = {
   // not all of it: full gravity and a root-heavy ramp (rootExp < 1) were found
   // by eye, against theory. Hair is the one system here with no honest headless
   // metric, so the eye is the instrument.
-  mass: 0.022,      // kg per segment
-  tension: 20,      // 6DOF angular spring stiffness
-  damping: 0.22,    // both the spring's and the body's angular damping
-  gravity: 1.5,     // fraction of world gravity — heavier than real, and right
-  limit: 75,        // degrees at the TIP
-  rootExp: 0.4,     // ramp exponent: lim = limit * (j/n)^rootExp
+  // ...WITH ONE LARGE ASTERISK, found 08-17: while those values were being
+  // tuned, three-vrm's springbones were overwriting every hair bone one system
+  // later in the frame (see avatar.js's vrm.update). So the sliders were tuning
+  // a simulation nobody could see — which is exactly what it felt like at the
+  // time: "hmm, the settings didn't change that much". tension 20 / damping
+  // 0.22 is therefore not a hand-tuned value for THIS sim; it is a value chosen
+  // against a different one.
+  //
+  // Re-measured now that the render follows the sim, as mean LOCAL bend per
+  // hair joint — world rotation cannot tell "the hair moves" from "the head
+  // moves", since a lock riding a tumbling body turns 100 degrees while lying
+  // perfectly straight:
+  //
+  //     tension  damping |  peak bend   at rest   jitter
+  //          20     0.22 |     34.9°     12.4°   0.020°/frame   <- as tuned
+  //           8     0.22 |     43.5°     15.8°   0.019
+  //           3     0.22 |     52.8°     20.3°   0.018
+  //           8     0.10 |     47.6°     19.4°   0.017
+  //           3     0.10 |     52.9°     24.9°   0.021          <- now
+  //
+  // Monotonic in both knobs, and the jitter does not pay for any of it. The
+  // dials are live and they finally bite, so this is a starting point to tune
+  // from by eye rather than a settled answer — hair remains the one system with
+  // no honest headless metric for "flows" versus "whips".
+  // TUNED BY JANUS, 08-17, and the FIRST tuning of this system done against a
+  // render that was actually showing it (see the matrixAutoUpdate note in
+  // step()). Every earlier number in this table — mine and theirs — was chosen
+  // while watching either three-vrm's springbones or nothing at all, so the
+  // history above is a record of what was measured, not of what was seen.
+  //
+  // Worth noting how close these land to the source playground's own defaults
+  // (mass 3 g, tension 8, damping 0.6, gravity 0.45, limit 25, rootExp 1.0),
+  // after a year of this port insisting it needed something different. It did
+  // not. It needed its output to reach the screen.
+  mass: 0.003,      // kg per segment
+  tension: 7.25,    // 6DOF angular spring stiffness
+  damping: 0.31,    // both the spring's and the body's angular damping
+  gravity: 0.45,    // fraction of world gravity
+  limit: 25,        // degrees at the TIP
+  rootExp: 1.2,     // ramp exponent: lim = limit * (j/n)^rootExp
+};
+
+/** Wing tuning, live. Same shape as HAIR_TUNING and the same instrument (the
+ *  eye, against a body being dropped), but a wing is not a lock of hair and the
+ *  numbers say so: three orders of magnitude more mass per segment, a limit
+ *  small enough that a folded wing cannot pass through the back it is attached
+ *  to, and a ramp that leaves the shoulder joint STIFFER than the elbow rather
+ *  than the reverse.
+ *
+ *  What a limp wing should look like is a real question and these are a first
+ *  answer: dead weight that swings from the shoulder and trails the body,
+ *  neither flapping (it is unconscious) nor rigid (it is not a prop). */
+export const WING_TUNING = {
+  mass: 0.55,       // kg per segment. Wings this size on a real animal would be
+                    // lighter, being mostly air — but a 20 g plate a metre long
+                    // is all lever and no inertia, and reads as paper.
+  // MEASURED, over 4 lean directions per row, because one fall's number is
+  // noise. The first guess here was 140/0.5, reasoning that "a wing has a
+  // shoulder that resists" — and it did resist, all the way to rigid: the joint
+  // spiked on impact and then snapped back to the pose it was born in, which
+  // reads exactly as Janus reported it, "rigid and twitchy". The bend a wing
+  // KEEPS is the number that matters, not the bend it reaches:
+  //
+  //     tension  damping |  peak bend   bend at rest   jitter
+  //         140     0.15 |     25.9°           0.3°   0.052°/frame
+  //          50     0.15 |     38.0°           0.6°   0.047
+  //          20     0.15 |     46.6°           1.4°   0.037
+  //           8     0.15 |     62.2°          12.5°   0.025   <- both best
+  //           3     0.15 |     72.4°          12.4°   0.064
+  //
+  // 8 is the knee: below it nothing more is gained in fold and the jitter
+  // climbs again (a spring too weak to hold its joint quiet against contact).
+  // Doubling the damping cost fold and doubled jitter at every tension.
+  tension: 8,       // 6DOF angular spring stiffness
+  damping: 0.15,    // both the spring's and the body's angular damping. Bullet's
+                    // spring "damping" is a target-velocity GAIN, not
+                    // dissipation, so more of it means snappier, not calmer.
+  gravity: 1.0,     // fraction of world gravity. Real, unlike hair's 1.5 — a
+                    // wing is a big surface and if anything falls SLOWER.
+  // The RAMP is where the remaining stiffness lived, and it got worse when the
+  // chains grew from two bones to three: lim = limit * ((j+1)/n)^rootExp, so at
+  // 38/1.6 the shoulder went from 12.5° (n=2) to 6.5° (n=3) without anyone
+  // touching a number. Re-measured on the 3-bone rig:
+  //
+  //     limit  rootExp |  peak bend   bend at rest   jitter
+  //        38      1.6 |     69.0°           4.7°   0.119°/frame
+  //        70      1.0 |     74.7°           5.9°   0.073        <- more fold,
+  //        70      0.7 |     74.4°           5.9°   0.077           less twitch
+  //
+  // A linear ramp dominates the steep one on BOTH axes, which is the unusual
+  // case where there is no trade to make.
+  //
+  // 0.7 looked calmer still on 4 leans (jitter 0.089 vs 0.130) — and did not
+  // survive: paired over 10 leans the difference is -0.003 ± 0.024, t = 0.13,
+  // i.e. nothing. Noted because that gap is exactly the size this project has
+  // been fooled by before, and the cheap paired re-test is what settles it.
+  //
+  // Re-measured AGAIN once the boxes were sized from the mesh (see
+  // boneMeshExtents — the distal upper segments had been carrying boxes a third
+  // of their true length, which is most of why they would not drape): the same
+  // row now rests at 9.0° ± 2.0 rather than 5.9°.
+  limit: 70,        // degrees at the outermost segment
+  rootExp: 1.0,     // ramp exponent — linear: the shoulder gets a third of the
+                    // range, the tip all of it.
 };
 
 export const JOINT_SPECS = {
@@ -383,6 +481,102 @@ function frameQuat(dir, out = new THREE.Quaternion()) {
   const x = new THREE.Vector3().crossVectors(ref, y).normalize();
   const z = new THREE.Vector3().crossVectors(x, y);
   return out.setFromRotationMatrix(new THREE.Matrix4().makeBasis(x, y, z));
+}
+
+/** Per-bone mesh extents, in each bone's OWN rest frame, read off the skin.
+ *
+ *  For limbs a bone's length is a fine proxy for the flesh on it — head to the
+ *  next head, and the box follows. Wings broke that assumption outright:
+ *  mythos's upper chain has a 16cm middle bone carrying 44cm of membrane, and
+ *  its outermost bone is a LEAF, where the chain builder had nothing to measure
+ *  and copied the previous segment's length. Both distal boxes came out about a
+ *  THIRD of the wing they stand for — visible in the debug overlay, and the
+ *  reason those sections would not drape: gravity's torque goes as the lever
+ *  arm, so a box a third the length has a third the pull and a ninth the
+ *  inertia to carry a swing with.
+ *
+ *  So ask the mesh instead. A vertex's position times boneInverse × bindMatrix
+ *  is where it sits in that bone's frame at bind time — pose-independent, so
+ *  this is computed ONCE per avatar and cached (the doll is rebuilt on every
+ *  grab). Vertices are assigned to whichever bone weights them MOST, and only
+ *  when that weight is decisive; a vertex split evenly across a joint belongs
+ *  to neither box.
+ *
+ *  Returns Map(boneName -> {c, he}) in bone-local units, or an empty map when
+ *  there is no skinned mesh to read — headless rigs have bones and no geometry,
+ *  and the caller keeps its bone-length path for them.
+ */
+function boneMeshExtents(avatar, key, match) {
+  // Keyed, because there are TWO callers with different matchers (hair and
+  // wings) and a single cached map would hand the second caller the first
+  // caller's answer — silently returning no extents and dropping it back to
+  // bone-length boxes, with nothing in the log to say the fix had stopped
+  // working.
+  const cache = avatar.__boneExt ??= new Map();
+  if (cache.has(key)) return cache.get(key);
+  const out = new Map();
+  const acc = new Map();      // bone name -> {lo, hi}
+  const v = new THREE.Vector3();
+  const m = new THREE.Matrix4();
+  avatar.root?.traverse?.((o) => {
+    if (!o.isSkinnedMesh || !o.skeleton?.bones?.length) return;
+    const pos = o.geometry?.attributes?.position;
+    const si = o.geometry?.attributes?.skinIndex;
+    const sw = o.geometry?.attributes?.skinWeight;
+    if (!pos || !si || !sw) return;
+    // which of this skeleton's bones are we being asked about
+    const want = new Map();
+    o.skeleton.bones.forEach((b, i) => { if (match(b.name)) want.set(i, b.name); });
+    if (!want.size) return;
+    for (let k = 0; k < pos.count; k++) {
+      let bi = -1, bw = 0;
+      for (let c = 0; c < 4; c++) {
+        const w = sw.getComponent(k, c);
+        if (w > bw) { bw = w; bi = si.getComponent(k, c); }
+      }
+      // 0.4 is "this vertex is decisively one bone's": below it the vertex
+      // straddles a joint and would stretch BOTH boxes past the real geometry.
+      if (bw < 0.4 || !want.has(bi)) continue;
+      const name = want.get(bi);
+      m.multiplyMatrices(o.skeleton.boneInverses[bi], o.bindMatrix);
+      v.fromBufferAttribute(pos, k).applyMatrix4(m);
+      let a = acc.get(name);
+      if (!a) acc.set(name, (a = { lo: v.clone(), hi: v.clone(), n: 0 }));
+      a.lo.min(v); a.hi.max(v); a.n++;
+    }
+  });
+  for (const [name, a] of acc) {
+    // a handful of stray vertices is not a shape; fall back rather than build a
+    // box out of noise
+    if (a.n < 24) continue;
+    out.set(name, {
+      c: a.lo.clone().add(a.hi).multiplyScalar(0.5),
+      he: a.hi.clone().sub(a.lo).multiplyScalar(0.5),
+    });
+  }
+  cache.set(key, out);
+  return out;
+}
+
+/** A bone's mesh extent, carried out to world by its live matrix: the box
+ *  centre and a single child box oriented with the bone. Returns null when
+ *  there is nothing measured for that bone, and the caller keeps its fallback.
+ *
+ *  `floor` is the minimum half-extent on every axis — a membrane or a lock of
+ *  hair can be millimetres thick, and a zero-depth box is a degenerate shape
+ *  with no inertia about two of its axes. */
+function extBox(nd, ext, floor = 0.01) {
+  if (!ext) return null;
+  nd.updateWorldMatrix(true, false);
+  return {
+    center: ext.c.clone().applyMatrix4(nd.matrixWorld),
+    boxes: [{
+      he: new THREE.Vector3(
+        Math.max(ext.he.x, floor), Math.max(ext.he.y, floor), Math.max(ext.he.z, floor)),
+      t: new THREE.Vector3(0, 0, 0),
+      q: nd.getWorldQuaternion(new THREE.Quaternion()),
+    }],
+  };
 }
 
 /** Shortest arc with the antiparallel case answered deterministically. */
@@ -1241,10 +1435,17 @@ export class AmmoRagdoll {
           avatar.__hairRest = rest;
         }
         // ...and start combed, not mid-tumble.
-        for (const [nd0, q0] of avatar.__hairRest) nd0.quaternion.copy(q0);
+        // ...and updateMatrix, or this reset never happens either: a
+        // springbone joint has matrixAutoUpdate false, so the bodies below
+        // would be built at whatever pose three-vrm's matrices still held —
+        // the boxes born offset from the hair you can see.
+        for (const [nd0, q0] of avatar.__hairRest) {
+          nd0.quaternion.copy(q0); nd0.updateMatrix();
+        }
         avatar.root.updateMatrixWorld(true);
         const headGroup = this._groupOf.get(headSeg.body) ?? G_STATIC;
         const R = Math.max(0.004 * H, 0.004);
+        const hairExt = boneMeshExtents(avatar, 'hair', (n) => /^Hair_\d+_\d+$/.test(n));
         // The source playground's DEFAULTS, transplanted. Where this port
         // guessed, it guessed like a FINGER — hair is built with isFinger=true,
         // so it inherited the finger damping and the finger collision group,
@@ -1294,8 +1495,20 @@ export class AmmoRagdoll {
             const len = Math.max(aW.distanceTo(bW), 0.015);
             prevLen = len;
             const mid = aW.clone().add(bW).multiplyScalar(0.5);
-            const body = mkBody(HAIR_MASS, mid, new THREE.Quaternion(),
-              [boxFor(mid, aW, bW, R, R, len)], true);
+            // The lock's own measurements when the mesh offers them (see
+            // boneMeshExtents), the bone spacing otherwise. A much SMALLER
+            // correction than the wings needed — measured on this rig, the
+            // median lock is 48mm long against 36mm of bone spacing, and
+            // 17x10mm in section against the 14x14mm the constant gives — so
+            // this is a tidy-up, not the fix that the wings' 3x error was.
+            // 131 of 346 segments are too sparsely tessellated to measure and
+            // keep the constant; they are the thin tips, where it is closest to
+            // right anyway.
+            const hx = extBox(nd, hairExt.get(nd.name), 0.004);
+            const body = hx
+              ? mkBody(HAIR_MASS, hx.center, new THREE.Quaternion(), hx.boxes, true)
+              : mkBody(HAIR_MASS, mid, new THREE.Quaternion(),
+                [boxFor(mid, aW, bW, R, R, len)], true);
             // Angular damping 0.9 was the finger constant. Per Bullet's
             // w *= (1-d)^dt, 0.9 bleeds angular momentum ~2.5x faster per step
             // than 0.6 — hair that cannot carry a swing through its arc reads
@@ -1364,9 +1577,189 @@ export class AmmoRagdoll {
             built++;
           }
         }
-        if (built) console.log(`[ammodoll] bullet hair: ${chains.size} locks, ${built} segments`);
+        if (built) {
+          // Claim the hair from three-vrm for as long as this doll lives. See
+          // avatar.js's vrm.update: without this the springbones overwrite
+          // every bone we are about to drive, one system later in the frame.
+          avatar.__simHair = true;
+          console.log(`[ammodoll] bullet hair: ${chains.size} locks, ${built} segments`);
+        }
       }
     }
+
+    // ---- BULLET WINGS. Same shape as the hair above — chains of boxes hung
+    // from a KINEMATIC anchor carried in a core body's frame, one-way, local
+    // dressing, excluded from settle and the pose wire — and deliberately NOT
+    // sharing its code. The two differ in every parameter that matters (mass by
+    // 25x, a plate cross-section instead of a filament, an anchor at the chest
+    // instead of the skull, a stiff root instead of a stiff tip), and a shared
+    // builder would be five booleans with one caller each.
+    //
+    // The division of labour with avatar.js is the point of the whole thing:
+    // while the body is alive its wings are DRIVEN (WING_IDLE's flap, on the raw
+    // bones, after vrm.update); the moment it goes limp the doll is built and
+    // these chains take the same bones over. Neither writes while the other
+    // does, so there is never a frame with two authors.
+    this._wingSegs = [];
+    this._wingAnchors = [];
+    {
+      // The chest, not the clavicle: the arms hang off 'chest' in CORE_JOINTS
+      // for the same reason — there is no clavicle body in this cut of the rig.
+      const chestSeg = this.segs.get('chest|neck') ?? this.segs.get('spine|chest');
+      const wingNodes = [];
+      avatar.root?.traverse?.((o) => {
+        if (/^[LR]_Wing_(Upper|Lower)(_\d+)?$/.test(o.name ?? '')) wingNodes.push(o);
+      });
+      const wchains = new Map();
+      for (const nd of wingNodes) {
+        // The index in the name IS the position in the chain. Counting
+        // underscores instead collapses _1 and _2 to the same depth, and then
+        // the sort below leaves their order to traversal luck — which decides
+        // which segment gets built as whose parent.
+        const m = nd.name.match(/^([LR]_Wing_(?:Upper|Lower))(?:_(\d+))?$/);
+        if (!wchains.has(m[1])) wchains.set(m[1], []);
+        wchains.get(m[1]).push({ i: m[2] ? Number(m[2]) : 0, node: nd });
+      }
+      if (chestSeg && wchains.size) {
+        // The AUTHORED pose, captured by avatar.js's _findWings before the flap
+        // ever ran, and shared here. Falling back to the live pose would define
+        // rest as "wherever the flap happened to be when you grabbed her", so
+        // the equilibrium would differ every time the doll was built — and
+        // since a drag release rebuilds, that is the hair's crumple ratchet
+        // again, in a system where it would read as wings drifting upward.
+        if (!avatar.__wingRest) {
+          const rest = new Map();
+          for (const [, l0] of wchains) for (const it of l0) rest.set(it.node, it.node.quaternion.clone());
+          avatar.__wingRest = rest;
+        }
+        for (const [nd0, q0] of avatar.__wingRest) {
+          nd0.quaternion.copy(q0); nd0.updateMatrix();   // harmless when auto is on
+        }
+        avatar.root.updateMatrixWorld(true);
+        const WT = WING_TUNING;
+        const WING_LIM = WT.limit * DEG;
+        const wingExt = boneMeshExtents(avatar, 'wing', (n) => /^[LR]_Wing_/.test(n));
+        let built = 0;
+        for (const [, list] of wchains) {
+          list.sort((x2, y2) => x2.i - y2.i);
+          const rootW = list[0].node.getWorldPosition(new THREE.Vector3());
+          const aShape = keep(new AMMO.btBoxShape(new AMMO.btVector3(0.01, 0.01, 0.01)));
+          _bt1.setIdentity();
+          _bv1.setValue(rootW.x, rootW.y, rootW.z); _bt1.setOrigin(_bv1);
+          const aMs = keep(new AMMO.btDefaultMotionState(_bt1));
+          _bv1.setValue(0, 0, 0);
+          const aCi = keep(new AMMO.btRigidBodyConstructionInfo(0, aMs, aShape, _bv1));
+          const anchor = keep(new AMMO.btRigidBody(aCi));
+          anchor.setCollisionFlags(anchor.getCollisionFlags() | CF_KINEMATIC);
+          anchor.setActivationState(DISABLE_DEACTIVATION);
+          this.world.addRigidBody(anchor, G_FINGER, 0);   // mask 0: touches nothing
+          this._bodies.push(anchor);
+          this._wingAnchors.push({
+            anchor, head: chestSeg.body, local: localOf(chestSeg.body, rootW),
+          });
+          let parentBody = anchor;
+          let prevLen = 0.2;
+          for (let j2 = 0; j2 < list.length; j2++) {
+            const nd = list[j2].node;
+            const aW = nd.getWorldPosition(new THREE.Vector3());
+            const childNd = list[j2 + 1]?.node;
+            const bW = childNd ? childNd.getWorldPosition(new THREE.Vector3())
+              : aW.clone().add(nd.getWorldDirection(new THREE.Vector3()).multiplyScalar(-prevLen));
+            const len = Math.max(aW.distanceTo(bW), 0.03);
+            prevLen = len;
+            const mid = aW.clone().add(bW).multiplyScalar(0.5);
+            // THE BOX IS THE MESH, when the rig has one to read.
+            //
+            // See boneMeshExtents: a wing bone's length is not the size of the
+            // wing on it. The extents come back in the bone's own frame, so the
+            // box rides out to world with the bone's live matrix — centre and
+            // orientation both — and needs no guess about span or thickness.
+            //
+            // The bone-length plate below is the fallback for a rig with no
+            // skinned geometry to measure (every headless fixture). It is a
+            // PLATE and not a filament on purpose: the width is what stops a
+            // wing lying flat inside the ground plane when the body lands on
+            // its back, where hair's 4mm cross-section would be a wire.
+            const ext = wingExt.get(nd.name);
+            let center = mid, boxes;
+            if (ext) {
+              nd.updateWorldMatrix(true, false);
+              center = ext.c.clone().applyMatrix4(nd.matrixWorld);
+              boxes = [{
+                // a membrane can be millimetres thick, and a zero-depth box is
+                // a degenerate shape with no inertia about two of its axes
+                he: new THREE.Vector3(
+                  Math.max(ext.he.x, 0.01), Math.max(ext.he.y, 0.01),
+                  Math.max(ext.he.z, 0.01)),
+                t: new THREE.Vector3(0, 0, 0),
+                q: nd.getWorldQuaternion(new THREE.Quaternion()),
+              }];
+            } else {
+              const halfSpan = len * 0.45, halfThick = Math.max(0.01, len * 0.05);
+              boxes = [boxFor(mid, aW, bW, halfSpan, halfThick, 0.03)];
+            }
+            const body = mkBody(WT.mass, center, new THREE.Quaternion(), boxes, true);
+            body.setDamping(0.35, WT.damping);
+            body.setFriction(0.6);        // wings drag on the floor, not slide
+            body.setRestitution(0.0);
+            body.setRollingFriction(0.0);
+            // Wings meet the WORLD only, never the body they hang from.
+            //
+            // The root segment starts inside the torso box by construction (it
+            // is anchored at the shoulder blade), and a contact born penetrating
+            // cannot be resolved — that is the hair's poof, and on a plate this
+            // size it would fire the whole body across the room. Excluding the
+            // torso is not enough either: a folded wing wraps the arm and the
+            // leg on that side. So: statics only. A wing can rest on the ground
+            // and cannot touch its owner.
+            this.world.addRigidBody(body, G_FINGER, G_STATIC);
+            _bv1.setValue(0, -9.81 * WT.gravity, 0);
+            body.setGravity(_bv1);       // AFTER addRigidBody — the source's lesson
+            const lim = WING_LIM * Math.pow((j2 + 1) / list.length, WT.rootExp);
+            const mkF = (bdy) => {
+              const tr = keep(new AMMO.btTransform());
+              tr.setIdentity();
+              const o = localOf(bdy, aW);
+              _bv2.setValue(o.x, o.y, o.z); tr.setOrigin(_bv2);
+              return tr;
+            };
+            const con = keep(new AMMO.btGeneric6DofSpringConstraint(
+              parentBody, body, mkF(parentBody), mkF(body), true));
+            _bv1.setValue(0, 0, 0);
+            con.setLinearLowerLimit(_bv1); con.setLinearUpperLimit(_bv1);
+            _bv1.setValue(-lim, -lim, -lim); con.setAngularLowerLimit(_bv1);
+            _bv1.setValue(lim, lim, lim); con.setAngularUpperLimit(_bv1);
+            for (let ax = 3; ax < 6; ax++) {
+              con.enableSpring(ax, true);
+              con.setStiffness(ax, WT.tension);
+              con.setDamping(ax, WT.damping);
+            }
+            // Equilibrium is the pose the wing was BORN in, which the reset
+            // above guarantees is the authored one.
+            con.setEquilibriumPoint();
+            this.world.addConstraint(con, true);
+            this._constraints.push(con);
+            this._wingSegs.push({
+              body, node: nd, parent: nd.parent,
+              restWorldQ: nd.getWorldQuaternion(new THREE.Quaternion()),
+              con, j: j2, n: list.length,
+            });
+            parentBody = body;
+            built++;
+          }
+        }
+        if (built) console.log(`[ammodoll] bullet wings: ${wchains.size} chains, ${built} segments`);
+      }
+    }
+
+    // Hair and wings are the same KIND of thing to the step loop — hung from a
+    // carried kinematic anchor, written back to a raw bone, invisible to settle
+    // and to the wire. Joined once here rather than concatenated per frame.
+    // `?? []` on the hair: _hairAnchors is only assigned INSIDE its build guard,
+    // so a rig with no hair leaves it undefined and the spread throws — which is
+    // exactly what the fleet's hairless rigs did the first time this ran.
+    this._dressAnchors = [...(this._hairAnchors ?? []), ...this._wingAnchors];
+    this._dressSegs = [...(this._hairSegs ?? []), ...this._wingSegs];
 
     // ---- the drive table (rapierdoll's law: BOTH references from the live
     // skeleton — refDir must be the direction the bone points in the pose
@@ -1547,6 +1940,33 @@ export class AmmoRagdoll {
     // a sleeping body will not notice its joints changed under it
     for (const b of this._bodies) b.activate();
     return n;
+  }
+
+  /** Push WING_TUNING into the running wings, no rebuild. Same contract as
+   *  retuneHair, and the same reason: a wing is being judged on how it settles,
+   *  and rebuilding to test a slider throws away the fall you were judging. */
+  retuneWings() {
+    if (!AMMO || !this._wingSegs?.length) return 0;
+    const WT = WING_TUNING;
+    for (const ws of this._wingSegs) {
+      ws.body.setDamping(0.35, WT.damping);
+      _bv1.setValue(0, -9.81 * WT.gravity, 0);
+      ws.body.setGravity(_bv1);
+      _bv1.setValue(0, 0, 0);
+      ws.body.getCollisionShape().calculateLocalInertia(WT.mass, _bv1);
+      ws.body.setMassProps(WT.mass, _bv1);
+      ws.body.updateInertiaTensor();
+      ws.body.activate();
+      if (!ws.con) continue;
+      const lim = WT.limit * DEG * Math.pow((ws.j + 1) / ws.n, WT.rootExp);
+      _bv1.setValue(-lim, -lim, -lim); ws.con.setAngularLowerLimit(_bv1);
+      _bv1.setValue(lim, lim, lim); ws.con.setAngularUpperLimit(_bv1);
+      for (let ax = 3; ax < 6; ax++) {
+        ws.con.setStiffness(ax, WT.tension);
+        ws.con.setDamping(ax, WT.damping);
+      }
+    }
+    return this._wingSegs.length;
   }
 
   /** Push HAIR_TUNING into the running hair, no rebuild.
@@ -1755,7 +2175,7 @@ export class AmmoRagdoll {
     // Kinematic roots move BEFORE the step (the source's law): Bullet derives a
     // kinematic body's velocity as (new - old)/dt, so moving one after the step
     // hands the solver a stale offset and the chains get whipped.
-    for (const ha of this._hairAnchors ?? []) {
+    for (const ha of this._dressAnchors ?? []) {
       const t0 = ha.head.getCenterOfMassTransform();
       const o0 = t0.getOrigin();
       _v.set(o0.x(), o0.y(), o0.z());
@@ -1845,10 +2265,24 @@ export class AmmoRagdoll {
     // hair rides raw nodes, local only: world orientation = the body's
     // rest→live rotation composed on the born orientation (rest-aligned
     // bodies make that exact), then into parent-local
-    for (const hs of this._hairSegs) {
+    for (const hs of this._dressSegs ?? []) {
       quatOf2(hs.body, _q).multiply(hs.restWorldQ);
       hs.parent.getWorldQuaternion(_qp).invert();
       hs.node.quaternion.copy(_qp.multiply(_q));
+      // updateMatrix() IS THE WRITE. Setting .quaternion is not.
+      //
+      // three-vrm sets `bone.matrixAutoUpdate = false` on every spring-bone
+      // joint (three-vrm.module.js:5279) and maintains matrix/matrixWorld by
+      // hand inside its own update. So on any rig whose hair is declared as
+      // springbones — which is every rig this pipeline builds — a bare
+      // quaternion write is composed into `matrix` by nobody and reaches the
+      // renderer never. The bones moved, the debug boxes moved, and the mesh
+      // stood still: "the hair is bending less than the collider boxes".
+      //
+      // This is why the WINGS worked from the first try and the hair never did.
+      // Wing bones are not springbone joints, so they keep the three.js default
+      // and the renderer recomposes them for free.
+      hs.node.updateMatrix();
     }
 
     if (this.settledFor >= SETTLE_TIME || this.elapsed >= DEADLINE) {
@@ -1873,6 +2307,18 @@ export class AmmoRagdoll {
     // never become the next tumble's definition of rest. Restoring the comb
     // here instead is a one-line change if that is ever wanted.
     this.done = true;
+    // The hair is NOT handed back here, and that is the point.
+    //
+    // This used to call springBoneManager.reset() — which does
+    // `bone.quaternion.copy(this._initialLocalRotation)` per joint
+    // (three-vrm.module.js:5353). That is a snap to the COMBED pose, and since
+    // dispose() fires the moment a body settles, it fired a few seconds into
+    // every fall: "the hair abruptly jumps back into the default position
+    // instead of staying in the position it fell into".
+    //
+    // A settled corpse keeps the hair the fall gave it. Ownership is released
+    // when she gets UP (avatar.js's _releaseHair, off setLimp), which is the
+    // moment the shape should start combing itself out again.
     try {
       for (const c of this._constraints) this.world.removeConstraint(c);
       for (const [, pin] of this._pinCons) this.world.removeConstraint(pin.con);

--- a/client/lib/ammodoll.js
+++ b/client/lib/ammodoll.js
@@ -438,15 +438,33 @@ const CORE_JOINTS = [
 // source's TENDON_CHAIN does (thumb excluded: no shared tendon).
 const FINGERS = ['Index', 'Middle', 'Ring', 'Little'];
 
-// collision filter bits — the filter is an OR of BOTH directions
-// ((groupA & maskB) || (groupB & maskA)), and it FREEZES at addRigidBody:
-// changing it later does nothing (source, the day it cost)
-// Bullet's filter group/mask are ints (btBroadphaseProxy), so there is room:
-// bit 0 statics, bits 1..16 per-core-body (torso + head + 8 limb segments +
-// 2 hands + 2 feet = 14 today), bit 30 the shared finger group.
+// Collision filter bits. The filter is an AND of BOTH directions
+// ((groupA & maskB) && (groupB & maskA)), and it FREEZES at addRigidBody:
+// changing it later does nothing (source, the day it cost).
+//
+// THE BUDGET IS 15 BITS, NOT 32. Bullet's own btBroadphaseProxy carries ints,
+// which is what the old comment here assumed — but ammo.js's IDL declares
+// addRigidBody's group and mask as SHORT, so anything above bit 14 is silently
+// truncated on the way into wasm. Measured on this rig, before the fix:
+//
+//     G_FINGER  1<<30 = 1073741824  ->  short 0      collides with NOTHING
+//     core body       =      65536  ->  short 0      collides with NOTHING
+//     core body       =      32768  ->  short -32768 sign bit, collides broadly
+//
+// Group 0 is why hair, wings and fingers fell straight through the floor: a
+// body dropped from 2m above the ground passed it and was still falling 100m
+// down. It reads as "the sim let them through" because it is exactly that, and
+// no amount of tuning touches it.
+//
+// So: bit 0 statics, bits 1..12 the twelve core bodies that need self-collision
+// (3 trunk + head + 8 limb segments), bit 14 everything that only ever wants
+// the ground. Hands and feet do NOT get bits of their own — they ride their
+// parent limb's (see the assignment below), which costs nothing anatomically
+// and is what makes 16 bodies fit in 12 bits.
 const G_STATIC = 1;
-const G_FINGER = 1 << 30;
-const BODY_BITS = 16;
+const G_FINGER = 1 << 14;      // 16384 — the top bit a signed short can hold
+const BODY_BITS = 12;
+const FILTER_MAX = 1 << 14;    // anything above this does not survive the call
 
 // ---------------------------------------------------------------- wasm temps
 
@@ -1110,16 +1128,63 @@ export class AmmoRagdoll {
           }
         }
       }
+      // A HAND RIDES ITS FOREARM'S BIT, a foot its calf's.
+      //
+      // Sixteen core bodies do not fit in the twelve bits a signed short can
+      // spare (see G_FINGER), and the alternative — dropping the last three
+      // assigned to ground-only — costs whichever bodies happen to be last in
+      // construction order their self-collision, asymmetrically: one hand keeps
+      // it, the other does not.
+      //
+      // Sharing is better than dropping AND better than a unique bit. The
+      // exclusion sets still work out right: building the forearm's mask skips
+      // the hand (adjacent, excluded) and skips itself, so the shared bit is
+      // absent and forearm/hand do not collide — which is what was wanted.
+      // Every OTHER body sees one bit meaning "that arm, hand included", so a
+      // hand still meets the torso, the head, and the opposite arm.
+      for (const seg of this.segs.values()) {
+        // by KEY, not by a `part` field — the extra segments carry `part` in
+        // their table but the seg objects built from them do not, so the first
+        // version of this matched nothing and quietly left three bodies on the
+        // ground-only fallback
+        if (!/^(left|right)(Hand|Foot)\|/.test(seg.key ?? '')) continue;
+        const parent = [...this.segs.values()].find((s) => s !== seg && s.b === seg.a);
+        if (parent && bodyIndex.has(parent.body)) bodyIndex.set(seg.body, bodyIndex.get(parent.body));
+      }
+      // A SHARED BIT EXCLUDES IF ANY OF ITS BODIES DOES.
+      //
+      // The per-body loop below was: OR in `other`'s bit unless `other` is
+      // excluded. With one bit per body that is exact. With a bit shared by a
+      // limb and its hand, it silently UN-excludes: building the thigh's mask
+      // skips the calf (adjacent) but not the foot — which now carries the
+      // calf's bit — so the bit went back in and thigh/calf collided at the
+      // knee again. Measured: knee hyperextension went from one rig to all six.
+      //
+      // Over-excluding is the safe direction (a thigh that ignores its own
+      // foot costs nothing); under-excluding puts two overlapping bodies in a
+      // penetration fight at a joint.
+      const bitBodies = new Map();
+      for (const [body, bit] of bodyIndex) {
+        if (!bitBodies.has(bit)) bitBodies.set(bit, []);
+        bitBodies.get(bit).push(body);
+      }
       this._groupOf = new Map();
       for (const [body, bit] of bodyIndex) {
         this._groupOf.set(body, (G_STATIC << 1) << bit);
         let mask = G_STATIC;
-        for (const [other, obit] of bodyIndex) {
-          if (other === body) continue;
-          if (excluded.get(body)?.has(other)) continue;
+        for (const [obit, sharers] of bitBodies) {
+          if (obit === bit) continue;
+          if (sharers.some((o) => excluded.get(body)?.has(o))) continue;
           mask |= (G_STATIC << 1) << obit;
         }
-        this.world.addRigidBody(body, (G_STATIC << 1) << bit, mask);
+        const group = (G_STATIC << 1) << bit;
+        // Loud, because the failure is SILENT: an over-budget group truncates
+        // to zero on the way into wasm and the body simply stops colliding.
+        if (group > FILTER_MAX) {
+          console.error(`[ammodoll] filter group ${group} exceeds the short budget `
+            + `— this body will collide with nothing`);
+        }
+        this.world.addRigidBody(body, group, mask);
       }
       // any core body past the bit budget joins ground-only (none today:
       // torso + head + 8 limbs + 2 hands + 2 feet = 13 ≤ 1+12 bits)
@@ -1748,7 +1813,14 @@ export class AmmoRagdoll {
             built++;
           }
         }
-        if (built) console.log(`[ammodoll] bullet wings: ${wchains.size} chains, ${built} segments`);
+        if (built) {
+          // Wings are springbone chains too now (import-tripo-avatar), so the
+          // same claim the hair makes has to be made here — otherwise a rig
+          // with wings and no hair would have three-vrm and Bullet writing the
+          // same bones, and three-vrm runs second.
+          avatar.__simHair = true;
+          console.log(`[ammodoll] bullet wings: ${wchains.size} chains, ${built} segments`);
+        }
       }
     }
 
@@ -2307,7 +2379,20 @@ export class AmmoRagdoll {
     // never become the next tumble's definition of rest. Restoring the comb
     // here instead is a one-line change if that is ever wanted.
     this.done = true;
-    // The hair is NOT handed back here, and that is the point.
+    // Hand the hair back ADOPTING the pose it is in.
+    //
+    // Not handing it back at all was wrong in one specific case, and only that
+    // one: a doll disposed MID-TUMBLE — letting go of a body you were dragging
+    // — left the hair owned by a sim that no longer existed, frozen in the pose
+    // it was dropped in while the body kept falling. Janus saw it on a dragged
+    // dummy and never on their own body going limp, which is the tell: a body
+    // that falls on its own keeps its doll until it settles.
+    //
+    // Adopting means three-vrm resumes from the fallen shape rather than
+    // combing it (the snap this used to cause), and the hair is LIVE again so
+    // it keeps falling with her. The authored shape comes back when she gets
+    // up — see _combHair.
+    this.avatar?._releaseHair?.({ adopt: true });
     //
     // This used to call springBoneManager.reset() — which does
     // `bone.quaternion.copy(this._initialLocalRotation)` per joint

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -412,9 +412,16 @@ export class Avatar {
    *  could not be what "sideways while dragging" meant — and that was a
    *  misreading of WHICH INSTANTS were being described. Grabbing, letting go,
    *  pinning, and the fall afterwards are all springbone moments, and they are
-   *  what the report was about. With the center dropped, all of it came right.
-   *  The lesson is not about hair: 96% of the samples answered a question
-   *  nobody had asked, and the 4% was the whole story.
+   *  what the report was about. Dropping the center made all of it much
+   *  better — but NOT completely: Janus still sees sideways hair
+   *  occasionally, "significantly less often". So this is a large fix to a
+   *  real cause, not the whole cause, and the remainder is an open thread
+   *  (rigtest/EIDOVERSE-DEPLOY.md).
+   *
+   *  Two lessons, and neither is about hair. The 96% answered a question
+   *  nobody had asked while the 4% was most of the story — a statistic can be
+   *  accurate and still be about the wrong thing. And "confirmed fixed" was
+   *  written here one report too early: better is not gone.
    */
   _springsLimp(on) {
     const sbm = this.vrm?.springBoneManager;

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -358,20 +358,44 @@ export class Avatar {
    *  no-op — and then put straight back, so the springs still pull toward the
    *  authored shape afterwards rather than freezing the crumple in forever.
    */
-  _releaseHair() {
+  _releaseHair({ adopt = false } = {}) {
     if (!this.__simHair) return;
     this.__simHair = false;
     const sbm = this.vrm?.springBoneManager;
     if (!sbm?.joints) return;
     this.vrm.scene?.updateMatrixWorld?.(true);
-    const saved = [];
-    for (const j of sbm.joints) {
-      if (!j?._initialLocalRotation || !j.bone) continue;
-      saved.push([j, j._initialLocalRotation.clone()]);
-      j._initialLocalRotation.copy(j.bone.quaternion);
+    // The authored spring rest, remembered ONCE, so adopting a fallen shape is
+    // always reversible and can never ratchet.
+    if (!this.__springRest) {
+      this.__springRest = new Map();
+      for (const j of sbm.joints) {
+        if (j?._initialLocalRotation) this.__springRest.set(j, j._initialLocalRotation.clone());
+      }
     }
-    sbm.reset();
-    for (const [j, q] of saved) j._initialLocalRotation.copy(q);
+    for (const j of sbm.joints) {
+      if (j?._initialLocalRotation && j.bone) j._initialLocalRotation.copy(j.bone.quaternion);
+    }
+    sbm.reset();                 // re-derives tails; the rotation restore is a no-op
+    if (!adopt) this._combHair();
+  }
+
+  /** Put the AUTHORED spring rest back, so the hair combs itself out again.
+   *
+   *  Split from the release because the two happen at different moments. A doll
+   *  that disposes mid-tumble (letting go of a dragged body) hands the hair back
+   *  ADOPTING the fallen shape: it stays exactly where it was dropped and is
+   *  live again, so it keeps falling with her. Getting UP is when the combed
+   *  shape comes back. Without the split, a body released mid-air had its hair
+   *  owned by a doll that no longer existed — frozen in the pose it was let go
+   *  in, which is precisely what a dragged dummy did while a body going limp on
+   *  its own never did (its doll lives until it settles). */
+  _combHair() {
+    const sbm = this.vrm?.springBoneManager;
+    if (!sbm?.joints || !this.__springRest) return;
+    for (const j of sbm.joints) {
+      const q = this.__springRest.get(j);
+      if (q && j._initialLocalRotation) j._initialLocalRotation.copy(q);
+    }
   }
 
   /** Find the wing bones once, and remember the pose they were authored in.
@@ -782,7 +806,7 @@ export class Avatar {
     // Getting up is when the hair goes back to three-vrm — not when the doll
     // disposed, which happens the moment the body settles and left the hair
     // snapping to combed while she was still lying there.
-    if (!on) this._releaseHair();
+    if (!on) { this._releaseHair(); this._combHair(); }
     if (!on) {
       if (this._wings === undefined) this._findWings();
       if (this._wings) {
@@ -1180,7 +1204,7 @@ export class Avatar {
     // and anything that ends a tumble without going through setLimp (an avatar
     // swap, a dragger taking over) would otherwise leave the hair suppressed
     // and frozen for good.
-    if (this.__simHair && !this._limp) this._releaseHair();
+    if (this.__simHair && !this._limp) { this._releaseHair(); this._combHair(); }
     const sbm = this.__simHair ? this.vrm.springBoneManager : null;
     if (sbm) this.vrm.springBoneManager = null;
     this.vrm.update(dt);

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -45,6 +45,61 @@ export const BLINK = {
                  // CLOSING plus the reopen, and this curve covers both halves.
 };
 
+// Wings, when a rig has them: [LR]_Wing_(Upper|Lower)[_<n>]. Four chains hung
+// off the clavicles — an upper pair and a lower pair per side — each as long as
+// the rig cares to make it (mythos went from two bones to three on 08-17;
+// nothing here counts them).
+//
+// The flap is PROCEDURAL rather than a clip, for two reasons. A VRMA clip can
+// only address humanoid bones, and these are not humanoid; and the wings have
+// to be able to stop being driven the instant the body goes limp, which a
+// running clip cannot do without a second blend tree. Driving the raw bones
+// directly costs nothing and makes limpness a one-line handover to the sim.
+//
+// The axis is the BODY'S FORWARD, not the bone's own X/Y/Z: bone roll out of
+// Blender is arbitrary (the eyelids cost a day over exactly this), so rotating
+// about a local axis would flap one rig and swipe sideways on the next. About
+// the forward axis, "up" is up for any wing that points outward, and the two
+// sides differ only by sign.
+export const WING_IDLE = {
+  deg: 15,       // half-amplitude at the shoulder. A resting bird's wings barely
+                 // move; this is an IDLE, not flight, and the first value big
+                 // enough to see (28) read as an animal trying to take off.
+  hz: 0.42,      // full flaps per second — "slowly", and slow enough that the
+                 // sine never looks like a loop.
+  bias: 0,       // degrees of permanent lift added to the flap, both sides. A
+                 // dial for resting the wings higher or lower than the rig's
+                 // rest pose without editing the blend.
+  tip: 0.65,     // the outer segment's share of the amplitude. Two segments
+                 // rotating as one plank is the difference between a wing and a
+                 // door; the tip carrying less than the root gives it a curve.
+  lag: 0.16,     // cycles the outer segment trails the inner by. This is the
+                 // whole reason a wing reads as membrane rather than board — the
+                 // tip is still going up as the shoulder starts down.
+  sync: true,    // upper and lower pairs share one phase. False gives the lower
+                 // pair a half-cycle offset (they beat against each other, which
+                 // is an insect, not a bird).
+  recover: 0.55, // seconds to slerp back into the flap after a ragdoll, out of
+                 // whatever pose the body was left in.
+  // ---- the SWEEP: how far the tips travel FORWARD and BACK.
+  //
+  // Rotating about the forward axis alone confines every tip to the plane
+  // across the body — up, down and inboard, and nothing fore or aft. That is a
+  // hinge, and it reads as one. A real wing also sweeps: the tip goes forward
+  // as it comes down and back as it rises, so the path is an ellipse rather
+  // than an arc, and it is the sweep that makes a flap look like it is moving
+  // air rather than waving.
+  //
+  // Applied as a second rotation about the body's UP axis, mirrored the other
+  // way from the flap (both wings must sweep forward together, and the two
+  // sides point opposite ways along the span).
+  sweep: 9,        // degrees fore/aft at the shoulder
+  sweepPhase: 0.25, // cycles the sweep leads the flap by. A QUARTER turn is
+                    // what opens the arc into an ellipse; at 0 the two
+                    // rotations peak together and the path stays a straight
+                    // diagonal line, just a tilted hinge.
+};
+
 const CORE_CLIPS = ['idle', 'walk'];
 const LATER_CLIPS = CLIP_SLOTS.filter((s) => !CORE_CLIPS.includes(s));
 // Until a clip arrives, the nearest thing that HAS arrived stands in. Silently
@@ -205,6 +260,14 @@ const _gw = new THREE.Vector3();
 const _gp = new THREE.Vector3();
 const _X = new THREE.Vector3(1, 0, 0);      // scratch — hot paths must not allocate
 const _v2 = new THREE.Vector3();
+const _wq = new THREE.Quaternion();        // wing scratch
+const _wpq = new THREE.Quaternion();
+const _wacc = new THREE.Quaternion();
+const _wr = new THREE.Quaternion();
+const _wax = new THREE.Vector3();
+const _wup = new THREE.Vector3();
+const _wsw = new THREE.Quaternion();
+const DEG = Math.PI / 180;
 
 export class Avatar {
   constructor(id, vrm, clips) {
@@ -277,6 +340,158 @@ export class Avatar {
       if (/^[LR]_Eye$/.test(o.name ?? '')) found.push({ node: o, rest: o.quaternion.clone() });
     });
     if (found.length) this._eyes = found;
+  }
+
+  /** Give the hair back to three-vrm, resuming from where the tumble left it.
+   *
+   *  Not a reset. springBoneManager.reset() restores every joint's
+   *  _initialLocalRotation (three-vrm.module.js:5353) — the combed pose — which
+   *  is a visible snap, and calling it when the doll disposed is what made the
+   *  hair jump back to default a few seconds into every fall.
+   *
+   *  What is wanted is the other half of reset(): the tail state re-derived
+   *  from the CURRENT world matrices, so the springs pick up smoothly with no
+   *  stored velocity, keep the dishevelled shape, and comb it out over the next
+   *  second the way they would if you had just been shoved. There is no public
+   *  call for that half alone, so the rest rotation is pointed at the pose the
+   *  hair is ALREADY in for the duration of the call — making the restore a
+   *  no-op — and then put straight back, so the springs still pull toward the
+   *  authored shape afterwards rather than freezing the crumple in forever.
+   */
+  _releaseHair() {
+    if (!this.__simHair) return;
+    this.__simHair = false;
+    const sbm = this.vrm?.springBoneManager;
+    if (!sbm?.joints) return;
+    this.vrm.scene?.updateMatrixWorld?.(true);
+    const saved = [];
+    for (const j of sbm.joints) {
+      if (!j?._initialLocalRotation || !j.bone) continue;
+      saved.push([j, j._initialLocalRotation.clone()]);
+      j._initialLocalRotation.copy(j.bone.quaternion);
+    }
+    sbm.reset();
+    for (const [j, q] of saved) j._initialLocalRotation.copy(q);
+  }
+
+  /** Find the wing bones once, and remember the pose they were authored in.
+   *
+   *  `[LR]_Wing_(Upper|Lower)` is the root of a chain and `_<n>` its nth
+   *  segment outward: mythos runs `_1`, `_2` today and may grow more. Depth is
+   *  the INDEX in the name, not a count of underscores — reading it as a count
+   *  makes `_1` and `_2` both depth 1, and then the two outer segments share a
+   *  phase and an amplitude and the chain flaps as two planks instead of three.
+   *
+   *  Chains do not all have to be the same length: depth is per bone, and the
+   *  ragdoll's limit ramp divides by each chain's own length.
+   *
+   *  Rest is captured here, before the first flap is ever applied, and every
+   *  frame rebuilds from it. That is not a style choice: composing onto last
+   *  frame's pose integrates, and an integrating flap winds the wings around
+   *  their own axis over a few minutes. The same capture is what the ragdoll
+   *  reads as its equilibrium, so it must be the AUTHORED pose and not a pose
+   *  the sim or the flap left behind (HANDOFF.md: never rebuild a rig from a
+   *  simulated pose — it cost the hair a permanent crumple).
+   */
+  _findWings() {
+    this._wings = null;
+    if (!this.vrm?.scene) return;
+    const found = [];
+    this.vrm.scene.traverse((o) => {
+      const m = /^([LR])_Wing_(Upper|Lower)(?:_(\d+))?$/.exec(o.name ?? '');
+      if (!m) return;
+      found.push({
+        node: o,
+        rest: o.quaternion.clone(),
+        // +1 left, -1 right. A single rotation about the body's forward axis
+        // lifts a wing that points +X and drops the one that points -X, so the
+        // mirror is a sign and nothing else.
+        side: m[1] === 'L' ? 1 : -1,
+        lower: m[2] === 'Lower',
+        depth: m[3] ? Number(m[3]) : 0,
+      });
+    });
+    if (!found.length) return;
+    // roots before tips: a tip's world frame is read AFTER its root has been
+    // written this frame, so the order it is visited in is load-bearing.
+    found.sort((a, b) => a.depth - b.depth);
+    this._wings = found;
+    // Shared with the ragdoll, which hangs its Bullet chains off this pose.
+    // Stored on the avatar because the doll is rebuilt on every grab.
+    this.__wingRest = new Map(found.map((w) => [w.node, w.rest]));
+  }
+
+  /** One frame of the idle flap. Every wing is rebuilt from its captured rest,
+   *  so this cannot integrate however long it runs.
+   *
+   *  The rotation is applied about a WORLD axis and then carried into the
+   *  bone's parent frame — local = parentWorld⁻¹ · R · parentWorld · rest —
+   *  which is the same construction the eyeballs use, and for the same reason:
+   *  the axis that means something ("the body's forward") is not an axis any
+   *  one bone owns.
+   */
+  _flap(dt) {
+    const W = WING_IDLE;
+    this._wingBlend = Math.min(1, (this._wingBlend ?? 1) + dt / Math.max(0.01, W.recover));
+    this._wingT = (this._wingT ?? 0) + dt * Math.max(0, W.hz);
+    this._wingT -= Math.floor(this._wingT);      // stays in [0,1) forever
+    // The body's forward, from the NORMALIZED rig: three-vrm guarantees those
+    // bones rest facing +Z, where the raw Tripo bones carry whatever roll
+    // Blender gave them. Falls back to the avatar group, which is upright and
+    // faces travel — worse only when the body is leaning.
+    const h = this.vrm.humanoid;
+    const ref = this._wingRef ?? (this._wingRef =
+      h?.getNormalizedBoneNode?.('upperChest') ?? h?.getNormalizedBoneNode?.('chest')
+      ?? h?.getNormalizedBoneNode?.('spine') ?? this.root);
+    ref.getWorldQuaternion(_wq);
+    _wax.set(0, 0, 1).applyQuaternion(_wq).normalize();   // forward: the flap
+    _wup.set(0, 1, 0).applyQuaternion(_wq).normalize();   // up: the sweep
+    for (const w of this._wings) {
+      // the outer segments trail their root, and (optionally) the lower pair
+      // trails the upper by half a beat
+      const ph = this._wingT - W.lag * w.depth - (W.sync || !w.lower ? 0 : 0.5);
+      // depth 0 carries the full amplitude; each segment out carries `tip` of
+      // the one before it, as its OWN rotation — the total sweep at the tip is
+      // larger than at the shoulder, because it inherits the root's as well.
+      const amp = W.deg * Math.pow(W.tip, w.depth);
+      const ang = (amp * Math.sin(ph * Math.PI * 2) + W.bias) * DEG * w.side;
+      _wr.setFromAxisAngle(_wax, ang);
+      // ...and the fore/aft sweep, about UP. Mirrored the OTHER way from the
+      // flap: the two wings point opposite ways along the span, so sweeping
+      // both forward together means opposite turns about the body's up axis.
+      // Composed on the left, so the sweep acts in the body's frame rather than
+      // in the already-flapped wing's.
+      const sw = W.sweep * Math.pow(W.tip, w.depth)
+        * Math.sin((ph + W.sweepPhase) * Math.PI * 2) * DEG * -w.side;
+      if (sw) _wr.premultiply(_wsw.setFromAxisAngle(_wup, sw));
+      // parentWorld is read fresh per bone, and roots are visited before tips
+      // (see _findWings), so a tip composes on its root's NEW orientation
+      // rather than last frame's.
+      // _wacc, not _wpq, as the accumulator: three.js quaternion ops MUTATE the
+      // receiver, so `_wpq.invert().multiply(_wr).multiply(_wpq)` reads the
+      // already-inverted-and-multiplied value back as the third factor and
+      // squares the rotation. It looked plausible — the wings flapped, in the
+      // right plane, symmetrically — and was 2x every commanded angle.
+      w.node.parent.getWorldQuaternion(_wpq);
+      _wacc.copy(_wpq).invert().multiply(_wr).multiply(_wpq).multiply(w.rest);
+      if (this._wingBlend < 1 && w.from) {
+        // Standing up, the bones are wherever the ragdoll left them — folded,
+        // or under her. Cutting straight to mid-flap is a one-frame teleport of
+        // something a metre long, so the first half-second is a slerp out of
+        // the pose she fell in. (The HAIR deliberately stays dishevelled; wings
+        // are limbs, and a bird shakes them back into place.)
+        w.node.quaternion.copy(w.from).slerp(_wacc, this._wingBlend);
+      } else {
+        w.node.quaternion.copy(_wacc);
+      }
+      // Explicit, though wing bones keep three.js's default: a bone declared as
+      // a VRM springbone has matrixAutoUpdate FALSE (three-vrm sets it on every
+      // spring joint), and on such a bone assigning .quaternion reaches the
+      // renderer never. That cost four rounds of debugging on the hair; costing
+      // it again on a rig that happens to declare its wings as springbones
+      // would be careless.
+      w.node.updateMatrix();
+    }
   }
 
   /** Hold the eyes shut (1) or let them open (0). Eased in update() so it
@@ -558,6 +773,23 @@ export class Avatar {
     // (/eyes) keeps them closed.
     if (on) { this._limpEyes = this.setEyes(true); }
     else if (this._limpEyes) { this._limpEyes = false; this.setEyes(false); }
+    // Wings: while limp they belong to the ragdoll (ammodoll hangs Bullet
+    // chains off these same bones), and here we only mark the handover BACK.
+    // Where the sim left them is captured now, so the flap can slerp out of it
+    // instead of cutting. On a REMOTE body no doll ever ran and the wings are
+    // simply frozen where the flap stopped — remotes carry no dressing on the
+    // wire, exactly as with the hair.
+    // Getting up is when the hair goes back to three-vrm — not when the doll
+    // disposed, which happens the moment the body settles and left the hair
+    // snapping to combed while she was still lying there.
+    if (!on) this._releaseHair();
+    if (!on) {
+      if (this._wings === undefined) this._findWings();
+      if (this._wings) {
+        for (const w of this._wings) w.from = w.node.quaternion.clone();
+        this._wingBlend = 0;
+      }
+    }
     if (!on) {
       // Hand the bones back as we found them. three.js only writes a bone when
       // the clip's computed value CHANGES, so a track that holds still — a
@@ -924,7 +1156,51 @@ export class Avatar {
     }
 
     BC('av:gaze-expr');
+    // ONE author per bone, again — this time for the hair.
+    //
+    // A rig with Hair_* chains is simulated TWICE while limp: ammodoll builds
+    // Bullet bodies for those bones and writes them in the 'me-drive' system,
+    // and three-vrm's springBoneManager writes the same bones inside
+    // vrm.update() during 'me-update'. Registration order is execution order,
+    // so the springbones always ran second and always won — the Bullet boxes
+    // swung wide in the debug overlay while the rendered hair barely moved,
+    // which is exactly how Janus described it.
+    //
+    // The wings never had this problem because nothing else simulates them.
+    // The hair's second simulator is the whole reason it moves while WALKING,
+    // so it cannot simply be removed: it is suppressed for exactly as long as a
+    // local sim owns those bones (__simHair, set by ammodoll between build and
+    // dispose), and dispose resets it so it resumes from where the tumble left
+    // the hair instead of snapping from its own stale state.
+    //
+    // Caveat worth knowing: this suppresses the whole manager, so a rig whose
+    // springbones include something Bullet does NOT drive — a skirt, a tail —
+    // would freeze that too while limp. Every chain in this rig is hair.
+    // Self-healing: ownership is claimed by the doll and released by setLimp,
+    // and anything that ends a tumble without going through setLimp (an avatar
+    // swap, a dragger taking over) would otherwise leave the hair suppressed
+    // and frozen for good.
+    if (this.__simHair && !this._limp) this._releaseHair();
+    const sbm = this.__simHair ? this.vrm.springBoneManager : null;
+    if (sbm) this.vrm.springBoneManager = null;
     this.vrm.update(dt);
+    if (sbm) this.vrm.springBoneManager = sbm;
+
+    // ---- wings: flap while alive, let go the instant the body does.
+    //
+    // AFTER vrm.update, unlike every other bone edit here, and deliberately.
+    // Wing bones are RAW and not humanoid, so nothing in vrm.update overwrites
+    // them — the ordering trap that put the head pitch and the blink up there
+    // does not apply. What DOES apply is that their parent clavicle is
+    // humanoid, and only receives this frame's clip pose when vrm.update copies
+    // normalized -> raw. Composing before that would hang every wing off last
+    // frame's shoulder, which shows as a shear whenever the body turns.
+    //
+    // While limp the wings belong to the sim: ammodoll hangs Bullet chains off
+    // these same bones and writes them every step, and two authors on one bone
+    // is decided by whichever runs second.
+    if (this._wings === undefined) this._findWings();
+    if (this._wings && !this._limp) this._flap(dt);
 
     // ---- contact shadow: on the GROUND, not on the body.
     // The blob is a child of root at a fixed local y, so it rode along under a

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -406,6 +406,15 @@ export class Avatar {
    *  This runs only where NO local sim owns the dressing — remotes, and the
    *  gap after a doll disposes. Where Bullet runs it already uses real world
    *  gravity and none of this applies.
+   *
+   *  CONFIRMED IN THE WORLD, 08-17. A 20s sample of a real drag showed Bullet
+   *  owning the hair for 96% of it, from which the first read was that this
+   *  could not be what "sideways while dragging" meant — and that was a
+   *  misreading of WHICH INSTANTS were being described. Grabbing, letting go,
+   *  pinning, and the fall afterwards are all springbone moments, and they are
+   *  what the report was about. With the center dropped, all of it came right.
+   *  The lesson is not about hair: 96% of the samples answered a question
+   *  nobody had asked, and the 4% was the whole story.
    */
   _springsLimp(on) {
     const sbm = this.vrm?.springBoneManager;

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -100,6 +100,15 @@ export const WING_IDLE = {
                     // diagonal line, just a tilted hinge.
 };
 
+/** What a limp body's springbones become, when no sim of its own is running.
+ *  Live: the debug panel dials these, and they take effect on the next body to
+ *  go limp. stiffness is a FACTOR on whatever the rig declared; gravity is a
+ *  floor, so a chain that already falls harder keeps its own value. */
+export const LIMP_SPRINGS = {
+  stiffness: 0.2,   // give way — the rest shape was authored for standing up
+  gravity: 0.45,    // ...and let the world win instead
+};
+
 const CORE_CLIPS = ['idle', 'walk'];
 const LATER_CLIPS = CLIP_SLOTS.filter((s) => !CORE_CLIPS.includes(s));
 // Until a clip arrives, the nearest thing that HAS arrived stands in. Silently
@@ -377,6 +386,88 @@ export class Avatar {
     }
     sbm.reset();                 // re-derives tails; the rotation restore is a no-op
     if (!adopt) this._combHair();
+  }
+
+  /** Springbone settings for a body that is LIMP and has no sim of its own.
+   *
+   *  three-vrm's springbones are tuned for a body that is standing up: the
+   *  droop is modelled into the rest shape, so gravityPower is near zero
+   *  (0.01-0.03) while stiffness is 0.35-1.3. Stiffness pulls each joint toward
+   *  its rest DIRECTION, and that direction rotates with the body — so on a
+   *  body lying on its side the hair is pulled sideways and world gravity is
+   *  far too weak to argue. That is "the direction of gravity pulling the hair
+   *  seems wrong", and it is not a bug in the springbones; it is a rest shape
+   *  being applied in a pose it was never authored for.
+   *
+   *  A body that cannot hold its own head up cannot hold its hair up either.
+   *  While limp and unowned, stiffness gives way and gravity takes over. The
+   *  originals are restored on standing, so nothing accumulates.
+   *
+   *  This runs only where NO local sim owns the dressing — remotes, and the
+   *  gap after a doll disposes. Where Bullet runs it already uses real world
+   *  gravity and none of this applies.
+   */
+  _springsLimp(on) {
+    const sbm = this.vrm?.springBoneManager;
+    if (!sbm?.joints || this.__springsLimp === on) return;
+    this.__springsLimp = on;
+    if (!this.__springSettings) {
+      this.__springSettings = new Map();
+      for (const j of sbm.joints) {
+        if (j?.settings) {
+          this.__springSettings.set(j, {
+            s: j.settings.stiffness, g: j.settings.gravityPower, center: j._center ?? null,
+          });
+        }
+      }
+    }
+    for (const j of sbm.joints) {
+      const o = this.__springSettings.get(j);
+      if (!o) continue;
+      j.settings.stiffness = on ? o.s * LIMP_SPRINGS.stiffness : o.s;
+      j.settings.gravityPower = on ? Math.max(o.g, LIMP_SPRINGS.gravity) : o.g;
+      // ...AND THE HAIR LIVES IN THE WORLD, not in the hips.
+      //
+      // `center` is why hair does not sweep back when you walk: the tail state
+      // is stored in the hips' frame, so pure locomotion moves hair and body
+      // together and the springs never see it. Exactly the same property is
+      // wrong for a body being carried: rotate it and the hair rotates
+      // RIGIDLY with it, because in hip space nothing happened. That is
+      // Janus's "drag it in one orientation and then the orientation changes",
+      // and "when it falls the hair stays in the direction it was falling
+      // before" — the hair is not lagging, it is being carried.
+      //
+      // A limp body is not walking, so the center has nothing left to protect.
+      // Dropped, the tails live in world space, gravity is world gravity, and
+      // swinging the body makes the hair trail the way it should.
+      if (on) j._center = null;
+      else if (o.center !== undefined) j._center = o.center;
+    }
+    // The tails were stored in the frame we just changed; re-derive them from
+    // the pose the hair is in, or the first frame after the switch reads old
+    // center-space numbers as world-space ones and flings it.
+    this._springsResync();
+  }
+
+  /** Re-derive spring tail state from the CURRENT pose, keeping that pose.
+   *
+   *  reset() alone would restore each joint's _initialLocalRotation (the combed
+   *  shape) — a visible snap. Pointing that rest at the pose the hair is
+   *  already in makes the restore a no-op while the tails re-derive, and then
+   *  the real rest goes back so the springs still pull toward the authored
+   *  shape afterwards. Needed anywhere the frame those tails live in changes. */
+  _springsResync() {
+    const sbm = this.vrm?.springBoneManager;
+    if (!sbm?.joints) return;
+    this.vrm.scene?.updateMatrixWorld?.(true);
+    const saved = [];
+    for (const j of sbm.joints) {
+      if (!j?._initialLocalRotation || !j.bone) continue;
+      saved.push([j, j._initialLocalRotation.clone()]);
+      j._initialLocalRotation.copy(j.bone.quaternion);
+    }
+    sbm.reset();
+    for (const [j, q] of saved) j._initialLocalRotation.copy(q);
   }
 
   /** Put the AUTHORED spring rest back, so the hair combs itself out again.
@@ -1205,6 +1296,9 @@ export class Avatar {
     // swap, a dragger taking over) would otherwise leave the hair suppressed
     // and frozen for good.
     if (this.__simHair && !this._limp) { this._releaseHair(); this._combHair(); }
+    // A limp body with no sim of its own hangs its hair on the world, not on
+    // its own rest shape (see _springsLimp).
+    this._springsLimp(this._limp && !this.__simHair);
     const sbm = this.__simHair ? this.vrm.springBoneManager : null;
     if (sbm) this.vrm.springBoneManager = null;
     this.vrm.update(dt);

--- a/client/lib/debug.js
+++ b/client/lib/debug.js
@@ -18,7 +18,7 @@ import { MeshBVHHelper } from 'three-mesh-bvh';
 import { colliders } from './colliders.js';
 import { closestParams, TUNING } from './ragdoll.js';
 import { JOINT_SPECS, HAIR_TUNING, WING_TUNING } from './ammodoll.js';
-import { BLINK, WING_IDLE } from './avatar.js';
+import { BLINK, WING_IDLE, LIMP_SPRINGS } from './avatar.js';
 import { makeFrame } from './frames.js';
 
 // box = an OBB, walkable on top, solid on the sides between min.y and max.y
@@ -505,6 +505,38 @@ function buildBlinkPanel(stack) {
   stack.appendChild(rows);
 }
 
+// A limp body with no sim of its own falls back to three-vrm, whose springs
+// are tuned for standing: the droop is in the rest shape, so gravity is near
+// zero and stiffness pulls toward a direction that rotates WITH the body. On a
+// body lying on its side that reads as gravity pulling the hair sideways.
+// These two take effect on the next body to go limp.
+const LIMP_FIELDS = [
+  ['stiffness', 0, 1, 0.02],   // factor on whatever the rig declared
+  ['gravity', 0, 1.5, 0.05],   // floor, not a replacement
+];
+
+function buildLimpPanel(stack) {
+  const rows = document.createElement('div');
+  rows.style.cssText = 'display:flex;flex-direction:column;gap:3px';
+  for (const [f, lo, hi, st] of LIMP_FIELDS) {
+    const wrap = document.createElement('div');
+    wrap.className = 'row';
+    const nm = document.createElement('span');
+    nm.className = 'nm'; nm.style.width = '54px'; nm.textContent = f;
+    const sl = document.createElement('input');
+    sl.type = 'range'; sl.min = lo; sl.max = hi; sl.step = st; sl.value = LIMP_SPRINGS[f];
+    const val = document.createElement('span');
+    val.className = 'v'; val.style.width = '44px';
+    const show = () => { val.textContent = f === 'stiffness'
+      ? `${LIMP_SPRINGS[f]}x` : String(LIMP_SPRINGS[f]); };
+    sl.oninput = () => { LIMP_SPRINGS[f] = Number(sl.value); show(); };
+    show();
+    wrap.append(nm, sl, val);
+    rows.appendChild(wrap);
+  }
+  stack.appendChild(rows);
+}
+
 function buildHairPanel(stack) {
   const defaults = { ...HAIR_TUNING };
   const rows = document.createElement('div');
@@ -740,6 +772,14 @@ export function initDebug(p = {}) {
   hhead.textContent = '— hair (live, while ragdolled) —';
   stack.appendChild(hhead);
   buildHairPanel(stack);
+
+  // limp springbones (remotes and post-dispose), live
+  const lhead = document.createElement('div');
+  lhead.className = 'row';
+  lhead.style.cssText = 'margin-top:6px;opacity:.75';
+  lhead.textContent = '— limp hair, no local sim —';
+  stack.appendChild(lhead);
+  buildLimpPanel(stack);
 
   // wings, live
   const whead = document.createElement('div');

--- a/client/lib/debug.js
+++ b/client/lib/debug.js
@@ -17,8 +17,8 @@ import { THREE, scene } from './core.js';
 import { MeshBVHHelper } from 'three-mesh-bvh';
 import { colliders } from './colliders.js';
 import { closestParams, TUNING } from './ragdoll.js';
-import { JOINT_SPECS, HAIR_TUNING } from './ammodoll.js';
-import { BLINK } from './avatar.js';
+import { JOINT_SPECS, HAIR_TUNING, WING_TUNING } from './ammodoll.js';
+import { BLINK, WING_IDLE } from './avatar.js';
 import { makeFrame } from './frames.js';
 
 // box = an OBB, walkable on top, solid on the sides between min.y and max.y
@@ -468,8 +468,11 @@ const BLINK_FIELDS = [
 
 const HAIR_FIELDS = [
   ['mass', 0.001, 0.05, 0.001],
-  ['tension', 0, 40, 0.5],
-  ['damping', 0, 1, 0.02],
+  // 0-40 put the whole interesting range (see WING/HAIR_TUNING: 3 to 20 covers
+  // barely-moving to lively) inside the first eighth of the track. These now
+  // resolve where the hair actually responds.
+  ['tension', 0, 24, 0.25],
+  ['damping', 0, 0.6, 0.01],
   ['gravity', 0, 1.5, 0.05],
   ['limit', 0, 90, 1],
   ['rootExp', 0.2, 3, 0.1],
@@ -548,6 +551,100 @@ function buildHairPanel(stack) {
   };
   btns.append(b1, b2);
   stack.append(rows, btns);
+}
+
+// ---- wings ------------------------------------------------------------------
+// Two tables, because a wing has two lives. WING_IDLE is the flap, read fresh
+// every frame by avatar.js, so its sliders bite instantly on a standing body.
+// WING_TUNING is the ragdoll's, and needs retuneWings() to reach constraints
+// that already exist — which only has anything to retune while a body is
+// actually limp. Drop her first, then reach for the lower half of this panel.
+const WING_IDLE_FIELDS = [
+  ['deg', 0, 60, 1],        // half-amplitude at the shoulder
+  ['hz', 0, 3, 0.02],       // flaps per second
+  ['bias', -40, 40, 1],     // permanent lift, degrees
+  ['tip', 0, 1.5, 0.05],    // outer segment's share
+  ['lag', 0, 0.5, 0.01],    // cycles the tip trails the root
+  ['sweep', 0, 40, 1],      // fore/aft travel — 0 pins the tips to the frontal
+                            // plane, which is the hinge look it exists to fix
+  ['sweepPhase', 0, 0.5, 0.01],  // 0.25 opens the path into an ellipse; 0 or
+                                 // 0.5 collapses it back to a tilted line
+  ['recover', 0.05, 2, 0.05],
+];
+const WING_SIM_FIELDS = [
+  ['mass', 0.02, 3, 0.01],
+  ['tension', 0, 400, 5],
+  ['damping', 0, 1, 0.02],
+  ['gravity', 0, 2, 0.05],
+  ['limit', 0, 90, 1],
+  ['rootExp', 0.2, 3, 0.1],
+];
+
+function buildWingPanel(stack) {
+  const idleDefaults = { ...WING_IDLE };
+  const simDefaults = { ...WING_TUNING };
+  const apply = () => {
+    const rd = providers.ragdoll?.();
+    if (rd?.retuneWings) rd.retuneWings();
+  };
+  const table = (fields, obj, live, fmt) => {
+    const rows = document.createElement('div');
+    rows.style.cssText = 'display:flex;flex-direction:column;gap:3px';
+    const mk = () => {
+      rows.textContent = '';
+      for (const [f, lo, hi, st] of fields) {
+        const wrap = document.createElement('div');
+        wrap.className = 'row';
+        const nm = document.createElement('span');
+        nm.className = 'nm'; nm.style.width = '54px'; nm.textContent = f;
+        const sl = document.createElement('input');
+        sl.type = 'range'; sl.min = lo; sl.max = hi; sl.step = st; sl.value = obj[f];
+        const val = document.createElement('span');
+        val.className = 'v'; val.style.width = '44px';
+        const show = () => { val.textContent = fmt(f); };
+        sl.oninput = () => { obj[f] = Number(sl.value); show(); if (live) apply(); };
+        show();
+        wrap.append(nm, sl, val);
+        rows.appendChild(wrap);
+      }
+    };
+    mk();
+    return { rows, mk };
+  };
+  const idle = table(WING_IDLE_FIELDS, WING_IDLE, false, (f) => (
+    f === 'deg' || f === 'bias' || f === 'sweep' ? `${WING_IDLE[f]}°`
+      : f === 'hz' ? `${WING_IDLE[f]}Hz`
+        : f === 'recover' ? `${(WING_IDLE[f] * 1000).toFixed(0)}ms`
+          : String(WING_IDLE[f])));
+  const sim = table(WING_SIM_FIELDS, WING_TUNING, true, (f) => (
+    f === 'mass' ? `${(WING_TUNING[f] * 1000).toFixed(0)}g`
+      : f === 'limit' ? `${WING_TUNING[f]}°` : String(WING_TUNING[f])));
+  const sub = (text) => {
+    const h = document.createElement('div');
+    h.className = 'nm'; h.style.cssText = 'opacity:0.6;margin-top:4px';
+    h.textContent = text;
+    return h;
+  };
+  const btns = document.createElement('div');
+  btns.className = 'row';
+  const b1 = document.createElement('button');
+  b1.textContent = 'reset wings';
+  b1.onclick = () => {
+    Object.assign(WING_IDLE, idleDefaults);
+    Object.assign(WING_TUNING, simDefaults);
+    idle.mk(); sim.mk(); apply();
+  };
+  const b2 = document.createElement('button');
+  b2.textContent = 'copy wings';
+  b2.onclick = async () => {
+    const one = (name, o) => `export const ${name} = {\n`
+      + Object.entries(o).map(([k, v]) => `  ${k}: ${v},`).join('\n') + '\n};';
+    const out = `${one('WING_IDLE', WING_IDLE)}\n\n${one('WING_TUNING', WING_TUNING)}`;
+    try { await navigator.clipboard.writeText(out); toastLike('wing tuning copied'); }
+    catch { console.log(out); toastLike('wing tuning logged'); }
+  };
+  btns.append(b1, b2);
+  stack.append(sub('flap (live)'), idle.rows, sub('limp (needs a ragdoll)'), sim.rows, btns);
 }
 
 // the panel has no toast of its own; keep the dependency to one line
@@ -643,6 +740,14 @@ export function initDebug(p = {}) {
   hhead.textContent = '— hair (live, while ragdolled) —';
   stack.appendChild(hhead);
   buildHairPanel(stack);
+
+  // wings, live
+  const whead = document.createElement('div');
+  whead.className = 'row';
+  whead.style.cssText = 'margin-top:6px;opacity:.75';
+  whead.textContent = '— wings —';
+  stack.appendChild(whead);
+  buildWingPanel(stack);
 
   // joint limits, live
   const jhead = document.createElement('div');

--- a/client/main.js
+++ b/client/main.js
@@ -510,6 +510,11 @@ if (typeof window !== 'undefined') window.setVoice = setVoice;
 }
 
 globalThis.__ambientDebug = () => ambientDebug();
+// My own body, for console probes. Chasing "the hair boxes move but the hair
+// mesh does not" meant asking whether the bones the sim writes are the same
+// objects the SkinnedMesh is bound to — a question answerable in one line from
+// the console and in no lines at all without a handle on the avatar.
+globalThis.__me = () => getMe();
 // One command R can paste to answer "why is it silent?" from her own console:
 // context state, how many sources exist, whether the gesture hook is waiting.
 globalThis.__audioState = () => audioState();

--- a/client/main.js
+++ b/client/main.js
@@ -515,6 +515,24 @@ globalThis.__ambientDebug = () => ambientDebug();
 // objects the SkinnedMesh is bound to — a question answerable in one line from
 // the console and in no lines at all without a handle on the avatar.
 globalThis.__me = () => getMe();
+// EVERY body in the scene, mine and the remotes, for console probes. Added
+// because "which system is driving that body's hair right now" — the flap,
+// Bullet, or three-vrm's springbones — is answerable in one line and was
+// answerable in none: the avatars were reachable only through module-private
+// maps, so a question about someone ELSE's body had nowhere to start.
+globalThis.__bodies = () => [
+  ...(getMe() ? [['me', getMe()]] : []),
+  ...[...remotes.entries()].map(([id, r]) => [id, r.avatar]),
+].filter(([, av]) => av).map(([who, av]) => ({
+  who,
+  limp: !!av._limp,
+  clip: av.currentSlot ?? null,
+  // exactly one of these should be true of a limp body: the local sim owns the
+  // hair and wings, or three-vrm does
+  simOwnsDressing: !!av.__simHair,
+  springbonesRunning: !av.__simHair && !!av.vrm?.springBoneManager,
+  avatar: av,
+}));
 // One command R can paste to answer "why is it silent?" from her own console:
 // context state, how many sources exist, whether the gesture hook is waiting.
 globalThis.__audioState = () => audioState();

--- a/tools/ammodoll-test.ts
+++ b/tools/ammodoll-test.ts
@@ -659,5 +659,349 @@ console.log('\nlifecycle (one rig, every downstream contract):');
     `done=${rd5.done}`);
 }
 
+// ---- wings ------------------------------------------------------------------
+// The fleet above cannot reach this code. makeAvatar builds HUMANOID bones and
+// nothing else, so a stand-in skeleton has no [LR]_Wing_* nodes for ammodoll to
+// find — which is the same gap that left headless bodies with no hair for a
+// month while the browser ran 75 locks of it (mcpl/physics.ts:216). So the wing
+// bones are grafted on here, from the shipped rig, the way physics.ts grafts
+// hair: read out of the VRM's node tree, parented to their real humanoid
+// ancestor.
+{
+  const { glbJson, humanBones, worldPositions, VRM_DIR } =
+    await import('./rig-load.mjs');
+  const { readFileSync, existsSync } = await import('node:fs');
+  const file = `${VRM_DIR}mythos-wings.vrm`;
+  console.log('\nwings (the ragdoll takes them over):');
+  if (!existsSync(file)) {
+    check('a winged rig is installed to test against', false, `no ${file}`);
+  } else {
+    // The CONTROL is the same rig as the fleet sees it — humanoid bones and the
+    // rig's real parent chain. Building the control with makeAvatar(P) instead
+    // would silently compare two different skeletons: with `realParent` passed,
+    // makeAvatar walks P's keys (54 bones, upperChest and shoulders and
+    // fingers) and without it walks PARENT's (16). The first version of this
+    // test did exactly that and reported 308mm of "wing shove" that was really
+    // 38 extra bones.
+    const rigW: any = FLEET.find((r: any) => r.name === 'mythos-wings');
+    if (!rigW) throw new Error('mythos-wings not in the fleet');
+    const g = glbJson(readFileSync(file));
+    const bones = humanBones(g);
+    const wp = worldPositions(g);
+    const P: any = { ...rigW.P };
+    const byName = new Map<string, number>();
+    g.nodes.forEach((n: any, i: number) => { if (n.name) byName.set(n.name, i); });
+    const parentOf = new Map<number, number>();
+    g.nodes.forEach((n: any, i: number) =>
+      (n.children ?? []).forEach((c: number) => parentOf.set(c, i)));
+    const wingParent: Record<string, string> = {};
+    for (const [name, i] of byName) {
+      if (!/^[LR]_Wing_(Upper|Lower)(_\d+)?$/.test(name)) continue;
+      P[name] = wp(i);
+      const pn = parentOf.get(i) != null ? g.nodes[parentOf.get(i)!]?.name : null;
+      // a segment either continues another wing bone, or hangs off the shoulder
+      wingParent[name] = (pn && /^[LR]_Wing_/.test(pn)) ? pn
+        : (name[0] === 'L' ? 'leftShoulder' : 'rightShoulder');
+    }
+    check('the rig carries every wing bone (4 chains x 3)',
+      Object.keys(wingParent).length === 12, `${Object.keys(wingParent).length} found`);
+    // HAIR bones too — the hair-ownership check below needs a rig that actually
+    // grows Bullet hair, and makeAvatar carries only humanoid bones by default
+    // (the same gap mcpl/physics.ts closes for headless agents).
+    const hairParent: Record<string, string> = {};
+    for (const [name, i] of byName) {
+      if (!/^Hair_\d+_\d+$/.test(name)) continue;
+      P[name] = wp(i);
+      const pn = parentOf.get(i) != null ? g.nodes[parentOf.get(i)!]?.name : null;
+      hairParent[name] = (pn && /^Hair_\d+_\d+$/.test(pn)) ? pn : 'head';
+    }
+    const RP2 = { ...rigW.realParent, ...wingParent, ...hairParent };
+
+    const av = makeAvatar(P, { realParent: { ...rigW.realParent, ...wingParent } });
+    const rd: any = new AmmoRagdoll(av, toppleLean(), av.restBonePositions());
+    check('the doll builds Bullet chains for them',
+      rd._wingSegs?.length === 12, `${rd._wingSegs?.length ?? 0} segments`);
+    // Chain ORDER is what the depth index buys: each segment's Bullet parent
+    // must be the body of its own parent BONE. Counting underscores made _1 and
+    // _2 the same depth, and the sort then left it to traversal luck which of
+    // them got built as the other's parent — a wing hinged in the wrong place,
+    // with nothing in the log to say so.
+    const segOf = new Map(rd._wingSegs.map((s: any) => [s.node, s]));
+    const misparented = rd._wingSegs.filter((s: any) => s.j > 0
+      && rd._wingSegs[rd._wingSegs.indexOf(s) - 1]?.node !== s.node.parent);
+    check('...each segment chained to its own parent BONE, in order',
+      misparented.length === 0,
+      misparented.map((s: any) => s.node.name).join(' '));
+    check('...and each chain ramps its limit over its own length',
+      rd._wingSegs.every((s: any) => s.n === 3));
+    check('...hung from four kinematic anchors',
+      rd._wingAnchors?.length === 4, `${rd._wingAnchors?.length ?? 0} anchors`);
+    check('...and the step loop sees hair and wings as one list',
+      rd._dressSegs?.length === (rd._hairSegs?.length ?? 0) + rd._wingSegs.length);
+
+    const wingNodes = rd._wingSegs.map((s: any) => s.node);
+    const before = wingNodes.map((n: any) => n.quaternion.clone());
+    // A wing must NOT be in the settle metric: 8 plates swinging on springs
+    // would hold a settled body awake, and the doll would never capture.
+    check('wings are excluded from the settle metric (not in _cores)',
+      rd._wingSegs.every((s: any) => !rd._cores.includes(s.body)));
+
+    // NO WING PLATE IS BORN INSIDE THE BODY.
+    //
+    // This is the hair's "poof" at wing scale: a contact born penetrating
+    // cannot be resolved — split impulse converts only 2cm of it and the rest
+    // is paid off as kinetic energy — and on a plate half a metre wide that is
+    // not a puff of hair, it is a body launched across the room. Hair solves it
+    // by excluding j===0 from the skull; wings are added with mask G_STATIC,
+    // which is a precaution and not a fix, so the geometry has to hold too.
+    //
+    // Measured as world AABBs at build time, which is deterministic. The
+    // obvious alternative — compare against a wingless twin — does NOT work:
+    // tried at settle it read 1m of divergence that was pure chaos, tried over
+    // the first half second it passed *even with the wings set to collide with
+    // everything*, i.e. it could not fail. This one can, and the head/torso
+    // pair below proves the instrument sees an overlap when there is one.
+    // "Inside" is asked of the actual boxes, not of bounding boxes: an AABB
+    // around a plate that sweeps out and back is enormous and overlaps the
+    // torso's for every root segment, which the first version of this reported
+    // as four wings born inside the body. The question that matters is whether
+    // the plate's CENTRE — where a penetrating contact would push from — sits
+    // within a core body's boxes.
+    const worldOf = (body: any) => {
+      const t = body.getCenterOfMassTransform();
+      const o = t.getOrigin(), r = t.getRotation();
+      return {
+        c: new THREE.Vector3(o.x(), o.y(), o.z()),
+        q: new THREE.Quaternion(r.x(), r.y(), r.z(), r.w()),
+        boxes: rd._vol.find((v: any) => v.body === body)?.boxes ?? [],
+      };
+    };
+    const inside = (p: any, body: any) => {
+      const w = worldOf(body);
+      const local = p.clone().sub(w.c).applyQuaternion(w.q.clone().invert());
+      return w.boxes.some((bx: any) => {
+        const b = local.clone().sub(bx.t).applyQuaternion(bx.q.clone().invert());
+        return Math.abs(b.x) <= bx.he.x && Math.abs(b.y) <= bx.he.y && Math.abs(b.z) <= bx.he.z;
+      });
+    };
+    const born: string[] = [];
+    for (const ws of rd._wingSegs) {
+      const p = worldOf(ws.body).c;
+      for (const core of rd._cores) if (inside(p, core)) born.push(ws.node.name);
+    }
+    check('no wing plate is born inside a body it cannot push out of',
+      born.length === 0, [...new Set(born)].join(' '));
+    // the predicate's own calibration: a body's own centre is inside its own
+    // boxes, so a clean wing result means "not inside", not "cannot tell"
+    const torso: any = rd.segs.get('chest|neck') ?? rd.segs.get('spine|chest');
+    check('...and that predicate can see an inside when there is one',
+      !!torso && inside(worldOf(torso.body).c, torso.body));
+    check('every anchor is kinematic (one-way, no reaction on the chest)',
+      rd._wingAnchors.every((a: any) => (a.anchor.getCollisionFlags() & 2) !== 0));
+
+    let steps = 0;
+    while (!rd.done && steps < 900) { rd.step(1 / 60); steps++; }
+    check('the body still falls and settles', rd.done, `${steps} steps`);
+    const moved = wingNodes.filter((n: any, i: number) =>
+      n.quaternion.angleTo(before[i]) > 1e-3).length;
+    check('the sim WRITES every wing bone during the fall', moved === 12,
+      `${moved}/12 moved`);
+
+    check('...with finite quaternions throughout',
+      wingNodes.every((n: any) => Number.isFinite(n.quaternion.x)
+        && Number.isFinite(n.quaternion.w)));
+    // the other half of the hair-ownership handshake (avatar-test has the
+    // consumer side): the doll must CLAIM the hair while it drives it, and
+    // hand it back reset, or three-vrm resumes from state captured before the
+    // fall and yanks the hair there in one frame
+    {
+      const hav = makeAvatar(P, { realParent: RP2 });
+      let didReset = false;
+      hav.vrm.springBoneManager = { reset: () => { didReset = true; }, update: () => {} };
+      hav.vrm.scene = { updateMatrixWorld: () => {} };
+      const hrd: any = new AmmoRagdoll(hav, toppleLean(), hav.restBonePositions());
+      check('a doll with Bullet hair claims those bones from three-vrm',
+        hav.__simHair === true, `hair segments: ${hrd._hairSegs?.length ?? 0}`);
+      hrd.dispose();
+      // A SETTLED BODY KEEPS THE HAIR THE FALL GAVE IT. dispose() used to hand
+      // the hair back and reset the springs, and since dispose fires the moment
+      // a body settles, the hair snapped to combed a few seconds into every
+      // fall while she was still lying there. Release belongs to getting up.
+      check('...and does NOT hand them back while she is still down',
+        hav.__simHair === true);
+      check('...so nothing resets the spring shape mid-fall', didReset === false);
+    }
+    rd.dispose();
+    check('dispose frees the wing bodies too', rd._freed === true);
+  }
+}
+
+// ---- wing boxes come from the MESH, not the bone length ---------------------
+// The failure: mythos's upper wing chain has a 16cm middle bone carrying 44cm
+// of membrane, and its outermost bone is a leaf where the builder had nothing
+// to measure and copied the previous segment's length. Both distal boxes came
+// out about a third of the wing they stood for — "the collider boxes are much
+// smaller than the actual wing sections", and the reason those sections would
+// not drape.
+//
+// Built here as a real THREE.SkinnedMesh rather than measured off the shipped
+// VRM, so the test states the contract instead of restating today's rig: a
+// SHORT bone with LONG geometry on it must get the geometry's box.
+{
+  console.log('\nwing boxes (sized by the mesh, not the bone):');
+  const { AmmoRagdoll } = await import('../client/lib/ammodoll.js');
+  const BONE_LEN = 0.15, MESH_LEN = 0.60, MESH_SPAN = 0.40;
+
+  const rigW: any = FLEET.find((r: any) => r.name === 'mythos-wings');
+  const P: any = { ...rigW.P };
+  // one chain, two segments, both short bones — the second a leaf
+  const shoulder = P.leftShoulder ?? P.leftUpperArm;
+  P.L_Wing_Upper = shoulder.clone().add(new THREE.Vector3(0.05, 0.05, 0));
+  P.L_Wing_Upper_1 = P.L_Wing_Upper.clone().add(new THREE.Vector3(BONE_LEN, 0, 0));
+  // ...and a hair chain, because the hair asks for its extents FIRST. Both
+  // families share one cache, and an unkeyed cache hands the second caller the
+  // first caller's map — wings would drop back to bone-length boxes on every
+  // rig that also has hair, which is every rig that matters, with nothing in
+  // the log to say the fix had stopped working.
+  P.Hair_0_0 = P.head.clone().add(new THREE.Vector3(0, 0.05, 0));
+  P.Hair_0_1 = P.Hair_0_0.clone().add(new THREE.Vector3(0, -0.04, 0));
+  const wingParent = {
+    L_Wing_Upper: 'leftShoulder', L_Wing_Upper_1: 'L_Wing_Upper',
+    Hair_0_0: 'head', Hair_0_1: 'Hair_0_0',
+  };
+  const av = makeAvatar(P, { realParent: { ...rigW.realParent, ...wingParent } });
+
+  // a slab of geometry on the OUTER bone, far longer than the bone itself
+  const bones = [av.nodes.L_Wing_Upper, av.nodes.L_Wing_Upper_1];
+  const geo = new THREE.BoxGeometry(MESH_LEN, MESH_SPAN, 0.02, 8, 8, 1);
+  const n = geo.attributes.position.count;
+  geo.setAttribute('skinIndex', new THREE.Uint16BufferAttribute(new Uint16Array(n * 4), 4));
+  geo.setAttribute('skinWeight', new THREE.Float32BufferAttribute(new Float32Array(n * 4), 4));
+  for (let i = 0; i < n; i++) {
+    geo.attributes.skinIndex.setXYZW(i, 1, 0, 0, 0);       // all on the OUTER bone
+    geo.attributes.skinWeight.setXYZW(i, 1, 0, 0, 0);
+  }
+  const skel = new THREE.Skeleton(bones);
+  const sm = new THREE.SkinnedMesh(geo, new THREE.MeshBasicMaterial());
+  av.root.add(sm);
+  sm.bind(skel);
+  av.root.updateMatrixWorld(true);
+
+  {
+    const hbones = [av.nodes.Hair_0_0, av.nodes.Hair_0_1];
+    const hgeo = new THREE.BoxGeometry(0.02, 0.05, 0.02, 2, 2, 2);
+    const hn = hgeo.attributes.position.count;
+    hgeo.setAttribute('skinIndex', new THREE.Uint16BufferAttribute(new Uint16Array(hn * 4), 4));
+    hgeo.setAttribute('skinWeight', new THREE.Float32BufferAttribute(new Float32Array(hn * 4), 4));
+    for (let i = 0; i < hn; i++) {
+      hgeo.attributes.skinIndex.setXYZW(i, 1, 0, 0, 0);
+      hgeo.attributes.skinWeight.setXYZW(i, 1, 0, 0, 0);
+    }
+    const hsm = new THREE.SkinnedMesh(hgeo, new THREE.MeshBasicMaterial());
+    av.root.add(hsm);
+    hsm.bind(new THREE.Skeleton(hbones));
+    av.root.updateMatrixWorld(true);
+  }
+
+  const rd: any = new AmmoRagdoll(av, toppleLean(), av.restBonePositions());
+  check('the fixture builds hair as well as wings (both families present)',
+    (rd._hairSegs?.length ?? 0) > 0 && (rd._wingSegs?.length ?? 0) > 0,
+    `hair ${rd._hairSegs?.length ?? 0}, wings ${rd._wingSegs?.length ?? 0}`);
+  const seg = rd._wingSegs.find((s: any) => s.node.name === 'L_Wing_Upper_1');
+  check('the rig under test has geometry 4x its bone length',
+    !!seg, seg ? '' : 'no outer wing segment built');
+  if (seg) {
+    const he = rd._vol.find((v: any) => v.body === seg.body).boxes[0].he;
+    const longest = 2 * Math.max(he.x, he.y, he.z);
+    check('the box spans the MESH, not the bone',
+      Math.abs(longest - MESH_LEN) < 0.05,
+      `box ${longest.toFixed(3)}m vs mesh ${MESH_LEN}m, bone ${BONE_LEN}m`);
+    const mid = 2 * [he.x, he.y, he.z].sort((a, b) => b - a)[1];
+    check('...across its span too, not a filament',
+      Math.abs(mid - MESH_SPAN) < 0.05, `${mid.toFixed(3)}m vs ${MESH_SPAN}m`);
+    check('...and a membrane keeps a floor thickness, not a degenerate box',
+      Math.min(he.x, he.y, he.z) >= 0.01);
+  }
+  // and the fallback still works where there is nothing to measure
+  const bare = makeAvatar(P, { realParent: { ...rigW.realParent, ...wingParent } });
+  const rdBare: any = new AmmoRagdoll(bare, toppleLean(), bare.restBonePositions());
+  check('a rig with no skinned mesh still gets bone-length boxes',
+    rdBare._wingSegs?.length === 2, `${rdBare._wingSegs?.length ?? 0} segments`);
+}
+
+// ---- the sim's writes must SURVIVE matrixAutoUpdate = false ----------------
+// three-vrm sets `bone.matrixAutoUpdate = false` on every spring-bone joint
+// (three-vrm.module.js:5279) and drives matrix/matrixWorld itself. On such a
+// bone, assigning `.quaternion` composes into `.matrix` never, so the renderer
+// shows the bone exactly where it was — while the Bullet body, the debug box
+// and every headless assertion move correctly.
+//
+// That is why this took four rounds to find: EVERY measurement agreed the
+// writeback was perfect (residual 0.01 deg), because they all read .quaternion,
+// which is exactly the thing that was being ignored. The instrument and the bug
+// shared a blind spot. So this test reads the WORLD MATRIX, the way a renderer
+// does, on bones configured the way three-vrm configures them.
+{
+  console.log('\nhair writes reach the renderer (matrixAutoUpdate = false):');
+  const rigW: any = FLEET.find((r: any) => r.name === 'mythos-wings');
+  const { glbJson, humanBones, worldPositions, VRM_DIR } = await import('./rig-load.mjs');
+  const { readFileSync } = await import('node:fs');
+  const g = glbJson(readFileSync(`${VRM_DIR}mythos-wings.vrm`));
+  const wp = worldPositions(g);
+  const P: any = { ...rigW.P };
+  const byName = new Map<string, number>();
+  g.nodes.forEach((n: any, i: number) => { if (n.name) byName.set(n.name, i); });
+  const parentOf = new Map<number, number>();
+  g.nodes.forEach((n: any, i: number) =>
+    (n.children ?? []).forEach((c: number) => parentOf.set(c, i)));
+  const hairParent: Record<string, string> = {};
+  for (const [name, i] of byName) {
+    if (!/^Hair_\d+_\d+$/.test(name)) continue;
+    P[name] = wp(i);
+    const pn = parentOf.get(i) != null ? g.nodes[parentOf.get(i)!]?.name : null;
+    hairParent[name] = (pn && /^Hair_\d+_\d+$/.test(pn)) ? pn : 'head';
+  }
+  const av = makeAvatar(P, { realParent: { ...rigW.realParent, ...hairParent } });
+  // exactly what three-vrm does to a spring joint
+  let frozen = 0;
+  av.root.traverse((o: any) => {
+    if (/^Hair_\d+_\d+$/.test(o.name ?? '')) { o.matrixAutoUpdate = false; frozen++; }
+  });
+  check('the fixture freezes hair bones the way three-vrm does', frozen > 0,
+    `${frozen} bones`);
+
+  const rd: any = new AmmoRagdoll(av, toppleLean(), av.restBonePositions());
+  const watch = rd._hairSegs.slice(0, 40);
+  const before = watch.map((s: any) => {
+    s.node.updateWorldMatrix(true, false);
+    return new THREE.Vector3().setFromMatrixPosition(s.node.matrixWorld);
+  });
+  for (let i = 0; i < 120; i++) rd.step(1 / 60);
+  // a renderer walks the graph; it does NOT call updateMatrix on a frozen bone
+  av.root.updateMatrixWorld(true);
+  let moved = 0, worst = 0;
+  watch.forEach((s: any, i: number) => {
+    const now = new THREE.Vector3().setFromMatrixPosition(s.node.matrixWorld);
+    const d = now.distanceTo(before[i]);
+    if (d > 0.005) moved++;
+    worst = Math.max(worst, d);
+  });
+  check('a frozen hair bone still MOVES IN ITS WORLD MATRIX after a fall',
+    moved > watch.length / 2,
+    `${moved}/${watch.length} moved, worst ${(worst * 100).toFixed(1)}cm`);
+  // and the matrix must agree with the quaternion — the failure mode was them
+  // disagreeing, with every test reading only the quaternion
+  const q = new THREE.Quaternion(), qm = new THREE.Quaternion();
+  const s0 = watch[0];
+  s0.node.matrix.decompose(new THREE.Vector3(), qm, new THREE.Vector3());
+  q.copy(s0.node.quaternion);
+  // 0.5 deg, not 1e-6: compose->decompose is a lossy round trip and the first
+  // threshold here flagged 0.02 deg of ordinary numeric drift as a defect. What
+  // this is actually watching for is a matrix that was never recomposed at all,
+  // which shows up as TENS of degrees (measured 40+ with the fix removed).
+  check('...and its matrix agrees with its quaternion (the two never diverge)',
+    qm.angleTo(q) < 0.5 * Math.PI / 180, `${(qm.angleTo(q) * 180 / Math.PI).toFixed(2)}° apart`);
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/tools/ammodoll-test.ts
+++ b/tools/ammodoll-test.ts
@@ -816,9 +816,14 @@ console.log('\nlifecycle (one rig, every downstream contract):');
     // fall and yanks the hair there in one frame
     {
       const hav = makeAvatar(P, { realParent: RP2 });
-      let didReset = false;
+      let didReset = false, adopted: any = null;
       hav.vrm.springBoneManager = { reset: () => { didReset = true; }, update: () => {} };
       hav.vrm.scene = { updateMatrixWorld: () => {} };
+      // the stand-in is not an Avatar, so it carries the one method the doll
+      // reaches for on the way out (avatar.js owns the real one)
+      hav._releaseHair = (opts: any) => {
+        adopted = opts; hav.__simHair = false; hav.vrm.springBoneManager.reset();
+      };
       const hrd: any = new AmmoRagdoll(hav, toppleLean(), hav.restBonePositions());
       check('a doll with Bullet hair claims those bones from three-vrm',
         hav.__simHair === true, `hair segments: ${hrd._hairSegs?.length ?? 0}`);
@@ -827,9 +832,12 @@ console.log('\nlifecycle (one rig, every downstream contract):');
       // the hair back and reset the springs, and since dispose fires the moment
       // a body settles, the hair snapped to combed a few seconds into every
       // fall while she was still lying there. Release belongs to getting up.
-      check('...and does NOT hand them back while she is still down',
-        hav.__simHair === true);
-      check('...so nothing resets the spring shape mid-fall', didReset === false);
+      // dispose hands the hair back ADOPTING the fallen pose — live again, so a
+      // body let go mid-drag keeps falling with its hair instead of freezing
+      check('...and hands them back on dispose, adopting the fallen pose',
+        hav.__simHair === false && adopted?.adopt === true,
+        `adopt=${adopted?.adopt}`);
+      check('...having re-derived the spring state so it resumes smoothly', didReset);
     }
     rd.dispose();
     check('dispose frees the wing bodies too', rd._freed === true);
@@ -1001,6 +1009,33 @@ console.log('\nlifecycle (one rig, every downstream contract):');
   // which shows up as TENS of degrees (measured 40+ with the fix removed).
   check('...and its matrix agrees with its quaternion (the two never diverge)',
     qm.angleTo(q) < 0.5 * Math.PI / 180, `${(qm.angleTo(q) * 180 / Math.PI).toFixed(2)}° apart`);
+}
+
+// ---- the collision filter fits in a SHORT --------------------------------
+// ammo.js declares addRigidBody's group and mask as short, not int. Anything
+// above bit 14 truncates on the way into wasm, and a group of 0 collides with
+// NOTHING -- which is why hair, wings and fingers fell through the floor, and
+// why both feet (the last two bits under the old 16-bit budget) were ghosts.
+// The failure is completely silent, so it is asserted rather than remembered.
+{
+  console.log('\ncollision groups fit the short the binding declares:');
+  const rig: any = FLEET.find((r: any) => r.name === 'mythos-wings') ?? FLEET[0];
+  const av = makeAvatar(rig.P, { realParent: rig.realParent });
+  const rd: any = new AmmoRagdoll(av, toppleLean(), av.restBonePositions());
+  const groups = [...rd._groupOf.values()] as number[];
+  const asShort = (v: number) => { const m = v & 0xffff; return m > 32767 ? m - 65536 : m; };
+  check('every core body has a bit (none dropped to ground-only)',
+    rd._groupOf.size === rd._cores.length,
+    `${rd._groupOf.size} of ${rd._cores.length}`);
+  check('no group truncates to zero (a body that collides with nothing)',
+    groups.every((g) => asShort(g) !== 0),
+    groups.filter((g) => asShort(g) === 0).join(','));
+  check('no group lands on the sign bit',
+    groups.every((g) => asShort(g) > 0),
+    groups.filter((g) => asShort(g) < 0).join(','));
+  check('the dressing group survives too',
+    asShort(1 << 14) === 1 << 14);
+  rd.dispose();
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/assets-stub.mjs
+++ b/tools/assets-stub.mjs
@@ -10,3 +10,8 @@ export const vrmaBytes = async () => null;
 export const vrmaShaLoaded = () => null;   // #101: no clip bytes in the stub world — seats read declared-approximate
 export const loadTrack = async () => null;
 export const loadDone = () => true;
+// Added when avatar.js grew a VRM warm/release path; without them the suite
+// cannot import at all (see loadwork-stub for the same lesson).
+export const releaseVRM = () => {};
+export const vrmWarmed = () => true;
+export const markVrmWarmed = () => {};

--- a/tools/avatar-test.ts
+++ b/tools/avatar-test.ts
@@ -558,6 +558,58 @@ console.log('\nwings:');
     check('...and ownership is released', self.__simHair === false);
   }
 
+  // A limp body with NO sim of its own must hang its hair on the world. The
+  // springs are authored for standing — gravity near zero, stiffness pulling
+  // toward a rest direction that rotates WITH the body — so on a body lying on
+  // its side the hair is pulled sideways and gravity cannot argue.
+  {
+    const { LIMP_SPRINGS } = await import('../client/lib/avatar.js');
+    const hips = { name: 'Hip' };
+    const joint: any = {
+      settings: { stiffness: 1.0, gravityPower: 0.02 }, _center: hips,
+      bone: { quaternion: new THREE.Quaternion() },
+      _initialLocalRotation: new THREE.Quaternion(),
+    };
+    let resets = 0;
+    const self: any = {
+      _limp: false, __simHair: false,
+      vrm: {
+        scene: { updateMatrixWorld() {} },
+        springBoneManager: { joints: new Set([joint]), reset() { resets++; } },
+      },
+    };
+    self._springsLimp = (Avatar.prototype as any)._springsLimp;
+    self._springsResync = (Avatar.prototype as any)._springsResync;
+    self._springsLimp(false);
+    check('a standing body keeps the rig\'s own spring settings',
+      joint.settings.stiffness === 1.0 && joint.settings.gravityPower === 0.02);
+    self._springsLimp(true);
+    check('a limp body with no sim lets gravity win',
+      joint.settings.gravityPower >= LIMP_SPRINGS.gravity
+      && joint.settings.stiffness < 1.0,
+      `stiffness ${joint.settings.stiffness}, gravity ${joint.settings.gravityPower}`);
+    check('...and gravity is a FLOOR, not a replacement',
+      joint.settings.gravityPower === Math.max(0.02, LIMP_SPRINGS.gravity));
+    self._springsLimp(false);
+    check('...restored exactly on standing, so nothing accumulates',
+      joint.settings.stiffness === 1.0 && joint.settings.gravityPower === 0.02);
+    // the CENTER is why a carried body's hair rotates rigidly with it: the tail
+    // state lives in hip space, so turning the body is invisible to the springs
+    self._springsLimp(true);
+    check('a limp body simulates its hair in the WORLD, not in its hips',
+      joint._center === null);
+    check('...re-deriving the tails, which lived in the frame just changed',
+      resets > 0);
+    self._springsLimp(false);
+    check('...and the hips center comes back on standing',
+      joint._center === hips);
+    // and it must be idempotent — update() calls it every frame
+    for (let i = 0; i < 5; i++) self._springsLimp(true);
+    check('...and repeated calls do not compound the factor',
+      Math.abs(joint.settings.stiffness - 1.0 * LIMP_SPRINGS.stiffness) < 1e-9,
+      `stiffness ${joint.settings.stiffness}`);
+  }
+
   // Letting go of a DRAGGED body disposes its doll mid-tumble. Adopting the
   // fallen shape hands the hair back live; not handing it back at all left it
   // owned by a sim that no longer existed and frozen in mid-air — seen on a

--- a/tools/avatar-test.ts
+++ b/tools/avatar-test.ts
@@ -94,7 +94,7 @@ function stand({ constant = false } = {}) {
   // real methods, or setLimp throws and the whole suite stops at test two.
   for (const m of ['setLimp', '_park', '_resolveBones', '_humanoidBones', 'setPose',
                    'clearPose', '_applyOverride', '_composeBegin', '_composeEnd',
-                   'setEyes', '_findLids', '_findWings', '_releaseHair']) {
+                   'setEyes', '_findLids', '_findWings', '_releaseHair', '_combHair']) {
     self[m] = (Avatar.prototype as any)[m];
   }
   // the slice of update() that matters here, in its real order
@@ -291,7 +291,7 @@ function wingStand() {
     cancelEmote() { this.emote = null; },
   };
   for (const m of ['_findWings', '_flap', 'setLimp', 'setEyes', '_findLids',
-                   '_resolveBones', '_humanoidBones', '_park', '_releaseHair']) {
+                   '_resolveBones', '_humanoidBones', '_park', '_releaseHair', '_combHair']) {
     self[m] = (Avatar.prototype as any)[m];
   }
   self._findWings();
@@ -548,6 +548,7 @@ console.log('\nwings:');
       },
     };
     self._releaseHair = (Avatar.prototype as any)._releaseHair;
+    self._combHair = (Avatar.prototype as any)._combHair;
     self._releaseHair();
     check('releasing the hair KEEPS the pose the fall left',
       bone.quaternion.angleTo(q(1.1)) < 1e-6,
@@ -555,6 +556,39 @@ console.log('\nwings:');
     check('...and puts the combed rest back, so it still combs out afterwards',
       joint._initialLocalRotation.angleTo(q(0)) < 1e-6);
     check('...and ownership is released', self.__simHair === false);
+  }
+
+  // Letting go of a DRAGGED body disposes its doll mid-tumble. Adopting the
+  // fallen shape hands the hair back live; not handing it back at all left it
+  // owned by a sim that no longer existed and frozen in mid-air — seen on a
+  // dragged dummy, never on a body going limp on its own, because that one
+  // keeps its doll until it settles.
+  {
+    const q = (x: number) => new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), x);
+    const bone = { quaternion: q(0.9) };
+    const joint = { bone, _initialLocalRotation: q(0) };
+    const self: any = {
+      __simHair: true, _limp: true,
+      vrm: {
+        scene: { updateMatrixWorld() {} },
+        springBoneManager: {
+          joints: new Set([joint]),
+          reset() { bone.quaternion.copy(joint._initialLocalRotation); },
+        },
+      },
+    };
+    self._releaseHair = (Avatar.prototype as any)._releaseHair;
+    self._combHair = (Avatar.prototype as any)._combHair;
+    self._releaseHair({ adopt: true });
+    check('a doll disposing mid-tumble hands the hair back LIVE, not frozen',
+      self.__simHair === false);
+    check('...keeping the pose it was dropped in',
+      bone.quaternion.angleTo(q(0.9)) < 1e-6);
+    check('...with the springs now resting THERE, so it falls on with her',
+      joint._initialLocalRotation.angleTo(q(0.9)) < 1e-6);
+    self._combHair();
+    check('...and getting up restores the authored shape (no ratchet)',
+      joint._initialLocalRotation.angleTo(q(0)) < 1e-6);
   }
 
   // a REMOTE body goes limp with no doll of its own — suppressing there would

--- a/tools/avatar-test.ts
+++ b/tools/avatar-test.ts
@@ -88,8 +88,13 @@ function stand({ constant = false } = {}) {
     cancelEmote() { this.emote = null; },
   };
   self._composed = new Map();
+  // setLimp reaches into the eyes and the wings on the way past. Both find
+  // NOTHING on this fixture (no vrm.scene to traverse) and say so, which is the
+  // behaviour a rig without lids or wings needs anyway — but they have to be
+  // real methods, or setLimp throws and the whole suite stops at test two.
   for (const m of ['setLimp', '_park', '_resolveBones', '_humanoidBones', 'setPose',
-                   'clearPose', '_applyOverride', '_composeBegin', '_composeEnd']) {
+                   'clearPose', '_applyOverride', '_composeBegin', '_composeEnd',
+                   'setEyes', '_findLids', '_findWings', '_releaseHair']) {
     self[m] = (Avatar.prototype as any)[m];
   }
   // the slice of update() that matters here, in its real order
@@ -212,6 +217,363 @@ for (const constant of [false, true]) {
       nodes.hips.quaternion.angleTo(clipPose) < 1e-3,
       `${nodes.hips.quaternion.angleTo(clipPose).toFixed(3)} rad off`);
   }
+}
+
+// ---- wings ------------------------------------------------------------------
+// The flap is geometry, and geometry is exactly the kind of thing that "runs
+// without throwing" while pointing the wrong way — the eyelids shipped rotating
+// about the wrong axis and passed every check there was, because every check
+// asked whether a number had changed. So these ask where the WING TIP went.
+//
+// The rest pose below is mythos's own, read out of mythos-wings.blend and
+// converted to glTF's Y-up (x, z, -y): wings that leave the shoulder blades and
+// sweep out, up and back.
+//
+// THREE bones per chain since 08-17, and the fixture is a list per chain rather
+// than named _1/_tip slots so that growing a chain again is a data edit. A
+// fixture that hard-codes the chain length cannot catch a depth bug — which is
+// exactly what happened: `_1` and `_2` both parsed as depth 1 (an underscore
+// COUNT, not the index), and with only two-bone chains in the fixture nothing
+// had a third segment to disagree about.
+const WING_REST: Record<string, [number, number, number][]> = {
+  // chain: [seg 0, seg 1, seg 2, ..., end of the last segment]
+  L_Wing_Upper: [
+    [0.0369, 0.7923, -0.067], [0.1696, 0.9047, -0.1645],
+    [0.2307, 0.9479, -0.2038], [0.4386, 1.0227, -0.3627],
+  ],
+  R_Wing_Upper: [
+    [-0.0432, 0.7923, -0.067], [-0.1786, 0.9047, -0.1623],
+    [-0.2361, 0.9471, -0.2026], [-0.4469, 1.0162, -0.3524],
+  ],
+  L_Wing_Lower: [
+    [0.0409, 0.7771, -0.067], [0.1466, 0.7004, -0.133],
+    [0.2224, 0.5254, -0.1626], [0.2554, 0.3382, -0.1864],
+  ],
+  R_Wing_Lower: [
+    [-0.0432, 0.7754, -0.067], [-0.1466, 0.7066, -0.1155],
+    [-0.2339, 0.5265, -0.1617], [-0.2599, 0.3393, -0.1884],
+  ],
+};
+
+function wingStand() {
+  const root = new THREE.Object3D();
+  const chest = new THREE.Object3D(); chest.name = 'upperChest';
+  root.add(chest);
+  const nodes: Record<string, any> = { upperChest: chest };
+  for (const [chain, pts] of Object.entries(WING_REST)) {
+    const V = (i: number) => new THREE.Vector3(...pts[i]);
+    let parent = chest;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const n = new THREE.Object3D();
+      n.name = i === 0 ? chain : `${chain}_${i}`;
+      n.position.copy(V(i)).sub(i === 0 ? new THREE.Vector3() : V(i - 1));
+      parent.add(n);
+      nodes[n.name] = n;
+      parent = n;
+    }
+    // not a bone — a marker at the end of the outermost segment, so a test can
+    // ask where the WING went rather than what a quaternion contains
+    const tip = new THREE.Object3D();
+    tip.name = `${chain}_tip#marker`;
+    tip.position.copy(V(pts.length - 1)).sub(V(pts.length - 2));
+    parent.add(tip);
+    nodes[`${chain}_tip`] = tip;
+  }
+  const self: any = {
+    _limp: false, root, emote: null, _parked: null,
+    vrm: {
+      scene: root,
+      humanoid: {
+        humanBones: {},
+        getNormalizedBoneNode: (n: string) => nodes[n] ?? null,
+      },
+    },
+    cancelEmote() { this.emote = null; },
+  };
+  for (const m of ['_findWings', '_flap', 'setLimp', 'setEyes', '_findLids',
+                   '_resolveBones', '_humanoidBones', '_park', '_releaseHair']) {
+    self[m] = (Avatar.prototype as any)[m];
+  }
+  self._findWings();
+  self.tick = function (dt = 1 / 60) {
+    if (!this._limp) this._flap(dt);
+    root.updateMatrixWorld(true);
+  };
+  const tipY = (n: string) => {
+    root.updateMatrixWorld(true);
+    return nodes[n].getWorldPosition(new THREE.Vector3()).y;
+  };
+  const tipPos = (n: string) => {
+    root.updateMatrixWorld(true);
+    return nodes[n].getWorldPosition(new THREE.Vector3());
+  };
+  return { self, nodes, tipY, tipPos };
+}
+
+console.log('\nwings:');
+{
+  const { self, nodes } = wingStand();
+  check('every wing bone is found (4 chains x 3)', self._wings?.length === 12,
+    `${self._wings?.length ?? 0} found`);
+  check('...at the depth its NAME says, not a count of underscores',
+    JSON.stringify(self._wings.map((w: any) => w.depth).sort()) === '[0,0,0,0,1,1,1,1,2,2,2,2]',
+    self._wings.map((w: any) => `${w.node.name}=${w.depth}`).join(' '));
+  check('roots are visited before tips',
+    self._wings.every((w: any, i: number) => i === 0
+      || w.depth >= self._wings[i - 1].depth));
+  check('sides are read off the name',
+    self._wings.filter((w: any) => w.side === 1).length === 6
+    && self._wings.filter((w: any) => w.side === -1).length === 6);
+  check('the authored pose is shared with the ragdoll',
+    self.__wingRest instanceof Map && self.__wingRest.size === 12);
+  // nodes are referenced so the fixture cannot be optimised into nothing
+  check('the marker hangs off the OUTERMOST segment',
+    nodes.L_Wing_Upper_tip.parent === nodes.L_Wing_Upper_2);
+}
+
+{
+  // Sweep a whole cycle and record where each tip goes.
+  const { self, tipY, tipPos } = wingStand();
+  const { WING_IDLE } = await import('../client/lib/avatar.js');
+  const dt = 1 / 120;
+  const frames = Math.round(1 / (WING_IDLE.hz * dt));      // one full flap
+  const track: Record<string, number[]> = {};
+  const p0: Record<string, any> = {};
+  for (const n of ['L_Wing_Upper_tip', 'R_Wing_Upper_tip',
+                   'L_Wing_Lower_tip', 'R_Wing_Lower_tip']) {
+    track[n] = []; p0[n] = tipPos(n).clone();
+  }
+  for (let i = 0; i <= frames; i++) {
+    self.tick(dt);
+    for (const n of Object.keys(track)) track[n].push(tipY(n));
+  }
+  const span = (n: string) => Math.max(...track[n]) - Math.min(...track[n]);
+  check('the tips actually move', Object.keys(track).every((n) => span(n) > 0.02),
+    Object.keys(track).map((n) => `${n} ${span(n).toFixed(3)}m`).join(' '));
+
+  // THE AXIS test — asked as "which axis", not "which direction the tip went".
+  //
+  // The first version asserted the swing was VERTICAL, which held while every
+  // wing pointed outward and broke the moment the lower chain was re-authored
+  // to hang DOWN: rotate a drooping wing about the body's forward axis and its
+  // tip travels sideways, correctly. That test was reading the rig's geometry
+  // and calling it the code's axis.
+  //
+  // What the flap actually promises is that it turns about the body's FORWARD
+  // axis, and a rotation about forward moves nothing along forward. So with the
+  // sweep off, every tip must stay in the frontal plane, whatever direction its
+  // bone happens to point. Geometry can change freely under this.
+  {
+    const sweep0 = WING_IDLE.sweep;
+    WING_IDLE.sweep = 0;
+    const rep = wingStand();
+    const fore: Record<string, number[]> = {};
+    for (const n of Object.keys(track)) fore[n] = [];
+    for (let i = 0; i <= frames; i++) {
+      rep.self.tick(dt);
+      for (const n of Object.keys(track)) fore[n].push(rep.tipPos(n).z);
+    }
+    WING_IDLE.sweep = sweep0;
+    const rng = (a: number[]) => Math.max(...a) - Math.min(...a);
+    const worst = Math.max(...Object.keys(fore).map((n) => rng(fore[n])));
+    check('the flap turns about the body FORWARD axis (no fore/aft without sweep)',
+      worst < 0.001, `${(worst * 1000).toFixed(2)}mm of fore/aft leaked in`);
+  }
+
+  // Symmetry: both sides must rise together. A sign error here gives one wing
+  // up while the other goes down, which is the single most likely mistake in
+  // the whole file and looks deliberate enough to survive a glance.
+  const corr = (a: string, b: string) => {
+    const A = track[a], B = track[b];
+    const ma = A.reduce((s, v) => s + v, 0) / A.length;
+    const mb = B.reduce((s, v) => s + v, 0) / B.length;
+    let num = 0, da = 0, db = 0;
+    for (let i = 0; i < A.length; i++) {
+      num += (A[i] - ma) * (B[i] - mb); da += (A[i] - ma) ** 2; db += (B[i] - mb) ** 2;
+    }
+    return num / Math.sqrt(da * db);
+  };
+  check('left and right rise TOGETHER (mirrored, not opposed)',
+    corr('L_Wing_Upper_tip', 'R_Wing_Upper_tip') > 0.99,
+    `r=${corr('L_Wing_Upper_tip', 'R_Wing_Upper_tip').toFixed(3)}`);
+  check('the upper and lower pairs are in sync',
+    corr('L_Wing_Upper_tip', 'L_Wing_Lower_tip') > 0.9,
+    `r=${corr('L_Wing_Upper_tip', 'L_Wing_Lower_tip').toFixed(3)}`);
+}
+
+{
+  // THE SWEEP: tips have to travel FORWARD and BACK too, not only up and down.
+  // Rotating about the forward axis alone confines every tip to the frontal
+  // plane — "rotating on the X-Z plane", as Janus put it — and that reads as a
+  // hinge. Three things have to hold, and a silent no-op passes none of them.
+  const { WING_IDLE } = await import('../client/lib/avatar.js');
+  const { self, tipPos } = wingStand();
+  const dt = 1 / 120;
+  const frames = Math.round(1 / (WING_IDLE.hz * dt));
+  const ys: Record<string, number[]> = {}, zs: Record<string, number[]> = {};
+  const names = ['L_Wing_Upper_tip', 'R_Wing_Upper_tip'];
+  for (const n of names) { ys[n] = []; zs[n] = []; }
+  for (let i = 0; i <= frames; i++) {
+    self.tick(dt);
+    for (const n of names) { const p = tipPos(n); ys[n].push(p.y); zs[n].push(p.z); }
+  }
+  const rng = (a: number[]) => Math.max(...a) - Math.min(...a);
+  const corr = (A: number[], B: number[]) => {
+    const ma = A.reduce((s, v) => s + v, 0) / A.length;
+    const mb = B.reduce((s, v) => s + v, 0) / B.length;
+    let num = 0, da = 0, db = 0;
+    for (let i = 0; i < A.length; i++) {
+      num += (A[i] - ma) * (B[i] - mb); da += (A[i] - ma) ** 2; db += (B[i] - mb) ** 2;
+    }
+    return num / Math.sqrt(da * db);
+  };
+  const fa = rng(zs.L_Wing_Upper_tip);
+  check('the tips also travel FORE AND AFT, not only in the frontal plane',
+    fa > 0.02, `${(fa * 100).toFixed(1)}cm fore/aft`);
+  check('...both wings sweeping forward together',
+    corr(zs.L_Wing_Upper_tip, zs.R_Wing_Upper_tip) > 0.99,
+    `r=${corr(zs.L_Wing_Upper_tip, zs.R_Wing_Upper_tip).toFixed(3)}`);
+  // quadrature is what opens the path into an ellipse. In phase (r near ±1) the
+  // tip runs up and down a tilted straight line, which is still just a hinge —
+  // a sweep that "works" by every other measure and changes nothing to look at.
+  const q = Math.abs(corr(ys.L_Wing_Upper_tip, zs.L_Wing_Upper_tip));
+  check('...and the tip path is an ellipse, not a tilted straight line',
+    q < 0.4, `|r(up, fore)|=${q.toFixed(3)} — 1.0 would be a line`);
+}
+
+{
+  // Does not integrate. Every frame rebuilds from the captured rest, so after
+  // any number of whole cycles the pose is the pose it started in — the failure
+  // this prevents is a wing that winds slowly around its own axis over an hour
+  // and is invisible for the first ten minutes.
+  const { self, nodes } = wingStand();
+  const { WING_IDLE } = await import('../client/lib/avatar.js');
+  // dt chosen so a cycle is a WHOLE number of frames. With a round dt the last
+  // frame of each cycle lands short, and 300 cycles of that rounding is a
+  // quarter turn of phase — which the first version of this test dutifully
+  // reported as 30° of drift in the code. The test was the thing drifting.
+  const perCycle = 600;
+  const dt = 1 / (WING_IDLE.hz * perCycle);
+  self.tick(dt);
+  const q0 = nodes.L_Wing_Upper.quaternion.clone();
+  for (let c = 0; c < 300; c++) for (let i = 0; i < perCycle; i++) self.tick(dt);
+  const drift = nodes.L_Wing_Upper.quaternion.angleTo(q0);
+  check('300 cycles later the wing is where it started (no integration)',
+    drift < 1e-3, `${(drift * 180 / Math.PI).toFixed(3)}° of drift`);
+}
+
+{
+  // The handover. While limp the flap must not write — the ragdoll owns these
+  // bones — and standing up must ease out of the pose the fall left, not cut.
+  const { self, nodes } = wingStand();
+  for (let i = 0; i < 40; i++) self.tick();
+  (Avatar.prototype as any).setLimp.call(self, true);
+  const fallen = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), 1.1);
+  nodes.L_Wing_Upper.quaternion.copy(fallen);
+  for (let i = 0; i < 40; i++) self.tick();
+  check('while limp the flap writes nothing',
+    nodes.L_Wing_Upper.quaternion.angleTo(fallen) < 1e-9);
+
+  // through the real setLimp — assigning _limp first would make it return at
+  // its own `on === this._limp` guard, and the test would be asserting on a
+  // method that never ran
+  (Avatar.prototype as any).setLimp.call(self, false);
+  check('standing up captures where the sim left each wing',
+    self._wings.every((w: any) => w.from) && self._wingBlend === 0);
+  self.tick();
+  const moved1 = nodes.L_Wing_Upper.quaternion.angleTo(fallen);
+  check('...and the first frame back is a step, not a teleport',
+    moved1 > 0 && moved1 < 0.25, `${(moved1 * 180 / Math.PI).toFixed(1)}° in one frame`);
+  for (let i = 0; i < 120; i++) self.tick();
+  check('...and the blend completes', self._wingBlend === 1);
+}
+
+// ---- one author per hair bone ----------------------------------------------
+// A rig with Hair_* chains has TWO simulators: ammodoll's Bullet bodies (system
+// 'me-drive') and three-vrm's springBoneManager, which runs inside vrm.update
+// one system later in 'me-update' and therefore always wrote last. The Bullet
+// boxes swung and the rendered hair did not follow.
+//
+// Nothing else can catch this: every bone is finite, every quaternion is
+// written, both sims are "working". The only observable is WHICH ran last.
+{
+  console.log('\nhair ownership while the sim drives it:');
+  const mk = () => {
+    const calls: string[] = [];
+    const self: any = {
+      _limp: false, _wings: null, _lids: null, _eyes: null, __simHair: false,
+      vrm: {
+        springBoneManager: { update: () => calls.push('spring'), reset: () => calls.push('reset') },
+        update: function (d: number) { this.springBoneManager?.update(d); },
+      },
+    };
+    // the slice of Avatar.update that decides the question
+    self.tick = function (dt = 1 / 60) {
+      const sbm = this.__simHair ? this.vrm.springBoneManager : null;
+      if (sbm) this.vrm.springBoneManager = null;
+      this.vrm.update(dt);
+      if (sbm) this.vrm.springBoneManager = sbm;
+    };
+    return { self, calls };
+  };
+  const a = mk();
+  a.self.tick();
+  check('a standing body runs three-vrm springbones (hair moves while walking)',
+    a.calls.includes('spring'));
+
+  const b = mk();
+  b.self._limp = true; b.self.__simHair = true;
+  b.calls.length = 0;
+  for (let i = 0; i < 10; i++) b.self.tick();
+  check('...but not while a local sim owns those same bones',
+    !b.calls.includes('spring'), `${b.calls.length} springbone updates ran`);
+  check('...and the manager is restored, not lost',
+    b.self.vrm.springBoneManager?.update != null);
+
+  // Handing the hair back must not COMB it. joint.reset() restores each bone's
+  // _initialLocalRotation, so the fallen shape would snap to default — which is
+  // exactly what it did, a few seconds into every fall.
+  {
+    const q = (x: number) => new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), x);
+    const bone = { quaternion: q(1.1) };                 // where the tumble left it
+    const joint = { bone, _initialLocalRotation: q(0) }; // combed
+    const self: any = {
+      __simHair: true, _limp: true,
+      vrm: {
+        scene: { updateMatrixWorld() {} },
+        springBoneManager: {
+          joints: new Set([joint]),
+          reset() { bone.quaternion.copy(joint._initialLocalRotation); },
+        },
+      },
+    };
+    self._releaseHair = (Avatar.prototype as any)._releaseHair;
+    self._releaseHair();
+    check('releasing the hair KEEPS the pose the fall left',
+      bone.quaternion.angleTo(q(1.1)) < 1e-6,
+      `moved ${(bone.quaternion.angleTo(q(1.1)) * 180 / Math.PI).toFixed(1)}°`);
+    check('...and puts the combed rest back, so it still combs out afterwards',
+      joint._initialLocalRotation.angleTo(q(0)) < 1e-6);
+    check('...and ownership is released', self.__simHair === false);
+  }
+
+  // a REMOTE body goes limp with no doll of its own — suppressing there would
+  // freeze its hair completely, which is worse than the bug
+  const c = mk();
+  c.self._limp = true;            // limp, but nothing claimed the hair
+  c.calls.length = 0;
+  c.self.tick();
+  check('a limp REMOTE (no local sim) keeps its springbone hair',
+    c.calls.includes('spring'));
+}
+
+{
+  // A rig with no wings must not cost anything or throw.
+  const root = new THREE.Object3D();
+  const self: any = { _limp: false, root, vrm: { scene: root, humanoid: {} } };
+  self._findWings = (Avatar.prototype as any)._findWings;
+  self._findWings();
+  check('a wingless rig finds nothing and says so', self._wings === null);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/core-stub.mjs
+++ b/tools/core-stub.mjs
@@ -24,3 +24,8 @@ export const angleDelta = (a, b) => {
   return d;
 };
 export const CONFIG = {};
+// warmqueue.js reaches for the shader-node namespace and the sun. Neither means
+// anything headless, but a MISSING export is a SyntaxError at import time, which
+// takes the whole suite down before a single test runs (see loadwork-stub).
+export const sun = { position: new THREE.Vector3(0, 1, 0) };
+export const TSL = new Proxy({}, { get: () => () => {} });

--- a/tools/import-tripo-avatar.ts
+++ b/tools/import-tripo-avatar.ts
@@ -298,6 +298,50 @@ say(`vrmified: ${Object.keys(humanBones).length} humanoid bones`);
         colliderGroups: [0],
       });
     }
+    // WINGS GET SPRINGBONES TOO, for the one case the client cannot cover.
+    //
+    // A wing is DRIVEN while the body is alive (the flap) and simulated in
+    // Bullet while it is limp — but only on the client that owns the body.
+    // Everyone else sees a REMOTE: no local doll, and the flap is gated on not
+    // being limp, so a fallen body's wings froze mid-stroke for every observer.
+    // Hair never had that problem because three-vrm was always catching it,
+    // which is exactly the fallback wings were missing.
+    //
+    // Stiffer and heavier-falling than hair: a wing is a limb, not a filament,
+    // so the root barely gives and the tip trails. Same hips center, so
+    // walking does not excite them. While a local sim owns the body these are
+    // suppressed wholesale (avatar.js), so this costs nothing where Bullet runs.
+    const wingChains = new Map<string, { idx: number; node: number }[]>();
+    for (const [name, ni] of idx.entries()) {
+      const m = /^([LR]_Wing_(?:Upper|Lower))(?:_(\d+))?$/.exec(String(name));
+      if (!m) continue;
+      const c = wingChains.get(m[1]) ?? [];
+      c.push({ idx: m[2] ? Number(m[2]) : 0, node: ni as number });
+      wingChains.set(m[1], c);
+    }
+    let wingSprings = 0;
+    if (!args.includes('--no-wing-springs')) {
+      for (const [cname, joints] of wingChains) {
+        joints.sort((a, b) => a.idx - b.idx);
+        if (joints.length < 2) continue;
+        springs.push({
+          name: `wing_${cname}`,
+          center: need('Hip'),
+          joints: joints.map((j, i) => {
+            const t = i / Math.max(1, joints.length - 1);
+            return {
+              node: j.node,
+              hitRadius: 0.02,
+              stiffness: 1.6 - 0.9 * t,     // shoulder holds, tip trails
+              gravityPower: 0.05 + 0.15 * t, // a limp wing hangs
+              gravityDir: [0, -1, 0],
+              dragForce: 0.75 - 0.25 * t,
+            };
+          }),
+        });
+        wingSprings++;
+      }
+    }
     g.extensionsUsed = [...new Set([...(g.extensionsUsed ?? []), 'VRMC_springBone'])];
     g.extensions.VRMC_springBone = {
       specVersion: '1.0',
@@ -307,7 +351,8 @@ say(`vrmified: ${Object.keys(humanBones).length} humanoid bones`);
       colliderGroups: [{ name: 'head', colliders: [0] }],
       springs,
     };
-    say(`springbones: ${springs.length} hair chains declared (+head collider)`);
+    say(`springbones: ${springs.length - wingSprings} hair chains`
+      + `${wingSprings ? ` + ${wingSprings} wing chains` : ''} declared (+head collider)`);
   }
 }
 

--- a/tools/import-tripo-avatar.ts
+++ b/tools/import-tripo-avatar.ts
@@ -388,29 +388,54 @@ const S = HEIGHT / (span * 1.16);
 say(`scale ×${S.toFixed(3)} (head-foot span ${(headY - footY).toFixed(2)} → target ${HEIGHT}m)`);
 const bin = Buffer.from(rest0.subarray(8));
 for (const n of g.nodes) if (n.translation) n.translation = n.translation.map((x: number) => x * S);
+// An accessor's bufferView is OPTIONAL. Without one its values are all zeros,
+// which a `sparse` block may then override for named indices — and that is
+// exactly what a rig with SHAPE KEYS exports: every morph-target POSITION comes
+// through as a sparse accessor with no bufferView of its own, because most
+// vertices do not move. Indexing g.bufferViews[undefined] threw outright
+// ("undefined is not an object") the first time a blend with shape keys reached
+// this stage.
+//
+// Skipping them would stop the crash and quietly break the file instead: the
+// base mesh would scale by S and the morph DELTAS would not, so every shape key
+// would apply at the old scale on a body 1.8x bigger. Sparse values are the
+// real data for the vertices they name, so they take the same multiply. (Sparse
+// value blocks are tightly packed — the spec forbids byteStride on them.)
 const accBytes = (a: any) => {
+  if (a.bufferView == null) return null;
   const bv = g.bufferViews[a.bufferView];
   return { base: (bv.byteOffset ?? 0) + (a.byteOffset ?? 0), stride: bv.byteStride ?? 0 };
 };
+const scaleVec3s = (base: number, count: number, step: number) => {
+  for (let i = 0; i < count; i++) for (let c = 0; c < 3; c++) {
+    const off = base + i * step + c * 4;
+    bin.writeFloatLE(bin.readFloatLE(off) * S, off);
+  }
+};
+let sparseScaled = 0;
 const seen = new Set();
 for (const m of g.meshes ?? []) for (const p of m.primitives) {
   for (const ai of [p.attributes.POSITION, ...(p.targets ?? []).map((t: any) => t.POSITION)]) {
     if (ai == null || seen.has(ai)) continue;
     seen.add(ai);
     const a = g.accessors[ai];
-    const { base, stride } = accBytes(a);
-    const step = stride || 12;
-    for (let i = 0; i < a.count; i++) for (let c = 0; c < 3; c++) {
-      const off = base + i * step + c * 4;
-      bin.writeFloatLE(bin.readFloatLE(off) * S, off);
+    const loc = accBytes(a);
+    if (loc) scaleVec3s(loc.base, a.count, loc.stride || 12);
+    if (a.sparse?.values) {
+      const bv = g.bufferViews[a.sparse.values.bufferView];
+      scaleVec3s((bv.byteOffset ?? 0) + (a.sparse.values.byteOffset ?? 0), a.sparse.count, 12);
+      sparseScaled++;
     }
     if (a.min) a.min = a.min.map((x: number) => x * S);
     if (a.max) a.max = a.max.map((x: number) => x * S);
   }
 }
+if (sparseScaled) say(`scaled ${sparseScaled} sparse morph-target accessor(s)`);
 for (const sk of g.skins ?? []) {
   const a = g.accessors[sk.inverseBindMatrices];
-  const { base, stride } = accBytes(a);
+  const loc = accBytes(a);
+  if (!loc) continue;                 // a skin with no bind matrices to scale
+  const { base, stride } = loc;
   const step = stride || 64;
   for (let i = 0; i < a.count; i++) for (const e of [12, 13, 14]) {
     const off = base + i * step + e * 4;

--- a/tools/loadwork-stub.mjs
+++ b/tools/loadwork-stub.mjs
@@ -2,3 +2,10 @@
 export const beginWork = () => ({ done() {} });
 export const enqueue = (fn) => Promise.resolve(fn?.());
 export const idleYield = () => Promise.resolve();
+// A stub that is MISSING an export is not a stub, it is a broken suite: avatar.js
+// grew nextFrame/loadNote imports and this file did not, so avatar-test.ts has
+// been dying at import with a SyntaxError rather than running. Adding a name
+// here is the price of the module boundary; the alternative is a test that
+// silently stops covering the thing it was written for.
+export const nextFrame = () => Promise.resolve();
+export const loadNote = () => {};


### PR DESCRIPTION
Mythos has wings, and the hair finally moves.

## Wings

`[LR]_Wing_(Upper|Lower)[_<n>]` — four chains off the clavicles, as long as the
rig cares to make them (mythos went two bones to three mid-review; nothing
counts them).

**Alive they are driven.** A procedural flap in `avatar.js`, not a clip: a VRMA
can only address humanoid bones, and a clip cannot stop the instant a body goes
limp. The rotation is about the **body's forward axis**, never a bone's own —
Blender roll is arbitrary, and an axis chosen per bone flaps one rig and swipes
sideways on the next. A second rotation about UP, a quarter cycle out of phase,
opens the tip path from an arc into an ellipse; without it the tips stay in the
frontal plane and it reads as a hinge.

**Limp they belong to Bullet.** Chains hung from massless kinematic anchors on
the chest, masked to statics only, so a wing can rest on the ground and can
never touch its owner. Ownership is exclusive in both directions: the flap stops
writing while limp, the sim writes instead, and standing up slerps out of the
pose she fell in.

## The hair

`node.quaternion.copy(...)` was never enough. three-vrm sets
`bone.matrixAutoUpdate = false` on every spring-bone joint
(`three-vrm.module.js:5279`) and drives `matrix`/`matrixWorld` itself — so on
any rig whose hair is declared as springbones (every rig this pipeline builds) a
bare quaternion write is composed into `matrix` by nobody and reaches the
renderer **never**. The bones moved, the debug boxes moved, the mesh stood still.

One `updateMatrix()` is the whole fix. It is also why the **wings worked on the
first try and the hair never had**: wing bones are not spring joints, so the
renderer recomposes them for free.

Worth recording how long this hid. Every headless check agreed the writeback was
perfect at 0.01° — because they all read `.quaternion`, the exact quantity being
ignored. The instrument and the bug shared a blind spot. What broke it open was
a differential test from Janus: set the tension slider to 0, and the collider
boxes go floppy while the mesh does not move at all. The new test freezes hair
bones the way three-vrm does and reads the **world matrix**, the way a renderer
does; removing the fix fails it at 51°.

Downstream of that, all measured against a render that was finally showing the
simulation:

- `HAIR_TUNING` is Janus's, and lands within a hair of the source playground's
  own defaults — after this port spent a long time insisting it needed something
  different. It did not. It needed to be visible.
- Springbones are suppressed only while a local sim owns those bones. A limp
  **remote** keeps its own, because suppressing there would freeze its hair,
  which is worse than the bug.
- A settled corpse keeps the hair the fall gave it. `dispose()` used to call
  `springBoneManager.reset()`, which restores each joint's
  `_initialLocalRotation` — a snap to combed, fired the moment a body settled.
  Release now happens on getting **up**, and keeps the fallen pose while
  re-deriving the tail state, so the springs comb it out over the next second
  instead of teleporting.

## Collider boxes come from the mesh

Wing and hair boxes are sized from the geometry each bone owns, not from bone
length. Mythos's upper chain has a 16 cm bone under 44 cm of membrane and a leaf
tip with nothing to measure, so both distal boxes came out a third of the wing
they stood for — and gravity's torque goes as the lever arm, which is most of
why they would not drape. Marginal for hair (48 mm vs 36 mm), decisive for wings.

## Also

- **Test stubs that had drifted.** `avatar-test.ts` had been dying at import with
  a SyntaxError rather than running. A stub missing a name takes the whole file
  down before the first assertion, so the suite reported nothing while looking
  like it simply had not been run.
- **`import-tripo-avatar`: a shape key is a sparse accessor.** Morph-target
  POSITIONs arrive with no `bufferView`, which threw outright. Skipping them
  stops the crash and quietly breaks the file instead — the base mesh scales and
  the morph deltas do not.

## Tests

`bun tools/avatar-test.ts` 44/44 · `bun tools/ammodoll-test.ts` 62/64.

The two failures are pre-existing and unrelated (knee hyperextension and the
Verlet fold bound); they are byte-identical with this branch's changes stashed,
and both are documented open threads in `rigtest/EIDOVERSE-DEPLOY.md`.

Every new test was checked by reintroducing the bug it guards: the depth parse,
the extent-cache collision, the `matrixAutoUpdate` write, and the sweep axis all
fail when their fix is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
