### PR TITLE
glb2vrm: refuse foreign rigs by family, not by first missing bone (#123)

### DIFF
--- a/tools/glb2vrm-test.ts
+++ b/tools/glb2vrm-test.ts
@@ -1,0 +1,114 @@
+// glb2vrm rig-family gate (#123), run headless.
+//
+//   bun tools/glb2vrm-test.ts
+//
+// The gate exists because a Mixamo rig fed to the converter used to die on
+// its first missing Tripo bone ("node not found: Hip"), naming a bone the
+// user never chose instead of the actual contract. These tests synthesize
+// minimal GLBs (a JSON chunk is a valid GLB; no geometry needed to test
+// name-based family detection) and drive the real CLI, asserting on the
+// message and exit code. Real-rig provenance: the gate was verified by hand
+// against three.js's Xbot.glb, a genuine Mixamo export with the colon kept.
+
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+function makeGLB(nodeNames: string[]): Uint8Array {
+  const json = { asset: { version: "2.0" }, nodes: nodeNames.map((name) => ({ name })), scenes: [{ nodes: [] }] };
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const pad = (4 - (jsonBytes.length % 4)) % 4;
+  const total = 12 + 8 + jsonBytes.length + pad;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true);
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonBytes.length + pad, true);
+  dv.setUint32(16, 0x4e4f534a, true);
+  out.set(jsonBytes, 20);
+  out.fill(0x20, 20 + jsonBytes.length);
+  return out;
+}
+
+const TRIPO_BONES = [
+  "Hip", "Spine01", "Spine02", "NeckTwist01", "Head",
+  "L_Clavicle", "L_Upperarm", "L_Forearm", "L_Hand",
+  "R_Clavicle", "R_Upperarm", "R_Forearm", "R_Hand",
+  "L_Thigh", "L_Calf", "L_Foot", "L_ToeBase",
+  "R_Thigh", "R_Calf", "R_Foot", "R_ToeBase",
+];
+
+const MIXAMO_BONES = [
+  "mixamorig:Hips", "mixamorig:Spine", "mixamorig:Spine1", "mixamorig:Spine2",
+  "mixamorig:Neck", "mixamorig:Head",
+  "mixamorig:LeftUpLeg", "mixamorig:LeftLeg", "mixamorig:LeftFoot", "mixamorig:LeftToeBase",
+];
+
+const dir = mkdtempSync(join(tmpdir(), "glb2vrm-test-"));
+const write = (name: string, bones: string[]) => {
+  const p = join(dir, name);
+  writeFileSync(p, makeGLB(bones));
+  return p;
+};
+
+async function run(file: string, ...args: string[]) {
+  const proc = Bun.spawn(["bun", join(import.meta.dir, "glb2vrm.ts"), file, ...args], {
+    stdout: "pipe", stderr: "pipe",
+  });
+  const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+  return { code: await proc.exited, out, err };
+}
+
+console.log("mixamo family is refused by name, both paths");
+{
+  const glb = write("mixamo.glb", MIXAMO_BONES);
+  const convert = await run(glb, "--name", "t");
+  check("convert exits 1", convert.code === 1);
+  check("convert names the family", /Mixamo rig detected/.test(convert.err), convert.err.trim());
+  check("convert says what to do", /Rerig using Tripo humanoid/.test(convert.err));
+  check("convert never says 'node not found'", !/node not found/.test(convert.err), convert.err.trim());
+  const measure = await run(glb, "--measure");
+  check("--measure exits 1", measure.code === 1);
+  check("--measure names the family", /Mixamo rig detected/.test(measure.err), measure.err.trim());
+}
+
+console.log("prefix variants still identify as mixamo");
+{
+  for (const variant of ["mixamorigHips", "mixamorig1:Hips", "MixamoRig:Hips"]) {
+    const glb = write(`v-${variant.replace(/[^a-z0-9]/gi, "")}.glb`, [variant, "Spine", "Head"]);
+    const r = await run(glb, "--name", "t");
+    check(`${variant} detected`, r.code === 1 && /Mixamo rig detected/.test(r.err), r.err.trim());
+  }
+}
+
+console.log("an unknown rig gets the contract, not one bone");
+{
+  const glb = write("unknown.glb", ["Root", "Bone01", "Bone02"]);
+  const r = await run(glb, "--name", "t");
+  check("exits 1", r.code === 1);
+  check("asks 'not a Tripo rig?'", /not a Tripo rig\?/.test(r.err), r.err.trim());
+  check("lists Hip among the missing", /missing bones .*Hip/.test(r.err));
+  check("never says 'node not found'", !/node not found/.test(r.err), r.err.trim());
+}
+
+console.log("a tripo-named rig passes the gate");
+{
+  // Bones alone are not a convertible body (no skin, no mesh), so conversion
+  // still fails downstream. The assertion is that it gets PAST the gate:
+  // whatever it dies of is not a family rejection.
+  const glb = write("tripo.glb", ["Armature", ...TRIPO_BONES]);
+  const r = await run(glb, "--name", "t");
+  check("not refused as mixamo", !/Mixamo rig detected/.test(r.err), r.err.trim());
+  check("not refused as unknown", !/not a Tripo rig\?/.test(r.err), r.err.trim());
+}
+
+rmSync(dir, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/glb2vrm.ts
+++ b/tools/glb2vrm.ts
@@ -256,6 +256,34 @@ const has = (n: string) => argv.includes(`--${n}`);
 
 const { json: g, bin } = parseGLB(await Bun.file(input).arrayBuffer());
 
+// Rig-family gate (#123). The converter bakes Tripo assumptions well beyond
+// bone names (A-pose surgery, Armature as the bake target, NeckTwist02 for
+// head pitch), so a foreign rig must be refused by FAMILY, up front, not die
+// on its first missing bone name. A VRM 1.0 input carries its own humanoid
+// map and skips the gate. Mixamo is identifiable before any conversion:
+// every joint carries the mixamorig prefix (exporters sometimes strip the
+// colon or add a numeric suffix, so match the prefix alone).
+if (!g.extensions?.VRMC_vrm) {
+  const nodeNames = ((g.nodes ?? []) as any[]).map((n) => n?.name ?? "");
+  if (nodeNames.some((n) => /^mixamorig/i.test(n))) {
+    console.error(
+      `${basename(input)}: Mixamo rig detected (mixamorig-prefixed joints). ` +
+        `Mixamo rigs are not currently supported: this converter assumes Tripo ` +
+        `bone names, A-pose rest, and Tripo skeleton structure throughout. ` +
+        `Rerig using Tripo humanoid.`,
+    );
+    process.exit(1);
+  }
+  const missing = Object.values(TRIPO_MAP).filter((b) => !nodeNames.includes(b));
+  if (missing.length) {
+    console.error(
+      `${basename(input)}: missing bones ${missing.join(", ")}: not a Tripo rig? ` +
+        `This converter accepts Tripo humanoid naming (Hip/Spine01/L_Upperarm/...).`,
+    );
+    process.exit(1);
+  }
+}
+
 if (has("measure")) {
   // Report conventions of any glb/vrm — used to sanity-check against library avatars.
   const v1 = g.extensions?.VRMC_vrm;
@@ -275,8 +303,6 @@ if (has("measure")) {
 const name = flag("name") ?? basename(input).replace(/\.(glb|vrm)$/, "");
 const targetHeight = Number(flag("height") ?? 1.65);
 const out = flag("out") ?? join(import.meta.dir, "..", "assets", "opt", "eidoverse", "assets", "vrms", `${name}.vrm`);
-
-for (const vrmBone of Object.values(TRIPO_MAP)) nodeByName(g, vrmBone); // fail fast on unknown rigs
 
 // Facing quadrant, measured ONCE before any pose surgery and reused by both
 // the T-pose step (its side axes are facing-relative!) and the final yaw bake.


### PR DESCRIPTION
The immediate fix both mica and antra scoped on #123: capability-gating plus a truthful error. Real Mixamo support and the semantic humanoid map from antra's comment stay open; nothing here renames or rerigs anything, per mica's constraint.

## What changed

- A rig-family gate runs right after the GLB parses, ahead of both the convert and `--measure` paths. Any `mixamorig`-prefixed joint (colon kept, stripped, or numerically suffixed) gets a refusal that names the actual contract: Mixamo rigs are not supported; this converter assumes Tripo bone names, A-pose rest, and Tripo skeleton structure. Detection happens before any conversion is attempted, which is where the issue said the rejection belongs.
- A rig that is neither Mixamo nor Tripo now reports every missing Tripo bone and asks "not a Tripo rig?" (the phrasing import-tripo-avatar already uses), instead of dying on the first failed lookup.
- VRM 1.0 inputs skip the gate; they carry their own humanoid map.

## Repro provenance

Verified against three.js's Xbot.glb, a genuine Mixamo export with the `mixamorig:` prefix intact. Before this change, convert dies with `node not found: Hip` and `--measure` dies with `node not found: L_ToeBase` (same class of misleading error, different bone; the `--measure` path is not mentioned in the issue text). After, both paths exit 1 with the honest message. Two notes for the issue thread: line references there have drifted (the fail-fast loop sat at glb2vrm.ts:279 on current main), and Xbot.glb is a freely available reproducible rig for the alias table when option 1 happens.

## Tests

`bun tools/glb2vrm-test.ts` drives the real CLI against synthetic GLBs (a JSON chunk alone is a valid GLB, which is enough for name-based family detection): 15 checks covering both paths, three prefix variants (`mixamorig:Hips`, `mixamorigHips`, `mixamorig1:Hips`), the unknown-rig contract message, and that a Tripo-named rig passes the gate. All pass. One gap named honestly: we had no raw Tripo GLB on hand to run a full conversion end to end, so the gate-pass case asserts only that a Tripo-named rig is not refused as a foreign family.

Co-authored with Spark, a Claude (Fable) instance working alongside me.
