### PR TITLE
store: uploads get the KTX2 shadow too — and a flagged fall-through is provisional, never immutable

### DIFF
--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -8,6 +8,7 @@
 //   vrmPool    whole parsed VRM instances at rest (§19b — no clone exists
 //              for a bound rig, so released bodies are reworn intact)
 
+import { withKtx2 } from '../../shared/ktx2.js';
 import { THREE, renderer, camera, scene, report, bus } from './core.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -148,7 +149,7 @@ const draco = new DRACOLoader().setDecoderPath('https://www.gstatic.com/draco/ve
 const ktx2 = new KTX2Loader()
   .setTranscoderPath('/node_modules/three/examples/jsm/libs/basis/')
   .detectSupport(renderer);
-/** Whether this GPU/browser negotiates KTX2 variants (?ktx2=1) — prefetch
+/** Whether this GPU/browser negotiates KTX2 variants (?ktx2=<key>, shared/ktx2.js) — prefetch
  *  must warm the SAME cache key demand fetches will use. */
 export const ktx2Capable = () => !!ktx2.workerConfig;
 function makeLoader(vrm = false) {
@@ -283,9 +284,8 @@ export async function loadVRM(libPath, { priority = 1 } = {}) {
     // byteCache (variant and original are distinct byte entries — correct),
     // while the vrmPool and its vrmMeta ledger key on libPath UNTOUCHED, so
     // pool identity is unaffected by negotiation.
-    const flag = libPath.split('?')[0].endsWith('.vrm') && ktx2.workerConfig
-      ? (libPath.includes('?') ? '&ktx2=1' : '?ktx2=1') : '';
-    const buf = await fetchBytes(`/library/${libPath}${flag}`);
+    const url = libPath.split('?')[0].endsWith('.vrm') && ktx2.workerConfig ? withKtx2(libPath) : libPath;
+    const buf = await fetchBytes(`/library/${url}`);
     work.phase('queued');
     // The parse and skeleton passes are the irreducibly-synchronous chunk of a
     // body: serialize so two arrivals can't stack theirs into the same frames,
@@ -477,8 +477,8 @@ export async function loadGLB(libPath) {
         // paths — the server answers with the variant when one exists, the
         // original otherwise. The full URL keys byteCache, so variant and
         // original are distinct entries, which is correct.
-        const flag = libPath.endsWith('.glb') && ktx2.workerConfig ? '?ktx2=1' : '';
-        const buf = await fetchBytes(`/library/${libPath}${flag}`);
+        const url = libPath.endsWith('.glb') && ktx2.workerConfig ? withKtx2(libPath) : libPath;
+        const buf = await fetchBytes(`/library/${url}`);
         work.phase('queued');
         return await enqueue(async () => {
           work.phase('parse');
@@ -775,9 +775,8 @@ export async function primeFiles(paths, { concurrency = 6 } = {}) {
         // cache (§16.2.B), and every toolkit module see the same identities —
         // the bytes just arrive GPU-native, and loadImageTexture sniffs the
         // container magic to tell which shape it got.
-        const flag = ktx2Capable() && /\.(png|jpe?g)$/i.test(p)
-          ? (p.includes('?') ? '&ktx2=1' : '?ktx2=1') : '';
-        const buf = await fetchBytes(`/library/${p}${flag}`);
+        const url = ktx2Capable() && /\.(png|jpe?g)$/i.test(p) ? withKtx2(p) : p;
+        const buf = await fetchBytes(`/library/${url}`);
         denoFiles.set(p, new Uint8Array(buf));
       } catch (e) { missing.push(p); }
     }

--- a/client/lib/prefetch.js
+++ b/client/lib/prefetch.js
@@ -21,6 +21,7 @@
 //      policy — assets that get USED are the ones that stay warm, and a newly
 //      needed asset displaces stale speculative ones by construction.
 
+import { withKtx2 } from '../../shared/ktx2.js';
 import { bus, CONFIG, report } from './core.js';
 import { whenBooted } from './boot.js';
 import { whenCalm } from './governor.js';
@@ -105,7 +106,7 @@ async function buildQueue() {
     const bare = url.split('?')[0];
     if (ktx2Capable() && (/\.(glb|vrm)$/.test(bare)
       || (/^\/library\/eidoverse\/assets\/(grass|sky|particle_textures)\//.test(bare) && /\.(png|jpe?g)$/i.test(bare)))) {
-      url += (url.includes('?') ? '&' : '?') + 'ktx2=1';
+      url = withKtx2(url);
     }
     if (!seen.has(url) && seen.add(url)) q.push({ url, size });
   };

--- a/docs/ktx2-encoder.md
+++ b/docs/ktx2-encoder.md
@@ -72,6 +72,13 @@ lands.
 
 ## Either platform
 
+The negotiation key a client sends (`?ktx2=<key>`) is a generation, defined
+once in `shared/ktx2.js` and imported by both the client and the sequencer.
+Bump it when a flagged answer has been served with the wrong caching — the
+old key's cache entries are simply never asked for again (a purge cannot
+reach browsers). The fall-through answer under the current key is served
+`no-cache` until a variant exists, then the variant is served immutable.
+
 `KTX2_TOKTX` may point at either `toktx` or the newer `ktx` binary — the
 probe (`findKtx2Encoder`) detects which by name. Without the env it also
 checks PATH for both. The sweep runs once per boot, serial, ~5-30s per

--- a/docs/ktx2-encoder.md
+++ b/docs/ktx2-encoder.md
@@ -46,6 +46,30 @@ curl -LO https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.2/K
 # binaries at ktx/bin/toktx.exe — point KTX2_TOKTX at it
 ```
 
+## Linux (the show VPS is Ubuntu) — the .deb, or portable
+
+The release ships `Linux-x86_64` as `.deb`, `.rpm` and `.tar.bz2`. The .deb
+puts `toktx` and `ktx` on PATH, which is all the probe needs:
+
+```sh
+curl -LO https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.2/KTX-Software-4.4.2-Linux-x86_64.deb
+sudo apt install ./KTX-Software-4.4.2-Linux-x86_64.deb
+toktx --version                    # toktx v4.4.2
+```
+
+Portable, no root: `tar xjf KTX-Software-4.4.2-Linux-x86_64.tar.bz2` and
+point `KTX2_TOKTX` at `<extracted>/bin/toktx` (the `bin/` + `lib/` sibling
+layout is load-bearing here too — the tools find `libktx` by rpath).
+
+Under systemd the sequencer's PATH is not your shell's (the same reason
+upload.ts spawns `process.execPath` and not `bun`): put
+`Environment=KTX2_TOKTX=/usr/bin/toktx` in the unit, or the boot sweep logs
+`no encoder` and every `?ktx2=1` answer stays webp. That is the show box's
+state as of 2026-08-24 — verified from outside: every library and store
+model fetched with `?ktx2=1` came back `EXT_texture_webp`, none
+`KHR_texture_basisu`. The §20 arc is built and dormant there until this
+lands.
+
 ## Either platform
 
 `KTX2_TOKTX` may point at either `toktx` or the newer `ktx` binary — the

--- a/server/config.ts
+++ b/server/config.ts
@@ -33,7 +33,7 @@ export const PATCH_DIR = join(ROOT, "upstream-patched");
 // Optimized shadows of store uploads (draco+webp@1024, see server/optimize.ts).
 // Originals in store/ are never touched; /library serving prefers a store-min
 // sibling when one exists. `.failed` markers stop hopeless files from being
-// retried every boot. The KTX2 shadow (the ?ktx2=1 answer) lives beside the
+// retried every boot. The KTX2 shadow (the ?ktx2=<key> answer, shared/ktx2.js) lives beside the
 // original instead — store/<hash>.glb.ktx2.glb, the library's <rel>.ktx2.glb
 // convention (server/store-variants.ts).
 export const STORE_MIN = join(OPT_DIR, "store-min");

--- a/server/config.ts
+++ b/server/config.ts
@@ -33,7 +33,9 @@ export const PATCH_DIR = join(ROOT, "upstream-patched");
 // Optimized shadows of store uploads (draco+webp@1024, see server/optimize.ts).
 // Originals in store/ are never touched; /library serving prefers a store-min
 // sibling when one exists. `.failed` markers stop hopeless files from being
-// retried every boot.
+// retried every boot. The KTX2 shadow (the ?ktx2=1 answer) lives beside the
+// original instead — store/<hash>.glb.ktx2.glb, the library's <rel>.ktx2.glb
+// convention (server/store-variants.ts).
 export const STORE_MIN = join(OPT_DIR, "store-min");
 
 mkdirSync(WORLDS_DIR, { recursive: true });

--- a/server/optimize.ts
+++ b/server/optimize.ts
@@ -211,9 +211,15 @@ function ktx2EncodeArgs(encoder: string, isToktx: boolean, srgb: boolean, uastc:
 
 /** Per-texture KTX2 encode, in place on the Document. Supports both
  *  KTX-Software CLIs — toktx (v4.4.2, the primary target) and the newer
- *  unified `ktx create` — detected by basename. Content problems skip the
- *  TEXTURE, never the file. Returns how many textures were converted. */
-async function ktx2CompressTextures(doc: Document, encoder: string): Promise<number> {
+ *  unified `ktx create` — detected by basename. A texture that will not
+ *  convert is skipped and NAMED in the tally; the caller decides whether a
+ *  partial result is a file at all (the GLB arm refuses one — a .ktx2.glb
+ *  with png inside is #122's class of lie, served immutable). Every encoder
+ *  output is checked for the KTX2 container magic before it is accepted. */
+export type Ktx2Tally = { eligible: number; converted: number; failed: string[] };
+const KTX2_MAGIC = [0xab, 0x4b, 0x54, 0x58, 0x20, 0x32, 0x30, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a];
+export const isKtx2Container = (b: Uint8Array) => b.length >= 12 && KTX2_MAGIC.every((v, i) => b[i] === v);
+async function ktx2CompressTextures(doc: Document, encoder: string): Promise<Ktx2Tally> {
   const isToktx = basename(encoder).toLowerCase().includes("toktx");
   // sharp converts non-PNG sources (webp/jpeg) and 4-aligns dimensions —
   // KHR_texture_basisu (and WebGPU BC upload) wants width/height % 4 == 0.
@@ -221,13 +227,15 @@ async function ktx2CompressTextures(doc: Document, encoder: string): Promise<num
   let sharp: any = null;
   try { sharp = (await getSharp()).sharp; } catch { /* PNG-only pass below */ }
   const tmp = mkdtempSync(join(tmpdir(), "ew-ktx2-"));
-  let converted = 0;
+  let converted = 0, eligible = 0;
+  const failed: string[] = [];
   try {
     const textures = doc.getRoot().listTextures();
     for (let i = 0; i < textures.length; i++) {
       const tex = textures[i];
       const image = tex.getImage();
       if (!image) continue;
+      eligible++;
       const label = tex.getName() || tex.getURI() || `#${i}`;
       const slots = listTextureSlots(tex);
       const srgb = slots.some((s) => COLOR_SLOT.test(s));
@@ -258,11 +266,11 @@ async function ktx2CompressTextures(doc: Document, encoder: string): Promise<num
           await Bun.write(inPath, await s.png().toBuffer());
         } catch (e) {
           console.error(`[optimize] ktx2: skip ${label} — sharp convert failed (${(e as Error).message})`);
-          continue;
+          failed.push(label); continue;
         }
       } else {
         console.error(`[optimize] ktx2: skip ${label} (${mime}${aligned ? "" : ", not 4-aligned"}) — sharp unavailable`);
-        continue;
+        failed.push(label); continue;
       }
       const outPath = join(tmp, `${i}.ktx2`);
       const args = ktx2EncodeArgs(encoder, isToktx, srgb, uastc, inPath, outPath);
@@ -271,9 +279,16 @@ async function ktx2CompressTextures(doc: Document, encoder: string): Promise<num
       const err = (await new Response(proc.stderr).text()).trim();
       if (code !== 0 || !existsSync(outPath)) {
         console.error(`[optimize] ktx2: encode failed on ${label} (${err.split("\n")[0] || `exit ${code}`}) — texture kept as-is`);
-        continue;
+        failed.push(label); continue;
       }
-      tex.setImage(new Uint8Array(await Bun.file(outPath).arrayBuffer())).setMimeType("image/ktx2");
+      const encoded = new Uint8Array(await Bun.file(outPath).arrayBuffer());
+      // an image must be what it says it is (#122/#124): the encoder exited 0,
+      // now the bytes have to carry the container they will be labelled with
+      if (!isKtx2Container(encoded)) {
+        console.error(`[optimize] ktx2: ${label} — encoder wrote ${encoded.length} bytes that are not a KTX2 container — texture kept as-is`);
+        failed.push(label); continue;
+      }
+      tex.setImage(encoded).setMimeType("image/ktx2");
       const uri = tex.getURI();
       if (uri) tex.setURI(uri.replace(/\.[a-zA-Z0-9]+$/, "") + ".ktx2");
       converted++;
@@ -284,18 +299,24 @@ async function ktx2CompressTextures(doc: Document, encoder: string): Promise<num
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
-  return converted;
+  return { eligible, converted, failed };
 }
 
 /** The --ktx2 diet: dedup + prune + resample (the store recipe minus webp —
- *  KTX2 encodes from the best source) + per-texture KTX2 + draco. */
-export async function optimizeGlbKtx2(bytes: Uint8Array, encoder: string): Promise<Uint8Array> {
+ *  KTX2 encodes from the best source) + per-texture KTX2 + draco. ALL or
+ *  nothing: `out` is null unless every eligible texture converted. A variant
+ *  with some — or no — KTX2 in it is a .ktx2.glb whose name lies about its
+ *  contents, and it would be served immutable to every capable client (the
+ *  #122 class). The tally says which it was: nothing eligible is exit 2's
+ *  business, anything unconverted is exit 5's (see the CLI). */
+export async function optimizeGlbKtx2(bytes: Uint8Array, encoder: string): Promise<{ out: Uint8Array | null } & Ktx2Tally> {
   const io = await getIO();
   const doc = await io.readBinary(bytes);
   await doc.transform(dedup(), prune(), resample());
-  await ktx2CompressTextures(doc, encoder);
+  const tally = await ktx2CompressTextures(doc, encoder);
+  if (tally.eligible === 0 || tally.converted < tally.eligible) return { out: null, ...tally };
   await doc.transform(draco());
-  return io.writeBinary(doc);
+  return { out: await io.writeBinary(doc), ...tally };
 }
 
 // ---- KTX2 for VRMs (§20c): the surgical container rewrite -------------------
@@ -770,6 +791,10 @@ export async function transcodeImageKtx2(src: Uint8Array, srcPath: string, encod
 // failure, reason on stderr.
 // Exit 3 (any --ktx2* mode) = no KTX2 encoder on this box — environmental,
 // the caller must env-skip (never a .failed marker).
+// Exit 5 (--ktx2) = an encoder answered but not every eligible texture
+// converted — the variant is REFUSED, nothing written. Environmental too (a
+// flaky or misconfigured encoder, not a bad model): no marker, retried next
+// boot; and not exit 3's ktx2Skip either — the encoder is there.
 
 if (import.meta.main) {
   const argv = process.argv.slice(2);
@@ -807,8 +832,20 @@ if (import.meta.main) {
       }
       console.log(`[optimize] ktx2-vrm: ${r.converted} image(s) → ${r.etc1s} etc1s + ${r.uastc} uastc`);
       out = r.out;
+    } else if (mode === "--ktx2") {
+      const r = await optimizeGlbKtx2(src, encoder!);
+      if (r.eligible === 0) {
+        console.error(`[optimize] ktx2: no convertible raster images (${Math.round(performance.now() - t0)}ms) — keeping original`);
+        process.exit(2);
+      }
+      if (!r.out) {
+        console.error(`[optimize] ktx2: ${r.converted}/${r.eligible} texture(s) converted — REFUSING a partial variant (${r.failed.join(", ")}); retry when the encoder is sane`);
+        process.exit(5);
+      }
+      console.log(`[optimize] ktx2: ${r.converted}/${r.eligible} texture(s) → KTX2`);
+      out = r.out;
     } else {
-      out = mode === "--ktx2" ? await optimizeGlbKtx2(src, encoder!) : await optimizeGlb(src);
+      out = await optimizeGlb(src);
     }
     const ms = Math.round(performance.now() - t0);
     // An already-lean upload (someone re-uploading our own optimized output,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,7 +13,8 @@ import { existsSync, readFileSync, writeFileSync, renameSync, readdirSync, mkdir
 import { join, normalize } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ROOT, WORLDS_DIR, LIBRARY_DIR, OPT_DIR, PATCH_DIR, JOIN_TOKEN } from "./config.ts";
-import { isStoreOriginal, isKtx2Variant } from "./store-variants.ts";
+import { isStoreOriginal, isServingArtifact } from "./store-variants.ts";
+import { wantsKtx2 } from "../shared/ktx2.js";
 import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_ISSUER_KEY, HN_ISS, HN_AUD, HN_LOGIN_URL, HN_REQUIRE_LOGIN } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
@@ -535,11 +536,12 @@ const ROUTES: Route[] = [
         for (const e of readdirSync(abs, { withFileTypes: true })) {
           const childRel = sub ? `${sub}/${e.name}` : e.name;
           if (e.isDirectory()) walk(base, childRel, depth + 1);
-          // KTX2 variants (<rel>.ktx2.glb / .ktx2.vrm / <img>.ktx2) are serving
-          // artifacts of the path beside them, reached only as that path +
-          // ?ktx2=1 — never an entry of their own. Listed, the prefetcher warms
-          // each one a second time under its own name (store-variants.ts).
-          else if (!isKtx2Variant(e.name)) out.push({ path: childRel, size: Bun.file(join(abs, e.name)).size });
+          // Serving artifacts are not entries: a KTX2 variant (<rel>.ktx2.glb /
+          // .ktx2.vrm / <img>.ktx2) is reached only as the path beside it +
+          // the negotiation, a .failed marker is the pump's verdict, a .tmp is
+          // a pass mid-write. Listed, the prefetcher fetches each one as an
+          // asset — a variant twice, a marker as a model (store-variants.ts).
+          else if (!isServingArtifact(e.name)) out.push({ path: childRel, size: Bun.file(join(abs, e.name)).size });
         }
       };
       // opt first: /library/ serving prefers the optimized mirror, so the
@@ -641,7 +643,7 @@ const ROUTES: Route[] = [
       // KHR_texture_basisu sits in extensionsRequired, and parsers without a
       // KTX2 decoder — agents, tools, old clients — THROW on required
       // extensions (GLTFLoader.js:1476). Only a client that detected support
-      // asks with ?ktx2=1; everyone else gets exactly today's bytes. Same
+      // asks with ?ktx2=<key>; everyone else gets exactly today's bytes. Same
       // cache ladder as the base file (non-immutable, ETag revalidates), and
       // the distinct URL is its own clean nginx/browser cache entry.
       // VRMs (§20c) negotiate identically — avatar URLs carry ?v= minted from
@@ -657,7 +659,9 @@ const ROUTES: Route[] = [
       // loadImageTexture sniffs the container magic, so the SAME path carries
       // either byte shape.
       const negotiable = rel.endsWith(".glb") || rel.endsWith(".vrm") || /\.(png|jpe?g)$/i.test(rel);
-      const wantKtx2 = url.searchParams.get("ktx2") === "1" && negotiable;
+      // The key is a generation (shared/ktx2.js): a retired one is an
+      // unflagged fetch — whatever that client pinned under it, it keeps.
+      const wantKtx2 = wantsKtx2(url.searchParams) && negotiable;
       if (wantKtx2) {
         const kRel = rel.endsWith(".glb") ? `${rel}.ktx2.glb`
           : rel.endsWith(".vrm") ? `${rel}.ktx2.vrm` : `${rel}.ktx2`;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, readdirSync, mkdir
 import { join, normalize } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ROOT, WORLDS_DIR, LIBRARY_DIR, OPT_DIR, PATCH_DIR, JOIN_TOKEN } from "./config.ts";
+import { isStoreOriginal, isKtx2Variant } from "./store-variants.ts";
 import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_ISSUER_KEY, HN_ISS, HN_AUD, HN_LOGIN_URL, HN_REQUIRE_LOGIN } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
@@ -186,7 +187,11 @@ const gzCache = new Map<string, { mtime: number; gz: Uint8Array }>();
 const hardCacheable = (path: string) =>
   !/\.vrma?$/i.test(path) && !/\.(m?js|json)$/i.test(path);
 
-function serveFrom(base: string, rel: string, cache = false, req?: Request, immutable = false): Response {
+// `provisional`: this answer is not the final one for this URL (a flagged
+// fetch whose variant does not exist yet — see the /library route). It wins
+// over `immutable`: no-cache, riding the ETag, so the moment a different file
+// answers the same URL its bytes get through.
+function serveFrom(base: string, rel: string, cache = false, req?: Request, immutable = false, provisional = false): Response {
   const path = normalize(join(base, rel));
   if (!path.startsWith(base)) return new Response("forbidden", { status: 403 });
   // A missing file must be a 404, not a Bun.file stream blowing up into a 500 —
@@ -203,7 +208,8 @@ function serveFrom(base: string, rel: string, cache = false, req?: Request, immu
     headers["etag"] = etag;
     if (req?.headers.get("if-none-match") === etag) {
       // cache-control must ride along on the 304 (it refreshes the stored response's lifetime)
-      headers["cache-control"] = immutable ? "public, max-age=31536000, immutable"
+      headers["cache-control"] = provisional ? "no-cache"
+        : immutable ? "public, max-age=31536000, immutable"
         : cache && hardCacheable(path) ? "public, max-age=86400" : cache ? "no-cache" : "no-store";
       return new Response(null, { status: 304, headers });
     }
@@ -214,7 +220,8 @@ function serveFrom(base: string, rel: string, cache = false, req?: Request, immu
   // (2026-07-22: "sydney's arms are swapped" was three of us looking at three
   // different cached rigs). no-cache = revalidate each load, still cheap.
   const hard = cache && hardCacheable(path);
-  headers["cache-control"] = immutable ? "public, max-age=31536000, immutable"
+  headers["cache-control"] = provisional ? "no-cache"
+    : immutable ? "public, max-age=31536000, immutable"
     : hard ? "public, max-age=86400" : cache ? "no-cache" : "no-store";
   // gzip the JS modules: three.webgpu.js is 2.1MB raw / ~500KB gzipped, and
   // over a DERP-relayed tailnet link that difference is seconds.
@@ -528,7 +535,11 @@ const ROUTES: Route[] = [
         for (const e of readdirSync(abs, { withFileTypes: true })) {
           const childRel = sub ? `${sub}/${e.name}` : e.name;
           if (e.isDirectory()) walk(base, childRel, depth + 1);
-          else out.push({ path: childRel, size: Bun.file(join(abs, e.name)).size });
+          // KTX2 variants (<rel>.ktx2.glb / .ktx2.vrm / <img>.ktx2) are serving
+          // artifacts of the path beside them, reached only as that path +
+          // ?ktx2=1 — never an entry of their own. Listed, the prefetcher warms
+          // each one a second time under its own name (store-variants.ts).
+          else if (!isKtx2Variant(e.name)) out.push({ path: childRel, size: Bun.file(join(abs, e.name)).size });
         }
       };
       // opt first: /library/ serving prefers the optimized mirror, so the
@@ -588,7 +599,10 @@ const ROUTES: Route[] = [
         let man: Record<string, { name?: string; by?: string; ts?: number }> = {};
         try { man = JSON.parse(readFileSync(join(storeDir, "manifest.json"), "utf8")); } catch { /* unnamed */ }
         const store = readdirSync(storeDir)
-          .filter((f) => f.endsWith(".glb"))
+          // a KTX2 variant (<hash>.glb.ktx2.glb) is the same model, not a
+          // catalog entry — the ghost-listing rule the library list already
+          // follows above (store-variants.ts)
+          .filter(isStoreOriginal)
           .map((f) => {
             const hash = f.replace(/\.glb$/i, "");
             const m = man[hash];
@@ -642,8 +656,9 @@ const ROUTES: Route[] = [
       // flagged fetch; contentType serves it as image/ktx2. The client's
       // loadImageTexture sniffs the container magic, so the SAME path carries
       // either byte shape.
-      if (url.searchParams.get("ktx2") === "1"
-          && (rel.endsWith(".glb") || rel.endsWith(".vrm") || /\.(png|jpe?g)$/i.test(rel))) {
+      const negotiable = rel.endsWith(".glb") || rel.endsWith(".vrm") || /\.(png|jpe?g)$/i.test(rel);
+      const wantKtx2 = url.searchParams.get("ktx2") === "1" && negotiable;
+      if (wantKtx2) {
         const kRel = rel.endsWith(".glb") ? `${rel}.ktx2.glb`
           : rel.endsWith(".vrm") ? `${rel}.ktx2.vrm` : `${rel}.ktx2`;
         const k = normalize(join(OPT_DIR, kRel));
@@ -657,17 +672,28 @@ const ROUTES: Route[] = [
           if (fresh) return serveFrom(OPT_DIR, kRel, true, req, versioned);
         }
       }
+      // A flagged fetch that falls through is PROVISIONAL for that URL, not
+      // final: the variant may still be encoding (a store upload's, seconds to
+      // minutes after landing; the library's, the boot sweep) — or the box has
+      // no encoder yet. Content-addressed does not make the fall-through final
+      // either: the ADDRESS is immutable, the flagged ANSWER is not, and a
+      // browser or nginx that pins the webp bytes under ?ktx2=1 for a year
+      // never sees the variant land (the show box, 2026-08-24: every store
+      // ?ktx2=1 answer immutable, every one webp). no-cache rides the ETag —
+      // a 304 while nothing changed, the variant's bytes the moment it exists;
+      // nginx honors it (nginx-show.conf) and simply does not cache these.
+      const provisional = wantKtx2;
       // store uploads: prefer the store-min shadow — same address, the
       // original stays as provenance and as the fallback while (or if) the
       // optimize pass hasn't landed for this hash
       if (rel.startsWith("store/")) {
         const minRel = `store-min/${rel.slice("store/".length)}`;
         const min = normalize(join(OPT_DIR, minRel));
-        if (min.startsWith(OPT_DIR) && existsSync(min)) return serveFrom(OPT_DIR, minRel, true, req, true);
+        if (min.startsWith(OPT_DIR) && existsSync(min)) return serveFrom(OPT_DIR, minRel, true, req, true, provisional);
       }
       const opt = normalize(join(OPT_DIR, rel));
-      if (opt.startsWith(OPT_DIR) && existsSync(opt)) return serveFrom(OPT_DIR, rel, true, req, versioned);
-      return serveFrom(LIBRARY_DIR, rel, true, req, versioned);
+      if (opt.startsWith(OPT_DIR) && existsSync(opt)) return serveFrom(OPT_DIR, rel, true, req, versioned, provisional);
+      return serveFrom(LIBRARY_DIR, rel, true, req, versioned, provisional);
     },
   },
   {

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -1,0 +1,82 @@
+// store-variants — the store's serving shadows, named in one place.
+//
+// A store upload (content-addressed: assets/opt/store/<hash>.glb, immutable)
+// gets TWO shadows, both built off the request path by upload.ts's serial
+// optimize pump and both served by routes.ts on the ORIGINAL's address:
+//
+//   store-min/<hash>.glb        draco + webp@1024 — the unflagged answer, what
+//                               every client without a KTX2 decoder gets
+//   store/<hash>.glb.ktx2.glb   draco + KTX2 (the §20a diet) — the ?ktx2=1
+//                               answer, beside the original exactly like every
+//                               library variant (OPT_DIR/<rel>.ktx2.glb), which
+//                               is the path the /library route already resolves
+//
+// The second shadow is what this module gives a name to. Before it, a KTX2-
+// capable client asking for a store upload fell through to store-min: webp
+// decodes to full RGBA8 on the GPU (a 1024² map with mips is ~5.3MB of VRAM)
+// where KTX2 stays block-compressed (~1.4MB) and skips createImageBitmap
+// entirely (§20: 1.0–1.2s/GLB of decode, 4–8× the VRAM). The library got that
+// variant on day one; the conjured props that actually fill a world never did
+// (#122's own evidence: store/305ea…glb?ktx2=1 → "draco + webp, and no KTX2
+// at all").
+//
+// Beside-the-original carries the ghost-listing obligation (§20c): the variant
+// ends in .glb too, so every place that enumerates store/*.glb — the catalog,
+// the boot sweep — asks isStoreOriginal, never endsWith(".glb"); and every
+// place that LISTS the opt tree (/library-list, which the prefetcher warms
+// from) skips isKtx2Variant, or each variant is downloaded a second time under
+// its own name.
+//
+// And one serving rule, in routes.ts: a flagged fetch (?ktx2=1) that falls
+// through to the webp shadow is PROVISIONAL for that URL — served no-cache,
+// never immutable — because the variant may still be encoding, or the box may
+// have no encoder yet. Content-addressed makes the ADDRESS immutable, not the
+// flagged answer; pinned for a year, the variant never reaches that cache.
+//
+// DOM-free and side-effect-free: unit-tested in tools/store-variants-test.ts.
+
+import { existsSync } from "node:fs";
+import { join, basename } from "node:path";
+
+/** The variant suffix. `<hash>.glb` + this = the KTX2 shadow's file name. */
+export const KTX2_SUFFIX = ".ktx2.glb";
+
+/** Any KTX2 serving artifact, of any asset class: `<rel>.ktx2.glb` (models,
+ *  library and store), `<rel>.ktx2.vrm` (bodies, §20c), `<img>.ktx2` (loose
+ *  toolkit images, §20d). Reached only through the ORIGINAL's path + ?ktx2=1;
+ *  never a listing entry of its own. */
+export function isKtx2Variant(name: string): boolean {
+  return /\.ktx2(\.glb|\.vrm)?$/i.test(name);
+}
+
+/** Is this store/ entry an upload, as opposed to a variant of one? The
+ *  predicate every store/*.glb enumeration must use (catalog, boot sweep):
+ *  a variant is the SAME model, not a second catalog entry and not a
+ *  candidate for its own shadows. */
+export function isStoreOriginal(name: string): boolean {
+  return name.endsWith(".glb") && !isKtx2Variant(name);
+}
+
+/** Where the KTX2 shadow of a store original lives: beside it, `<path>.ktx2.glb`
+ *  — routes.ts's own resolution for a flagged fetch (`${rel}.ktx2.glb` under
+ *  OPT_DIR), so serving needs no change to find it. */
+export function ktx2VariantPath(original: string): string {
+  return `${original}${KTX2_SUFFIX}`;
+}
+
+/** Which shadows a store original still lacks. A `.failed` marker counts as
+ *  present — the pass already gave its answer (not smaller / not convertible)
+ *  and the sweep must not re-measure it every boot. `exists` is injectable
+ *  for tests; production passes nothing and reads the disk. */
+export function storeShadowsMissing(
+  original: string,
+  minDir: string,
+  exists: (p: string) => boolean = existsSync,
+): { min: boolean; ktx2: boolean } {
+  const min = join(minDir, basename(original));
+  const k = ktx2VariantPath(original);
+  return {
+    min: !exists(min) && !exists(`${min}.failed`),
+    ktx2: !exists(k) && !exists(`${k}.failed`),
+  };
+}

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -6,7 +6,7 @@
 //
 //   store-min/<hash>.glb        draco + webp@1024 — the unflagged answer, what
 //                               every client without a KTX2 decoder gets
-//   store/<hash>.glb.ktx2.glb   draco + KTX2 (the §20a diet) — the ?ktx2=1
+//   store/<hash>.glb.ktx2.glb   draco + KTX2 (the §20a diet) — the ?ktx2=<key>
 //                               answer, beside the original exactly like every
 //                               library variant (OPT_DIR/<rel>.ktx2.glb), which
 //                               is the path the /library route already resolves
@@ -27,7 +27,9 @@
 // from) skips isKtx2Variant, or each variant is downloaded a second time under
 // its own name.
 //
-// And one serving rule, in routes.ts: a flagged fetch (?ktx2=1) that falls
+// And one serving rule, in routes.ts: a flagged fetch (?ktx2=<key>, the key
+// being shared/ktx2.js's — a generation, rotated when a flagged answer has
+// been pinned wrong, as it had been under =1) that falls
 // through to the webp shadow is PROVISIONAL for that URL — served no-cache,
 // never immutable — because the variant may still be encoding, or the box may
 // have no encoder yet. Content-addressed makes the ADDRESS immutable, not the
@@ -43,10 +45,19 @@ export const KTX2_SUFFIX = ".ktx2.glb";
 
 /** Any KTX2 serving artifact, of any asset class: `<rel>.ktx2.glb` (models,
  *  library and store), `<rel>.ktx2.vrm` (bodies, §20c), `<img>.ktx2` (loose
- *  toolkit images, §20d). Reached only through the ORIGINAL's path + ?ktx2=1;
- *  never a listing entry of its own. */
+ *  toolkit images, §20d). Reached only through the ORIGINAL's path + the
+ *  ?ktx2=<key> negotiation; never a listing entry of its own. */
 export function isKtx2Variant(name: string): boolean {
   return /\.ktx2(\.glb|\.vrm)?$/i.test(name);
+}
+
+/** Anything the opt tree holds that is not an asset a client addresses by
+ *  name: a KTX2 variant, a `.failed` marker (the pump's diagnostic verdict on
+ *  a pass), a `.tmp` (a pass mid-write). None is a listing entry — the
+ *  prefetcher pushes every listed store path as a fetch, and a marker fetched
+ *  as a model is a 404 on a good day. */
+export function isServingArtifact(name: string): boolean {
+  return isKtx2Variant(name) || /\.(failed|tmp)$/i.test(name);
 }
 
 /** Is this store/ entry an upload, as opposed to a variant of one? The

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -9,6 +9,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync } from "node:fs";
 import { join, basename, dirname, relative } from "node:path";
 import { JOIN_TOKEN, UPLOAD_CAP, ROOT, OPT_DIR, STORE_MIN, LIBRARY_DIR } from "./config.ts";
+import { isStoreOriginal, ktx2VariantPath, storeShadowsMissing } from "./store-variants.ts";
 import { agentTokens, HN_ISSUER_KEY, HN_ISS, HN_AUD } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { worlds } from "./world.ts";
@@ -22,7 +23,8 @@ let tripoImportBusy = false;   // one Tripo import at a time — they cost CPU-s
 
 // ---- store optimization -----------------------------------------------------
 // Every uploaded GLB (drag-drop, Orrery conjures) gets a draco+webp shadow in
-// store-min/, built by a SUBPROCESS — draco encoding is CPU-seconds of
+// store-min/ AND a KTX2 variant beside the original (store-variants.ts — the
+// ?ktx2=1 answer, the §20a diet), both built by a SUBPROCESS — draco encoding is CPU-seconds of
 // synchronous wasm, and inside this process it would freeze pose relay for
 // every world. One file at a time; the sequencer never waits on it.
 type OptItem = { src: string; dest: string; mode?: "--ktx2" | "--ktx2-vrm" | "--ktx2-img" };
@@ -30,10 +32,21 @@ const optQueue: OptItem[] = [];
 let optRunning = false;
 let ktx2Skip = false; // set when a --ktx2 run exits 3 (no encoder) — stop queuing variants this boot
 function queueOptimize(absPath: string) {
+  let pushed = false;
   if (!optQueue.some((q) => q.src === absPath && !q.mode)) {
     optQueue.push({ src: absPath, dest: join(STORE_MIN, basename(absPath)) });
-    pumpOptimize();
+    pushed = true;
   }
+  // The KTX2 shadow too: same source (the ORIGINAL — the §20a diet encodes
+  // from the best bytes, and store-min has been wrong before, #122), the
+  // variant beside it where routes.ts already looks. Not once this boot has
+  // learned there is no encoder — every upload would otherwise spawn a pass
+  // that exits 3 and relearns it.
+  if (!ktx2Skip && !optQueue.some((q) => q.src === absPath && q.mode === "--ktx2")) {
+    optQueue.push({ src: absPath, dest: ktx2VariantPath(absPath), mode: "--ktx2" });
+    pushed = true;
+  }
+  if (pushed) pumpOptimize();
 }
 async function pumpOptimize() {
   if (optRunning) return;
@@ -90,10 +103,17 @@ async function pumpOptimize() {
 setTimeout(() => {
   const dir = join(OPT_DIR, "store");
   if (!existsSync(dir)) return;
-  const pending = readdirSync(dir).filter((f) => f.endsWith(".glb")
-    && !existsSync(join(STORE_MIN, f)) && !existsSync(join(STORE_MIN, `${f}.failed`)));
+  // isStoreOriginal, not endsWith(".glb"): the KTX2 variants live in this
+  // same dir and end in .glb too — a variant must never queue as an upload
+  // of its own (the ghost-listing rule, §20c). An original lacking EITHER
+  // shadow queues both; the pump skips the one that already exists.
+  const pending = readdirSync(dir).filter((f) => {
+    if (!isStoreOriginal(f)) return false;
+    const m = storeShadowsMissing(join(dir, f), STORE_MIN);
+    return m.min || m.ktx2;
+  });
   if (!pending.length) return;
-  console.log(`[store] boot sweep: ${pending.length} unoptimized upload(s) queued`);
+  console.log(`[store] boot sweep: ${pending.length} upload(s) missing a shadow queued`);
   for (const f of pending) queueOptimize(join(dir, f));
 }, 5000);
 // Library KTX2 sweep (§20a, VRMs §20c, loose images §20d): every library

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -24,7 +24,7 @@ let tripoImportBusy = false;   // one Tripo import at a time — they cost CPU-s
 // ---- store optimization -----------------------------------------------------
 // Every uploaded GLB (drag-drop, Orrery conjures) gets a draco+webp shadow in
 // store-min/ AND a KTX2 variant beside the original (store-variants.ts — the
-// ?ktx2=1 answer, the §20a diet), both built by a SUBPROCESS — draco encoding is CPU-seconds of
+// ?ktx2=<key> answer, shared/ktx2.js; the §20a diet), both built by a SUBPROCESS — draco encoding is CPU-seconds of
 // synchronous wasm, and inside this process it would freeze pose relay for
 // every world. One file at a time; the sequencer never waits on it.
 type OptItem = { src: string; dest: string; mode?: "--ktx2" | "--ktx2-vrm" | "--ktx2-img" };
@@ -86,6 +86,14 @@ async function pumpOptimize() {
         console.log("[ktx2] no encoder — set KTX2_TOKTX or put toktx/ktx on PATH (docs/ktx2-encoder.md); variants skipped this boot");
         ktx2Skip = true;
         for (let i = optQueue.length - 1; i >= 0; i--) if (optQueue[i].mode) optQueue.splice(i, 1);
+      } else if (code === 5 && mode) {
+        // An encoder answered, but not every eligible texture converted — the
+        // CLI REFUSED to write a variant whose name would lie about its
+        // contents (the #122 class, and it would be served immutable).
+        // ENVIRONMENTAL like code 3 (a flaky or misconfigured encoder, not a
+        // bad model): no marker, so the next boot sweep retries; and no
+        // ktx2Skip either — the encoder is there, one file did not convert.
+        console.error(`[ktx2] ${base} REFUSED — partial conversion, serving the original: ${err.split("\n").pop() ?? `exit ${code}`}`);
       } else {
         // Environmental failures (deps not installed yet) must NOT mark the
         // file — that would permanently skip every upload made before the
@@ -120,7 +128,7 @@ setTimeout(() => {
 // model gets a GPU-native-texture variant at OPT_DIR/<rel>.ktx2.glb, every
 // avatar a surgical-rewrite variant at OPT_DIR/<rel>.ktx2.vrm, and every
 // curated loose texture a flip-baked variant at OPT_DIR/<rel>.ktx2 — all
-// served only on ?ktx2=1 (routes.ts). PATH-PRESERVING, unlike the store arm — basename()
+// served only on ?ktx2=<key> (routes.ts, shared/ktx2.js). PATH-PRESERVING, unlike the store arm — basename()
 // collides across library rels — and through the SAME serial pump, deferred
 // further so boot stays about serving worlds. GLBs go through the full
 // gltf-transform diet; VRMs go through --ktx2-vrm ONLY (optimize.ts header

--- a/shared/ktx2.js
+++ b/shared/ktx2.js
@@ -1,0 +1,32 @@
+// ktx2 — the texture negotiation KEY, one constant both sides import.
+//
+// A KTX2-capable client asks for a library or store asset with ?ktx2=<key>
+// and the sequencer answers with the GPU-native variant when one exists, the
+// original otherwise (routes.ts, the §20 negotiation). The key is a
+// GENERATION, not a boolean, and it lives here rather than as a literal in
+// four client fetch sites and one server branch, because rotating it is the
+// only way to walk away from a poisoned cache: an answer served
+// `max-age=31536000, immutable` under ?ktx2=1 — which is what every store
+// upload's flagged answer WAS, webp included (2026-08-24, the show box) —
+// never revalidates, not in a browser, not in nginx (it keys on the full
+// query string), no matter what the origin says afterwards. A fresh key is
+// a fresh cache entry everywhere at once; the old one simply stops being
+// asked for. Bump this when a flagged answer has been pinned wrong.
+//
+// Generations: 1 — the §20 launch key (2026-08-10), retired 2026-08-24 because
+// provisional fall-throughs had been served immutable under it.
+export const KTX2_KEY = '2';
+export const KTX2_QUERY = `ktx2=${KTX2_KEY}`;
+
+/** Does this request negotiate KTX2 — the CURRENT key only. A retired key is
+ *  an unflagged fetch: whatever that client cached under it is what it
+ *  already has, and a new client never asks with it. */
+export function wantsKtx2(params) {
+  return params.get('ktx2') === KTX2_KEY;
+}
+
+/** Append the negotiation to a URL that may already carry a query
+ *  (avatar URLs carry ?v=<mtime>). */
+export function withKtx2(url) {
+  return url + (url.includes('?') ? '&' : '?') + KTX2_QUERY;
+}

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -1,0 +1,303 @@
+// The store's KTX2 shadow (server/store-variants.ts), run headless.
+//
+//   bun tools/store-variants-test.ts
+//   KTX2_TOKTX=/path/to/toktx bun tools/store-variants-test.ts   # + the encode section
+//
+// The contract under test: a store upload gets a KTX2 variant BESIDE the
+// original (store/<hash>.glb.ktx2.glb — the library's <rel>.ktx2.glb
+// convention, which is the path /library?ktx2=1 already resolves), the
+// variant is built from the ORIGINAL and is really KTX2 (KHR_texture_basisu
+// required, every image image/ktx2 — the #122 shape is exactly what a webp
+// fall-through looks like), and the ghost-listing rule — a variant is never
+// enumerated as an upload of its own: not by the store catalog
+// (/library-models), not by the directory listing the prefetcher warms from
+// (/library-list), not by the boot sweep, not by the "what does this original
+// still lack" question. Plus the serving rule that makes any of it reach a
+// client: a flagged fetch answered by the webp shadow is PROVISIONAL —
+// no-cache, never immutable — so the variant's bytes get through the moment
+// it exists, instead of being pinned out for a year.
+//
+// Sections 1-2 are pure and always run. Section 3 spawns the real
+// optimize.ts --ktx2 CLI on a fixture upload and is gated on an encoder the
+// way the server is: none on this box → reported as skipped, never as a
+// failure (the exit-3 doctrine — environmental, not a .failed). Section 4
+// spawns the real sequencer (the deps-route-test pattern: verified-free port,
+// nonce-proven ownership) and fetches the store fixture the way a browser
+// does — with and without the flag, with and without the variant on disk —
+// asserting bytes AND cache-control. It needs no encoder: which FILE answers
+// is the question, not what is in it.
+//
+// Negative control: on the branch base this file dies at import
+// (server/store-variants.ts does not exist). Of the serving checks, main
+// fails "flagged → variant" (nothing ever wrote that path) and "flagged
+// fall-through is provisional" (the show box, 2026-08-24: every store
+// ?ktx2=1 answer immutable, every one webp).
+
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync, rmdirSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Document, NodeIO } from "@gltf-transform/core";
+import { PNG } from "pngjs";
+import { isStoreOriginal, isKtx2Variant, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX } from "../server/store-variants.ts";
+import { findKtx2Encoder } from "../server/optimize.ts";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${label}${!ok && detail ? `\n      ${detail}` : ""}`);
+  if (!ok) failures++;
+};
+
+console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
+
+// ---------------------------------------------- 1. the pure contract
+{
+  const OPT = "/srv/assets/opt";                    // any base; only the shape matters
+  const hash = "305ea80018ad4dbf";                  // #122's lantern, for the record
+  const rel = `store/${hash}.glb`;
+  const original = join(OPT, rel);
+
+  check("an upload is a store original", isStoreOriginal(`${hash}.glb`));
+  check("its KTX2 variant is NOT (it is the same model)", !isStoreOriginal(`${hash}.glb${KTX2_SUFFIX}`));
+  check("the manifest is not", !isStoreOriginal("manifest.json"));
+  check("a .failed marker is not", !isStoreOriginal(`${hash}.glb${KTX2_SUFFIX}.failed`));
+  check("a body is not (store holds models only)", !isStoreOriginal("someone.vrm"));
+
+  check("the variant lives beside the original", ktx2VariantPath(original) === join(OPT, `store/${hash}.glb.ktx2.glb`),
+    ktx2VariantPath(original));
+  // The serving contract, stated the way routes.ts states it — a flagged
+  // fetch for rel resolves join(OPT_DIR, `${rel}.ktx2.glb`). The two files
+  // must agree on that path WITHOUT importing each other; this is the check
+  // that names the gap on main (routes resolved it, nothing wrote it).
+  const routesResolution = join(OPT, `${rel}.ktx2.glb`);
+  check("…which is exactly the path /library?ktx2=1 resolves (routes.ts)", ktx2VariantPath(original) === routesResolution,
+    `wrote ${ktx2VariantPath(original)}, routes reads ${routesResolution}`);
+
+  const minDir = join(OPT, "store-min");
+  const missing = (present: string[]) => storeShadowsMissing(original, minDir, (p) => present.includes(p));
+  let m = missing([]);
+  check("a fresh upload lacks both shadows", m.min && m.ktx2);
+  m = missing([join(minDir, `${hash}.glb`)]);
+  check("store-min present → only the KTX2 shadow is missing", !m.min && m.ktx2);
+  m = missing([join(minDir, `${hash}.glb.failed`)]);
+  check("a store-min .failed counts as answered (never re-measured)", !m.min && m.ktx2);
+  m = missing([ktx2VariantPath(original)]);
+  check("variant present → only store-min is missing", m.min && !m.ktx2);
+  m = missing([`${ktx2VariantPath(original)}.failed`]);
+  check("a variant .failed counts as answered too", m.min && !m.ktx2);
+  m = missing([join(minDir, `${hash}.glb`), ktx2VariantPath(original)]);
+  check("both present → nothing to queue", !m.min && !m.ktx2);
+}
+
+// ---------------------------------------------- 2. the ghost-listing rule
+{
+  // What readdirSync(store/) returns once variants exist. The catalog and the
+  // boot sweep both filter with isStoreOriginal; endsWith(".glb") — what
+  // they used to do — lists the variant as a second "conjured 305ea800…"
+  // and queues it for shadows of its own.
+  const listing = ["305ea80018ad4dbf.glb", "305ea80018ad4dbf.glb.ktx2.glb", "305ea80018ad4dbf.glb.ktx2.glb.failed",
+    "a1b2c3d4e5f60718.glb", "manifest.json", "scripts"];
+  const originals = listing.filter(isStoreOriginal);
+  check("the catalog lists each upload once", originals.length === 2 && originals[0] === "305ea80018ad4dbf.glb" && originals[1] === "a1b2c3d4e5f60718.glb",
+    originals.join(", "));
+  check("…and endsWith(\".glb\") would have listed the ghost (the old predicate)",
+    listing.filter((f) => f.endsWith(".glb")).length === 3);
+
+  // The listing rule is one predicate for every asset class the §20 arc
+  // shadows — what /library-list must skip so the prefetcher (which warms
+  // every listed .glb/.vrm with ?ktx2=1) never pulls a variant twice.
+  for (const v of ["x.glb.ktx2.glb", "aletheia.vrm.ktx2.vrm", "moon_color_1k.jpg.ktx2", "grass_01.png.ktx2", "UPPER.GLB.KTX2.GLB"])
+    check(`${v} is a variant`, isKtx2Variant(v));
+  for (const o of ["x.glb", "aletheia.vrm", "moon_color_1k.jpg", "x.glb.ktx2.glb.failed", "manifest.json", "sky_system.js"])
+    check(`${o} is not`, !isKtx2Variant(o));
+}
+
+// ---------------------------------------------- fixtures: two distinct GLBs
+// A 256² varying PNG — 4-aligned, so optimize.ts hands it to the encoder
+// as-is (no sharp in the loop: this file is about the KTX2 arm, and
+// one-libvips-test.ts already owns the webp/sharp story). It has to VARY:
+// prune() folds a solid texture into baseColorFactor and drops it.
+// The node name carries a per-run nonce, so the content hash — and with it
+// the store path — is unique to THIS run: the fixture is its own ownership
+// proof in section 4 (only the tree we spawn from has it).
+const NONCE = crypto.randomUUID();
+async function fixtureGlb(tag: string): Promise<Uint8Array> {
+  const W = 256, png = new PNG({ width: W, height: W });
+  for (let y = 0; y < W; y++)
+    for (let x = 0; x < W; x++) {
+      const i = (y * W + x) * 4;
+      png.data[i] = x; png.data[i + 1] = y; png.data[i + 2] = (x ^ y) & 0xff; png.data[i + 3] = 255;
+    }
+  const doc = new Document();
+  const buf = doc.createBuffer();
+  const tex = doc.createTexture("probe").setImage(new Uint8Array(PNG.sync.write(png))).setMimeType("image/png");
+  const mat = doc.createMaterial("probeMat").setBaseColorTexture(tex);
+  const prim = doc.createPrimitive().setMaterial(mat)
+    .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf)
+      .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])))
+    // UVs are load-bearing: without them prune() reads the texture as
+    // unreferenced and drops it, and the pass has nothing to encode
+    .setAttribute("TEXCOORD_0", doc.createAccessor().setType("VEC2").setBuffer(buf)
+      .setArray(new Float32Array([0, 0, 1, 0, 0, 1])));
+  const mesh = doc.createMesh("probeMesh").addPrimitive(prim);
+  const scene = doc.createScene("s").addChild(doc.createNode(`${tag}-${NONCE}`).setMesh(mesh));
+  // The stand-in variant must differ from the original in SIZE, not just in
+  // bytes: serveFrom's ETag is size+mtime, and two same-size files written in
+  // the same millisecond share one — which is a fixture artifact (a real
+  // variant is never the size of the webp shadow), not the contract.
+  if (tag !== "original") scene.addChild(doc.createNode(`${tag}-second-node-so-the-size-differs`));
+  return new NodeIO().writeBinary(doc);
+}
+const glb = await fixtureGlb("original");
+const hash = new Bun.CryptoHasher("sha256").update(glb).digest("hex").slice(0, 16);
+const glbJson = (bytes: Uint8Array) => {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset);
+  return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + dv.getUint32(12, true))));
+};
+
+// ---------------------------------------------- 3. the encode, end to end (encoder permitting)
+const encoder = findKtx2Encoder();
+if (!encoder) {
+  console.log("\n  - encode: skipped — no KTX2 encoder on this box (set KTX2_TOKTX or put toktx/ktx on PATH; docs/ktx2-encoder.md)");
+} else {
+  console.log(`\n  the encode, with ${encoder}:`);
+  const tmp = mkdtempSync(join(tmpdir(), "ew-store-ktx2-"));
+  try {
+    // Land it the way POST /upload does: content-addressed under store/.
+    const store = join(tmp, "store"), minDir = join(tmp, "store-min");
+    mkdirSync(store, { recursive: true });
+    const original = join(store, `${hash}.glb`);
+    writeFileSync(original, glb);
+    const dest = ktx2VariantPath(original);
+
+    // The exact spawn upload.ts's pump makes for a --ktx2 item.
+    const proc = Bun.spawn([process.execPath, "run", join(import.meta.dir, "../server/optimize.ts"), "--ktx2", original, dest],
+      { stdout: "pipe", stderr: "pipe", env: { ...process.env, KTX2_TOKTX: encoder } });
+    const code = await proc.exited;
+    const err = (await new Response(proc.stderr).text()).trim();
+    check("optimize.ts --ktx2 wrote the variant (exit 0)", code === 0, `exit ${code}: ${err.split("\n").pop() ?? ""}`);
+    check("…at the path beside the original", existsSync(dest), dest);
+
+    if (existsSync(dest)) {
+      const json = glbJson(new Uint8Array(await Bun.file(dest).arrayBuffer()));
+      const req: string[] = json.extensionsRequired ?? [];
+      check("the variant REQUIRES KHR_texture_basisu (a real KTX2 variant, not a webp fall-through)",
+        req.includes("KHR_texture_basisu"), req.join(", "));
+      check("…and draco, the rest of the §20a diet", req.includes("KHR_draco_mesh_compression"), req.join(", "));
+      const mimes: string[] = (json.images ?? []).map((im: any) => im.mimeType);
+      check("every image is image/ktx2", mimes.length > 0 && mimes.every((m) => m === "image/ktx2"), mimes.join(", "));
+      check("no image is webp (the #122 shape)", !mimes.includes("image/webp"));
+    }
+
+    // With a real variant on disk: the enumeration questions, asked of the disk.
+    const listed = readdirSync(store).filter(isStoreOriginal);
+    check("the catalog would list exactly the one upload", listed.length === 1 && listed[0] === `${hash}.glb`, listed.join(", "));
+    const m = storeShadowsMissing(original, minDir);
+    check("the boot sweep sees the KTX2 shadow as done, store-min as still owed", !m.ktx2 && m.min);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------- 4. serving, through the real sequencer
+console.log("\n  serving, through the real sequencer:");
+{
+  // OPT_DIR is this checkout's assets/opt (gitignored) — the only tree the
+  // server reads, so the fixture goes there, under its content hash, and
+  // comes out again in cleanup. A stand-in variant: section 4 asks WHICH
+  // file answers a URL and how it is cached, not what a KTX2 file contains
+  // (section 3's job) — so it runs on a box with no encoder, which is also
+  // the box that most needs the provisional rule.
+  const variant = await fixtureGlb("variant");
+  const OPT = join(import.meta.dir, "..", "assets", "opt");
+  const storeDir = join(OPT, "store"), minDir = join(OPT, "store-min");
+  const madeStore = !existsSync(storeDir), madeMin = !existsSync(minDir);
+  mkdirSync(storeDir, { recursive: true }); mkdirSync(minDir, { recursive: true });
+  const original = join(storeDir, `${hash}.glb`);
+  const variantPath = ktx2VariantPath(original);
+  // a store-min .failed: "already lean, serve the original" — so the child's
+  // boot sweep has nothing to build for this hash and the unflagged answer is
+  // deterministic (the original), not a race with a subprocess
+  const minFailed = join(minDir, `${hash}.glb.failed`);
+  writeFileSync(original, glb); writeFileSync(variantPath, variant); writeFileSync(minFailed, "fixture");
+
+  // deps-route-test's two defenses: a verifiably-free port, and ownership.
+  let PORT = 0;
+  for (let i = 0; i < 20 && !PORT; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); }
+    catch { PORT = cand; }
+  }
+  // process.execPath, not "bun" (the Windows .cmd shim dies at launch and
+  // kill() reaps nothing — the stale-listener trap). An EMPTY library and no
+  // encoder for the child: its boot sweeps must find nothing to encode.
+  const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT),
+    WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-store-serve-")), EIDOVERSE_DIR: mkdtempSync(join(tmpdir(), "ew-empty-lib-")) };
+  delete env.KTX2_TOKTX;
+  const server = spawn(process.execPath, [join(import.meta.dir, "..", "server", "server.ts")], { env, stdio: "ignore" });
+  const cleanup = () => {
+    try { server.kill(); } catch { /* already gone */ }
+    for (const p of [original, variantPath, minFailed]) try { rmSync(p, { force: true }); } catch { /* best effort */ }
+    if (madeStore) try { rmdirSync(storeDir); } catch { /* not empty — someone else's uploads */ }
+    if (madeMin) try { rmdirSync(minDir); } catch { /* same */ }
+  };
+  process.on("exit", cleanup);
+
+  let up = false;
+  for (let i = 0; i < 40 && !up; i++) {
+    try { await fetch(`http://127.0.0.1:${PORT}/`); up = true; }
+    catch { await new Promise((r) => setTimeout(r, 250)); }
+  }
+  check("child server came up on a verified-free port", up, `:${PORT}`);
+
+  const url = (flag: boolean) => `http://127.0.0.1:${PORT}/library/store/${hash}.glb${flag ? "?ktx2=1" : ""}`;
+  const get = async (flag: boolean) => {
+    const res = await fetch(url(flag));
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    return { status: res.status, cc: res.headers.get("cache-control") ?? "", etag: res.headers.get("etag") ?? "", bytes };
+  };
+  const same = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
+  const whichFile = (b: Uint8Array) => { try { return String(glbJson(b).nodes?.[0]?.name ?? "?").split("-")[0]; } catch { return "unparseable"; } };
+
+  if (up) {
+    // ownership: only the tree we spawned from holds this run's fixture
+    const plain = await get(false);
+    const owned = plain.status === 200 && same(plain.bytes, glb);
+    check("listener is OUR child (the fixture round-trips), not a squatter", owned, `status=${plain.status} file=${whichFile(plain.bytes)}`);
+    if (!owned) { console.log("\n  refusing to test an unowned server\n"); }
+    else {
+      check("unflagged → the original, immutable (content-addressed)", plain.cc.includes("immutable"), plain.cc);
+
+      const flagged = await get(true);
+      check("flagged → the variant beside it", flagged.status === 200 && same(flagged.bytes, variant), `file=${whichFile(flagged.bytes)}`);
+      check("…immutable too (the variant is the final answer for that URL)", flagged.cc.includes("immutable"), flagged.cc);
+
+      // the enumerations, asked of the running server
+      const catalog: { path: string }[] = await fetch(`http://127.0.0.1:${PORT}/library-models`).then((r) => r.json());
+      const mine = catalog.filter((h) => h.path === `store/${hash}.glb`);
+      const ghosts = catalog.filter((h) => isKtx2Variant(h.path));
+      check("/library-models lists the upload once and the variant never", mine.length === 1 && ghosts.length === 0,
+        `mine=${mine.length} ghosts=${ghosts.map((g) => g.path).join(", ")}`);
+      const listing: { path: string }[] = await fetch(`http://127.0.0.1:${PORT}/library-list?dir=store`).then((r) => r.json());
+      check("/library-list?dir=store lists the upload and not the variant (the prefetcher warms this)",
+        listing.some((f) => f.path === `store/${hash}.glb`) && !listing.some((f) => isKtx2Variant(f.path)),
+        listing.map((f) => f.path).join(", "));
+
+      // the variant is not there yet (or never will be — no encoder): the
+      // flagged answer is the original, and it must not be pinned
+      rmSync(variantPath);
+      const provisional = await get(true);
+      check("flagged, no variant → falls through to the original", provisional.status === 200 && same(provisional.bytes, glb),
+        `file=${whichFile(provisional.bytes)}`);
+      check("…PROVISIONAL: no-cache, never immutable", provisional.cc === "no-cache", provisional.cc);
+      check("…and a different ETag than the variant's, so the swap is a 200 not a 304", provisional.etag !== flagged.etag && provisional.etag !== "",
+        `${provisional.etag} vs ${flagged.etag}`);
+      const still = await get(false);
+      check("the unflagged answer stays immutable — the address IS content-addressed", still.cc.includes("immutable"), still.cc);
+    }
+  }
+  cleanup();
+}
+
+console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
+process.exit(failures ? 1 : 0);

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -1,54 +1,67 @@
-// The store's KTX2 shadow (server/store-variants.ts), run headless.
+// The store's KTX2 shadow (server/store-variants.ts, shared/ktx2.js), run
+// headless — helpers, the optimizer's refusal seams, and the real sequencer.
 //
 //   bun tools/store-variants-test.ts
-//   KTX2_TOKTX=/path/to/toktx bun tools/store-variants-test.ts   # + the encode section
+//   KTX2_TOKTX=/path/to/toktx bun tools/store-variants-test.ts   # + one real encode
 //
 // The contract under test: a store upload gets a KTX2 variant BESIDE the
 // original (store/<hash>.glb.ktx2.glb — the library's <rel>.ktx2.glb
-// convention, which is the path /library?ktx2=1 already resolves), the
-// variant is built from the ORIGINAL and is really KTX2 (KHR_texture_basisu
-// required, every image image/ktx2 — the #122 shape is exactly what a webp
-// fall-through looks like), and the ghost-listing rule — a variant is never
-// enumerated as an upload of its own: not by the store catalog
-// (/library-models), not by the directory listing the prefetcher warms from
-// (/library-list), not by the boot sweep, not by the "what does this original
-// still lack" question. Plus the serving rule that makes any of it reach a
-// client: a flagged fetch answered by the webp shadow is PROVISIONAL —
-// no-cache, never immutable — so the variant's bytes get through the moment
-// it exists, instead of being pinned out for a year.
+// convention, which is the path /library?ktx2=<key> already resolves); the
+// variant is built from the ORIGINAL and is really KTX2, ALL of it — the
+// optimizer refuses a partial or empty conversion rather than write a
+// .ktx2.glb whose name lies (the #122 class), and refuses it RETRYABLY (exit
+// 5, no .failed marker; exit 2 + marker only when there was nothing to
+// convert); the ghost-listing rule — a variant, a marker, a .tmp is never
+// enumerated as an asset, not by the store catalog (/library-models), not by
+// the listing the prefetcher warms from (/library-list), not by the boot
+// sweep; the negotiation key is a GENERATION (shared/ktx2.js): the current
+// key negotiates, a retired one is an unflagged fetch; and a flagged fetch
+// answered by the webp shadow is PROVISIONAL — no-cache, never immutable —
+// so the variant's bytes get through the moment it exists, which the
+// If-None-Match round-trip here demonstrates.
 //
-// Sections 1-2 are pure and always run. Section 3 spawns the real
-// optimize.ts --ktx2 CLI on a fixture upload and is gated on an encoder the
-// way the server is: none on this box → reported as skipped, never as a
-// failure (the exit-3 doctrine — environmental, not a .failed). Section 4
-// spawns the real sequencer (the deps-route-test pattern: verified-free port,
-// nonce-proven ownership) and fetches the store fixture the way a browser
-// does — with and without the flag, with and without the variant on disk —
-// asserting bytes AND cache-control. It needs no encoder: which FILE answers
-// is the question, not what is in it.
+// No encoder is needed for any of it: a FAKE toktx (a bun script behind a
+// platform wrapper, driven by FAKE_TOKTX_MODE) emits a canned real KTX2, or
+// fails, or fails on its second call, or writes bytes that are not KTX2 —
+// the seams the review asked to see exercised. Section 3 also runs the real
+// encoder once if the box has one (the exit-3 doctrine: none → skipped).
+// Sections 4-7 spawn the real sequencer (the deps-route-test pattern:
+// verified-free port, fixture-as-nonce ownership) with the fake encoder in
+// its environment and drive it through POST /upload, the boot sweep, and
+// the fetches a browser makes.
 //
 // Negative control: on the branch base this file dies at import
-// (server/store-variants.ts does not exist). Of the serving checks, main
-// fails "flagged → variant" (nothing ever wrote that path) and "flagged
-// fall-through is provisional" (the show box, 2026-08-24: every store
-// ?ktx2=1 answer immutable, every one webp).
+// (server/store-variants.ts, shared/ktx2.js do not exist). Of the serving
+// checks, main fails "flagged → variant" (nothing ever wrote that path) and
+// "fall-through is provisional" (the show box, 2026-08-24: every store
+// ?ktx2=1 answer immutable, every one webp); of the optimizer checks, main
+// writes the partial and the empty variant (review of #142, reproduced).
 
-import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync, rmdirSync } from "node:fs";
-import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, rmdirSync, chmodSync } from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Document, NodeIO } from "@gltf-transform/core";
 import { PNG } from "pngjs";
-import { isStoreOriginal, isKtx2Variant, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX } from "../server/store-variants.ts";
-import { findKtx2Encoder } from "../server/optimize.ts";
+import { isStoreOriginal, isKtx2Variant, isServingArtifact, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX } from "../server/store-variants.ts";
+import { findKtx2Encoder, isKtx2Container } from "../server/optimize.ts";
+import { KTX2_KEY, KTX2_QUERY, wantsKtx2, withKtx2 } from "../shared/ktx2.js";
 
 let failures = 0;
 const check = (label: string, ok: boolean, detail?: string) => {
   console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${label}${!ok && detail ? `\n      ${detail}` : ""}`);
   if (!ok) failures++;
 };
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const until = async (pred: () => boolean, ms: number, step = 250) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) { if (pred()) return true; await sleep(step); }
+  return pred();
+};
+const ROOT = join(import.meta.dir, "..");
+const OPTIMIZE = join(ROOT, "server", "optimize.ts");
 
-console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
+console.log("\nthe store's KTX2 shadow (store-variants.ts, shared/ktx2.js):\n");
 
 // ---------------------------------------------- 1. the pure contract
 {
@@ -70,7 +83,7 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
   // must agree on that path WITHOUT importing each other; this is the check
   // that names the gap on main (routes resolved it, nothing wrote it).
   const routesResolution = join(OPT, `${rel}.ktx2.glb`);
-  check("…which is exactly the path /library?ktx2=1 resolves (routes.ts)", ktx2VariantPath(original) === routesResolution,
+  check("…which is exactly the path /library?ktx2=<key> resolves (routes.ts)", ktx2VariantPath(original) === routesResolution,
     `wrote ${ktx2VariantPath(original)}, routes reads ${routesResolution}`);
 
   const minDir = join(OPT, "store-min");
@@ -87,6 +100,14 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
   check("a variant .failed counts as answered too", m.min && !m.ktx2);
   m = missing([join(minDir, `${hash}.glb`), ktx2VariantPath(original)]);
   check("both present → nothing to queue", !m.min && !m.ktx2);
+
+  // the negotiation key is a generation, shared by both sides
+  check("the current key is 2 (1 retired 2026-08-24 — its flagged answers had been pinned immutable)", KTX2_KEY === "2" && KTX2_QUERY === "ktx2=2");
+  check("the current key negotiates", wantsKtx2(new URLSearchParams("ktx2=2")));
+  check("the retired key does NOT — it is an unflagged fetch now", !wantsKtx2(new URLSearchParams("ktx2=1")));
+  check("no key does not", !wantsKtx2(new URLSearchParams("v=123")));
+  check("withKtx2 appends with ? on a bare path", withKtx2("store/x.glb") === "store/x.glb?ktx2=2");
+  check("…and with & when ?v= is already there (avatar URLs)", withKtx2("eidoverse/assets/vrms/a.vrm?v=9") === "eidoverse/assets/vrms/a.vrm?v=9&ktx2=2");
 }
 
 // ---------------------------------------------- 2. the ghost-listing rule
@@ -96,7 +117,7 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
   // they used to do — lists the variant as a second "conjured 305ea800…"
   // and queues it for shadows of its own.
   const listing = ["305ea80018ad4dbf.glb", "305ea80018ad4dbf.glb.ktx2.glb", "305ea80018ad4dbf.glb.ktx2.glb.failed",
-    "a1b2c3d4e5f60718.glb", "manifest.json", "scripts"];
+    "a1b2c3d4e5f60718.glb", "manifest.json", "manifest.json.tmp", "scripts"];
   const originals = listing.filter(isStoreOriginal);
   check("the catalog lists each upload once", originals.length === 2 && originals[0] === "305ea80018ad4dbf.glb" && originals[1] === "a1b2c3d4e5f60718.glb",
     originals.join(", "));
@@ -104,200 +125,398 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts):\n");
     listing.filter((f) => f.endsWith(".glb")).length === 3);
 
   // The listing rule is one predicate for every asset class the §20 arc
-  // shadows — what /library-list must skip so the prefetcher (which warms
-  // every listed .glb/.vrm with ?ktx2=1) never pulls a variant twice.
+  // shadows — what /library-list must skip so the prefetcher (which pushes
+  // every listed store path as a fetch) never pulls a variant twice…
   for (const v of ["x.glb.ktx2.glb", "aletheia.vrm.ktx2.vrm", "moon_color_1k.jpg.ktx2", "grass_01.png.ktx2", "UPPER.GLB.KTX2.GLB"])
-    check(`${v} is a variant`, isKtx2Variant(v));
-  for (const o of ["x.glb", "aletheia.vrm", "moon_color_1k.jpg", "x.glb.ktx2.glb.failed", "manifest.json", "sky_system.js"])
-    check(`${o} is not`, !isKtx2Variant(o));
+    check(`${v} is a variant`, isKtx2Variant(v) && isServingArtifact(v));
+  for (const o of ["x.glb", "aletheia.vrm", "moon_color_1k.jpg", "manifest.json", "sky_system.js"])
+    check(`${o} is not`, !isKtx2Variant(o) && !isServingArtifact(o));
+  // …nor fetches a marker as a model (review of #142, P2)
+  for (const a of ["x.glb.ktx2.glb.failed", "x.glb.failed", "x.glb.tmp", "manifest.json.tmp", "x.glb.ktx2.glb.tmp"])
+    check(`${a} is a serving artifact, never a listing entry`, isServingArtifact(a));
+  check("the listing the prefetcher sees is originals + the manifest only",
+    listing.filter((f) => !isServingArtifact(f)).join(",") === "305ea80018ad4dbf.glb,a1b2c3d4e5f60718.glb,manifest.json,scripts");
 }
 
-// ---------------------------------------------- fixtures: two distinct GLBs
-// A 256² varying PNG — 4-aligned, so optimize.ts hands it to the encoder
-// as-is (no sharp in the loop: this file is about the KTX2 arm, and
-// one-libvips-test.ts already owns the webp/sharp story). It has to VARY:
-// prune() folds a solid texture into baseColorFactor and drops it.
-// The node name carries a per-run nonce, so the content hash — and with it
-// the store path — is unique to THIS run: the fixture is its own ownership
-// proof in section 4 (only the tree we spawn from has it).
+// ---------------------------------------------- fixtures
+// Varying textures — prune() folds a solid one into baseColorFactor and drops
+// it. 4-aligned PNGs, so optimize.ts hands them to the encoder as-is (no
+// sharp in the loop: one-libvips-test.ts owns that story). The node name
+// carries a per-run nonce, so each fixture's content hash — its store path
+// — is unique to THIS run: the fixture is its own ownership proof against a
+// spawned server (only the tree we spawn from has it).
 const NONCE = crypto.randomUUID();
-async function fixtureGlb(tag: string): Promise<Uint8Array> {
-  const W = 256, png = new PNG({ width: W, height: W });
+function pngBytes(seed: number, W = 64): Uint8Array {
+  const png = new PNG({ width: W, height: W });
   for (let y = 0; y < W; y++)
     for (let x = 0; x < W; x++) {
       const i = (y * W + x) * 4;
-      png.data[i] = x; png.data[i + 1] = y; png.data[i + 2] = (x ^ y) & 0xff; png.data[i + 3] = 255;
+      png.data[i] = (x * 4 + seed) & 0xff; png.data[i + 1] = (y * 4) & 0xff; png.data[i + 2] = ((x ^ y) * 4 + seed) & 0xff; png.data[i + 3] = 255;
     }
+  return new Uint8Array(PNG.sync.write(png));
+}
+/** `textures`: 0 = untextured mesh, 1 = baseColor, 2 = baseColor + normal
+ *  (the normal takes the UASTC branch — a different encoder argv). */
+async function fixtureGlb(tag: string, textures: 0 | 1 | 2, extraNode = false): Promise<Uint8Array> {
   const doc = new Document();
   const buf = doc.createBuffer();
-  const tex = doc.createTexture("probe").setImage(new Uint8Array(PNG.sync.write(png))).setMimeType("image/png");
-  const mat = doc.createMaterial("probeMat").setBaseColorTexture(tex);
+  const mat = doc.createMaterial("probeMat");
+  if (textures >= 1) mat.setBaseColorTexture(doc.createTexture("base").setImage(pngBytes(1)).setMimeType("image/png"));
+  if (textures >= 2) mat.setNormalTexture(doc.createTexture("normal").setImage(pngBytes(7)).setMimeType("image/png"));
   const prim = doc.createPrimitive().setMaterial(mat)
     .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf)
       .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])))
-    // UVs are load-bearing: without them prune() reads the texture as
-    // unreferenced and drops it, and the pass has nothing to encode
+    // UVs are load-bearing: without them prune() reads the textures as
+    // unreferenced and drops them, and the pass has nothing to encode
     .setAttribute("TEXCOORD_0", doc.createAccessor().setType("VEC2").setBuffer(buf)
       .setArray(new Float32Array([0, 0, 1, 0, 0, 1])));
   const mesh = doc.createMesh("probeMesh").addPrimitive(prim);
   const scene = doc.createScene("s").addChild(doc.createNode(`${tag}-${NONCE}`).setMesh(mesh));
-  // The stand-in variant must differ from the original in SIZE, not just in
-  // bytes: serveFrom's ETag is size+mtime, and two same-size files written in
-  // the same millisecond share one — which is a fixture artifact (a real
-  // variant is never the size of the webp shadow), not the contract.
-  if (tag !== "original") scene.addChild(doc.createNode(`${tag}-second-node-so-the-size-differs`));
+  // a stand-in variant must differ from its original in SIZE, not just in
+  // bytes: serveFrom's ETag is size+mtime (a real variant never matches the
+  // shadow's size; a fixture written in the same millisecond can)
+  if (extraNode) scene.addChild(doc.createNode(`${tag}-second-node-so-the-size-differs`));
   return new NodeIO().writeBinary(doc);
 }
-const glb = await fixtureGlb("original");
-const hash = new Bun.CryptoHasher("sha256").update(glb).digest("hex").slice(0, 16);
+const hashOf = (b: Uint8Array) => new Bun.CryptoHasher("sha256").update(b).digest("hex").slice(0, 16);
 const glbJson = (bytes: Uint8Array) => {
   const dv = new DataView(bytes.buffer, bytes.byteOffset);
   return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + dv.getUint32(12, true))));
 };
+const isKtx2Glb = (bytes: Uint8Array) => {
+  try {
+    const j = glbJson(bytes);
+    const mimes: string[] = (j.images ?? []).map((im: any) => im.mimeType);
+    return (j.extensionsRequired ?? []).includes("KHR_texture_basisu") && mimes.length > 0 && mimes.every((m) => m === "image/ktx2");
+  } catch { return false; }
+};
 
-// ---------------------------------------------- 3. the encode, end to end (encoder permitting)
-const encoder = findKtx2Encoder();
-if (!encoder) {
-  console.log("\n  - encode: skipped — no KTX2 encoder on this box (set KTX2_TOKTX or put toktx/ktx on PATH; docs/ktx2-encoder.md)");
+// ---------------------------------------------- the fake encoder
+// A real 4×4 ETC1S KTX2 (toktx v4.4.2, 506 bytes) — what "ok" emits. The
+// optimizer checks the container magic on every encoder output, so the fake
+// has to produce the genuine article to be accepted; "garbage" is the
+// control for that check.
+const CANNED_KTX2 = Uint8Array.from(atob(
+  "q0tUWCAyMLsNChoKAAAAAAEAAAAEAAAABAAAAAAAAAAAAAAAAQAAAAMAAAABAAAAmAAAACwAAADEAAAAeAAAAEABAAAAAAAAtwAAAAAAAAD5AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAD4AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAD3AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAIAKACjAQIAAwMAAAgAAAAAAAAAAAA/AAAAAAAAAAAA/////xIAAABLVFhvcmllbnRhdGlvbgByZAAAACcAAABLVFh3cml0ZXIAdG9rdHggdjQuNC4yIC8gbGlia3R4IHY0LjQuMgAALgAAAEtUWHdyaXRlclNjUGFyYW1zAC0tZW5jb2RlIGV0YzFzIC0tcWxldmVsIDEyOAAAAAAAAAADAAMALwAAAA0AAAArAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAALABIAAAAAAACIIEDVAAAAAGBQMu0EYGABMAAAAAAAAIBCAKQAAAAAAEGiR9GgYpPr//4cqVf9XVVVVBQDBRAAAAAAAAPJfbQCYAAAAAAAAQUYATAAQAAAAgEBxADABAAAAAACAAAIMBgo="),
+  (c) => c.charCodeAt(0));
+check("the canned KTX2 carries the container magic", isKtx2Container(CANNED_KTX2));
+
+const FAKE_DIR = mkdtempSync(join(tmpdir(), "ew-fake-toktx-"));
+const FAKE_SCRIPT = join(FAKE_DIR, "fake-toktx.ts");
+writeFileSync(join(FAKE_DIR, "canned.ktx2"), CANNED_KTX2);
+writeFileSync(FAKE_SCRIPT, `// fake toktx — argv shape is toktx's: [...flags, outPath, inPath]
+const argv = process.argv.slice(2);
+const outPath = argv[argv.length - 2], inPath = argv[argv.length - 1];
+const mode = process.env.FAKE_TOKTX_MODE ?? "ok";
+const counter = process.env.FAKE_TOKTX_COUNTER;
+let n = 1;
+if (counter) {
+  const fs = await import("node:fs");
+  n = (fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0) + 1;
+  fs.writeFileSync(counter, String(n));
+}
+if (mode === "fail" || (mode === "fail-second" && n % 2 === 0)) { console.error("fake toktx: refusing " + inPath); process.exit(1); }
+const fs = await import("node:fs");
+if (mode === "garbage") { fs.writeFileSync(outPath, fs.readFileSync(inPath)); process.exit(0); }   // exit 0, bytes are the PNG
+fs.copyFileSync(new URL("./canned.ktx2", import.meta.url), outPath);
+process.exit(0);
+`);
+// The wrapper: findKtx2Encoder wants an existing path; the optimizer spawns
+// it directly and detects toktx by basename. process.execPath, not "bun"
+// (the Windows .cmd shim; docs/INCIDENTS.md).
+let FAKE_TOKTX: string;
+if (process.platform === "win32") {
+  FAKE_TOKTX = join(FAKE_DIR, "toktx.cmd");
+  writeFileSync(FAKE_TOKTX, `@echo off\r\n"${process.execPath}" run "${FAKE_SCRIPT}" %*\r\nexit /b %ERRORLEVEL%\r\n`);
 } else {
-  console.log(`\n  the encode, with ${encoder}:`);
+  FAKE_TOKTX = join(FAKE_DIR, "toktx");
+  writeFileSync(FAKE_TOKTX, `#!/bin/sh\nexec "${process.execPath}" run "${FAKE_SCRIPT}" "$@"\n`);
+  chmodSync(FAKE_TOKTX, 0o755);
+}
+
+/** upload.ts's exact spawn for a --ktx2 item, with the encoder chosen. */
+async function runKtx2(src: string, dest: string, env: Record<string, string>) {
+  const proc = Bun.spawn([process.execPath, "run", OPTIMIZE, "--ktx2", src, dest],
+    { stdout: "pipe", stderr: "pipe", env: { ...process.env, ...env } });
+  const code = await proc.exited;
+  const err = (await new Response(proc.stderr).text()).trim();
+  const out = (await new Response(proc.stdout).text()).trim();
+  return { code, err, out, wrote: existsSync(dest), tmpLeft: existsSync(`${dest}.tmp`) };
+}
+
+// ---------------------------------------------- 3. the optimizer's refusal seams
+console.log("\n  the optimizer, against the fake encoder:");
+{
   const tmp = mkdtempSync(join(tmpdir(), "ew-store-ktx2-"));
   try {
-    // Land it the way POST /upload does: content-addressed under store/.
-    const store = join(tmp, "store"), minDir = join(tmp, "store-min");
-    mkdirSync(store, { recursive: true });
-    const original = join(store, `${hash}.glb`);
-    writeFileSync(original, glb);
-    const dest = ktx2VariantPath(original);
+    const store = join(tmp, "store"); mkdirSync(store, { recursive: true });
+    const place = (bytes: Uint8Array) => { const p = join(store, `${hashOf(bytes)}.glb`); writeFileSync(p, bytes); return p; };
+    const two = place(await fixtureGlb("two", 2));
+    const one = place(await fixtureGlb("one", 1));
+    const none = place(await fixtureGlb("none", 0));
+    const corrupt = join(store, "0000000000000000.glb");
+    writeFileSync(corrupt, new Uint8Array([0x67, 0x6c, 0x54, 0x46, 2, 0, 0, 0, 40, 0, 0, 0, 9, 9, 9, 9]));   // GLB magic, garbage after
 
-    // The exact spawn upload.ts's pump makes for a --ktx2 item.
-    const proc = Bun.spawn([process.execPath, "run", join(import.meta.dir, "../server/optimize.ts"), "--ktx2", original, dest],
-      { stdout: "pipe", stderr: "pipe", env: { ...process.env, KTX2_TOKTX: encoder } });
-    const code = await proc.exited;
-    const err = (await new Response(proc.stderr).text()).trim();
-    check("optimize.ts --ktx2 wrote the variant (exit 0)", code === 0, `exit ${code}: ${err.split("\n").pop() ?? ""}`);
-    check("…at the path beside the original", existsSync(dest), dest);
+    let r = await runKtx2(two, ktx2VariantPath(two), { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok" });
+    check("ok: two textures → exit 0, variant written", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    check("…and it is really KTX2 — basisu required, every image image/ktx2", r.wrote && isKtx2Glb(new Uint8Array(readFileSync(ktx2VariantPath(two)))));
+    check("…the tally says 2/2", r.out.includes("2/2 texture(s)"), r.out);
 
-    if (existsSync(dest)) {
-      const json = glbJson(new Uint8Array(await Bun.file(dest).arrayBuffer()));
-      const req: string[] = json.extensionsRequired ?? [];
-      check("the variant REQUIRES KHR_texture_basisu (a real KTX2 variant, not a webp fall-through)",
-        req.includes("KHR_texture_basisu"), req.join(", "));
-      check("…and draco, the rest of the §20a diet", req.includes("KHR_draco_mesh_compression"), req.join(", "));
-      const mimes: string[] = (json.images ?? []).map((im: any) => im.mimeType);
-      check("every image is image/ktx2", mimes.length > 0 && mimes.every((m) => m === "image/ktx2"), mimes.join(", "));
-      check("no image is webp (the #122 shape)", !mimes.includes("image/webp"));
+    r = await runKtx2(one, ktx2VariantPath(one), { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "fail" });
+    check("all-fail: exit 5, NOTHING written (the empty variant main would have shipped)", r.code === 5 && !r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    check("…no .tmp left behind", !r.tmpLeft);
+    check("…and it names the texture it could not convert", r.err.includes("0/1") && r.err.includes("base"), r.err.split("\n").pop());
+
+    const counter = join(tmp, "counter");
+    r = await runKtx2(two, ktx2VariantPath(two) + ".partial", { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "fail-second", FAKE_TOKTX_COUNTER: counter });
+    check("partial-fail: 1 of 2 converts → exit 5, nothing written (the partial variant main would have shipped)", r.code === 5 && !r.wrote,
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    check("…the tally says 1/2 and names the normal map", r.err.includes("1/2") && r.err.includes("normal"), r.err.split("\n").pop());
+
+    r = await runKtx2(one, ktx2VariantPath(one) + ".garbage", { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "garbage" });
+    check("an encoder that exits 0 but writes non-KTX2 bytes → refused (the container check), exit 5", r.code === 5 && !r.wrote && r.err.includes("not a KTX2 container"),
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
+    r = await runKtx2(none, ktx2VariantPath(none), { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok" });
+    check("nothing to convert (untextured) → exit 2, nothing written — a content verdict, the marker's business", r.code === 2 && !r.wrote,
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
+    r = await runKtx2(corrupt, ktx2VariantPath(corrupt), { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok" });
+    check("a corrupt container → exit 1 (a real failure, marker's business too)", r.code === 1 && !r.wrote, `exit ${r.code}`);
+
+    r = await runKtx2(one, ktx2VariantPath(one) + ".noenc", { KTX2_TOKTX: join(tmp, "no-such-toktx"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
+    check("no encoder anywhere → exit 3 (the env-skip, unchanged)", r.code === 3 && !r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
+    const real = findKtx2Encoder();
+    if (!real) console.log("  - real encoder: skipped — none on this box (KTX2_TOKTX / toktx / ktx; docs/ktx2-encoder.md)");
+    else {
+      r = await runKtx2(two, ktx2VariantPath(two) + ".real", { KTX2_TOKTX: real });
+      check(`the real encoder (${real.split(/[\\/]/).pop()}): exit 0, a KTX2 variant`, r.code === 0 && r.wrote && isKtx2Glb(new Uint8Array(readFileSync(ktx2VariantPath(two) + ".real"))),
+        `exit ${r.code}: ${r.err.split("\n").pop()}`);
     }
-
-    // With a real variant on disk: the enumeration questions, asked of the disk.
-    const listed = readdirSync(store).filter(isStoreOriginal);
-    check("the catalog would list exactly the one upload", listed.length === 1 && listed[0] === `${hash}.glb`, listed.join(", "));
-    const m = storeShadowsMissing(original, minDir);
-    check("the boot sweep sees the KTX2 shadow as done, store-min as still owed", !m.ktx2 && m.min);
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
 }
 
-// ---------------------------------------------- 4. serving, through the real sequencer
-console.log("\n  serving, through the real sequencer:");
-{
-  // OPT_DIR is this checkout's assets/opt (gitignored) — the only tree the
-  // server reads, so the fixture goes there, under its content hash, and
-  // comes out again in cleanup. A stand-in variant: section 4 asks WHICH
-  // file answers a URL and how it is cached, not what a KTX2 file contains
-  // (section 3's job) — so it runs on a box with no encoder, which is also
-  // the box that most needs the provisional rule.
-  const variant = await fixtureGlb("variant");
-  const OPT = join(import.meta.dir, "..", "assets", "opt");
-  const storeDir = join(OPT, "store"), minDir = join(OPT, "store-min");
-  const madeStore = !existsSync(storeDir), madeMin = !existsSync(minDir);
-  mkdirSync(storeDir, { recursive: true }); mkdirSync(minDir, { recursive: true });
-  const original = join(storeDir, `${hash}.glb`);
-  const variantPath = ktx2VariantPath(original);
-  // a store-min .failed: "already lean, serve the original" — so the child's
-  // boot sweep has nothing to build for this hash and the unflagged answer is
-  // deterministic (the original), not a race with a subprocess
-  const minFailed = join(minDir, `${hash}.glb.failed`);
-  writeFileSync(original, glb); writeFileSync(variantPath, variant); writeFileSync(minFailed, "fixture");
+// ---------------------------------------------- the real sequencer
+// OPT_DIR is this checkout's assets/opt (gitignored) — the only tree the
+// server reads, so fixtures go there under their content hashes and come out
+// again in cleanup (including their manifest entries). An EMPTY library for
+// the child, so its library sweep has nothing to encode.
+const OPT = join(ROOT, "assets", "opt");
+const STORE = join(OPT, "store"), STORE_MIN = join(OPT, "store-min");
+const madeStore = !existsSync(STORE), madeMin = !existsSync(STORE_MIN);
+mkdirSync(STORE, { recursive: true }); mkdirSync(STORE_MIN, { recursive: true });
+const EMPTY_LIB = mkdtempSync(join(tmpdir(), "ew-empty-lib-"));
+// "No encoder" has to be TRUE for the child: KTX2_TOKTX pointing nowhere is
+// not enough when PATH holds the fake — Bun.which("toktx") resolves toktx.cmd
+// through PATHEXT on Windows (this file's own first run found it that way).
+// An empty dir for PATH and HOME (the ~/.local/ktx fallback) makes it true.
+const NOWHERE = mkdtempSync(join(tmpdir(), "ew-nowhere-"));
+const NO_ENCODER = { KTX2_TOKTX: join(NOWHERE, "no-such-toktx"), PATH: NOWHERE, HOME: NOWHERE, USERPROFILE: NOWHERE };
+const DOOR = "test-door";
+const mine = new Set<string>();   // hashes this run put in the store
+const shadowsOf = (hash: string) => [
+  join(STORE, `${hash}.glb`), join(STORE, `${hash}.glb.ktx2.glb`), join(STORE, `${hash}.glb.ktx2.glb.failed`),
+  join(STORE, `${hash}.glb.ktx2.glb.tmp`), join(STORE_MIN, `${hash}.glb`), join(STORE_MIN, `${hash}.glb.failed`), join(STORE_MIN, `${hash}.glb.tmp`)];
+let live: ChildProcess | null = null;
+const cleanup = () => {
+  try { live?.kill(); } catch { /* gone */ }
+  for (const h of mine) for (const p of shadowsOf(h)) try { rmSync(p, { force: true }); } catch { /* best effort */ }
+  try {   // our manifest entries, not anyone else's
+    const mp = join(STORE, "manifest.json");
+    if (existsSync(mp)) {
+      const man = JSON.parse(readFileSync(mp, "utf8"));
+      for (const h of mine) delete man[h];
+      if (Object.keys(man).length) writeFileSync(mp, JSON.stringify(man)); else rmSync(mp);
+    }
+  } catch { /* best effort */ }
+  if (madeStore) try { rmdirSync(STORE); } catch { /* not empty — someone else's uploads */ }
+  if (madeMin) try { rmdirSync(STORE_MIN); } catch { /* same */ }
+  try { rmSync(FAKE_DIR, { recursive: true, force: true }); } catch { /* best effort */ }
+  try { rmSync(EMPTY_LIB, { recursive: true, force: true }); } catch { /* best effort */ }
+  try { rmSync(NOWHERE, { recursive: true, force: true }); } catch { /* best effort */ }
+};
+process.on("exit", cleanup);
 
-  // deps-route-test's two defenses: a verifiably-free port, and ownership.
-  let PORT = 0;
-  for (let i = 0; i < 20 && !PORT; i++) {
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
     const cand = 20000 + Math.floor(Math.random() * 20000);
     try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); }
-    catch { PORT = cand; }
+    catch { return cand; }
   }
-  // process.execPath, not "bun" (the Windows .cmd shim dies at launch and
-  // kill() reaps nothing — the stale-listener trap). An EMPTY library and no
-  // encoder for the child: its boot sweeps must find nothing to encode.
-  const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT),
-    WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-store-serve-")), EIDOVERSE_DIR: mkdtempSync(join(tmpdir(), "ew-empty-lib-")) };
-  delete env.KTX2_TOKTX;
-  const server = spawn(process.execPath, [join(import.meta.dir, "..", "server", "server.ts")], { env, stdio: "ignore" });
-  const cleanup = () => {
-    try { server.kill(); } catch { /* already gone */ }
-    for (const p of [original, variantPath, minFailed]) try { rmSync(p, { force: true }); } catch { /* best effort */ }
-    if (madeStore) try { rmdirSync(storeDir); } catch { /* not empty — someone else's uploads */ }
-    if (madeMin) try { rmdirSync(minDir); } catch { /* same */ }
-  };
-  process.on("exit", cleanup);
-
+  throw new Error("no free port in 20 tries");
+}
+/** Spawn the sequencer with `extra` in its environment (the optimize
+ *  subprocesses inherit it — that is how the fake encoder's mode reaches
+ *  them). Returns the door, the log so far, and a stop. */
+async function startServer(extra: Record<string, string | undefined>) {
+  const PORT = await freePort();
+  const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT), JOIN_TOKEN: DOOR,
+    WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-store-serve-")), EIDOVERSE_DIR: EMPTY_LIB, ...extra };
+  const proc = spawn(process.execPath, [join(ROOT, "server", "server.ts")], { env, stdio: ["ignore", "pipe", "pipe"] });
+  live = proc;
+  let log = "";
+  proc.stdout!.on("data", (d) => { log += d; });
+  proc.stderr!.on("data", (d) => { log += d; });
   let up = false;
-  for (let i = 0; i < 40 && !up; i++) {
-    try { await fetch(`http://127.0.0.1:${PORT}/`); up = true; }
-    catch { await new Promise((r) => setTimeout(r, 250)); }
+  for (let i = 0; i < 60 && !up; i++) {
+    try { await fetch(`http://127.0.0.1:${PORT}/`); up = true; } catch { await sleep(250); }
   }
-  check("child server came up on a verified-free port", up, `:${PORT}`);
-
-  const url = (flag: boolean) => `http://127.0.0.1:${PORT}/library/store/${hash}.glb${flag ? "?ktx2=1" : ""}`;
-  const get = async (flag: boolean) => {
-    const res = await fetch(url(flag));
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    return { status: res.status, cc: res.headers.get("cache-control") ?? "", etag: res.headers.get("etag") ?? "", bytes };
+  const base = `http://127.0.0.1:${PORT}`;
+  const get = async (rel: string, headers: Record<string, string> = {}) => {
+    const res = await fetch(`${base}/library/${rel}`, { headers });
+    return { status: res.status, cc: res.headers.get("cache-control") ?? "", etag: res.headers.get("etag") ?? "",
+      bytes: res.status === 200 ? new Uint8Array(await res.arrayBuffer()) : new Uint8Array(0) };
   };
-  const same = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
-  const whichFile = (b: Uint8Array) => { try { return String(glbJson(b).nodes?.[0]?.name ?? "?").split("-")[0]; } catch { return "unparseable"; } };
+  const upload = async (bytes: Uint8Array, name: string) => {
+    const res = await fetch(`${base}/upload?token=${DOOR}&name=${name}`, { method: "POST", body: bytes });
+    return { status: res.status, body: res.ok ? await res.json() : await res.text() };
+  };
+  const stop = async () => { try { proc.kill(); } catch { /* gone */ } live = null; await sleep(300); };
+  return { up, PORT, base, get, upload, stop, log: () => log };
+}
+const same = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
+const whichFile = (b: Uint8Array) => { try { return String(glbJson(b).nodes?.[0]?.name ?? "?").split("-")[0]; } catch { return "unparseable"; } };
 
-  if (up) {
+// ---------------------------------------------- 4. upload → queue → variant → served (fake encoder, ok)
+console.log("\n  the real sequencer — an upload becomes a served variant:");
+{
+  const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok" });
+  check("child server came up on a verified-free port", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const glb = await fixtureGlb("uploaded", 2);
+    const hash = hashOf(glb); mine.add(hash);
+    const up = await S.upload(glb, "store-variants-test");
+    check("POST /upload landed it content-addressed", up.status === 200 && up.body?.path === `store/${hash}.glb`, `${up.status} ${JSON.stringify(up.body)}`);
     // ownership: only the tree we spawned from holds this run's fixture
-    const plain = await get(false);
-    const owned = plain.status === 200 && same(plain.bytes, glb);
+    const plain = await S.get(`store/${hash}.glb`);
+    const owned = plain.status === 200 && same(plain.bytes, glb) || (plain.status === 200 && whichFile(plain.bytes) === "uploaded");
     check("listener is OUR child (the fixture round-trips), not a squatter", owned, `status=${plain.status} file=${whichFile(plain.bytes)}`);
-    if (!owned) { console.log("\n  refusing to test an unowned server\n"); }
+    if (!owned) console.log("\n  refusing to test an unowned server\n");
     else {
-      check("unflagged → the original, immutable (content-addressed)", plain.cc.includes("immutable"), plain.cc);
-
-      const flagged = await get(true);
-      check("flagged → the variant beside it", flagged.status === 200 && same(flagged.bytes, variant), `file=${whichFile(flagged.bytes)}`);
-      check("…immutable too (the variant is the final answer for that URL)", flagged.cc.includes("immutable"), flagged.cc);
+      // The pump runs store-min then --ktx2, serially, off the request path.
+      // Until the variant lands, the flagged answer is whatever the unflagged
+      // one is, marked provisional; once it lands, the variant, immutable.
+      const early = await S.get(withKtx2(`store/${hash}.glb`));
+      const earlyIsVariant = isKtx2Glb(early.bytes);
+      check("a flagged fetch is answered either way, and its caching says which", early.status === 200
+        && (earlyIsVariant ? early.cc.includes("immutable") : early.cc === "no-cache"), `variant=${earlyIsVariant} cc=${early.cc}`);
+      const landed = await until(() => existsSync(ktx2VariantPath(join(STORE, `${hash}.glb`))), 30_000);
+      check("the queue built the KTX2 shadow beside the original", landed, ktx2VariantPath(join(STORE, `${hash}.glb`)));
+      check("…and it says so in the sequencer's log", /\[ktx2\] .*→ .*\.ktx2\.glb/.test(S.log()), S.log().split("\n").filter((l) => l.includes("ktx2")).join(" | "));
+      const flagged = await S.get(withKtx2(`store/${hash}.glb`));
+      check("flagged (current key) → the variant, really KTX2, immutable", flagged.status === 200 && isKtx2Glb(flagged.bytes) && flagged.cc.includes("immutable"),
+        `cc=${flagged.cc} ktx2=${isKtx2Glb(flagged.bytes)}`);
+      const retired = await S.get(`store/${hash}.glb?ktx2=1`);
+      check("the retired key (=1) is an unflagged fetch: not the variant, immutable like the address", retired.status === 200 && !isKtx2Glb(retired.bytes) && retired.cc.includes("immutable"),
+        `cc=${retired.cc} ktx2=${isKtx2Glb(retired.bytes)}`);
+      const bare = await S.get(`store/${hash}.glb`);
+      check("unflagged → not the variant, immutable", bare.status === 200 && !isKtx2Glb(bare.bytes) && bare.cc.includes("immutable"), bare.cc);
 
       // the enumerations, asked of the running server
-      const catalog: { path: string }[] = await fetch(`http://127.0.0.1:${PORT}/library-models`).then((r) => r.json());
-      const mine = catalog.filter((h) => h.path === `store/${hash}.glb`);
-      const ghosts = catalog.filter((h) => isKtx2Variant(h.path));
-      check("/library-models lists the upload once and the variant never", mine.length === 1 && ghosts.length === 0,
-        `mine=${mine.length} ghosts=${ghosts.map((g) => g.path).join(", ")}`);
-      const listing: { path: string }[] = await fetch(`http://127.0.0.1:${PORT}/library-list?dir=store`).then((r) => r.json());
-      check("/library-list?dir=store lists the upload and not the variant (the prefetcher warms this)",
-        listing.some((f) => f.path === `store/${hash}.glb`) && !listing.some((f) => isKtx2Variant(f.path)),
-        listing.map((f) => f.path).join(", "));
+      const catalog: { path: string }[] = await fetch(`${S.base}/library-models`).then((r) => r.json());
+      check("/library-models lists the upload once and the variant never",
+        catalog.filter((h) => h.path === `store/${hash}.glb`).length === 1 && !catalog.some((h) => isKtx2Variant(h.path)),
+        catalog.filter((h) => h.path.includes(hash)).map((h) => h.path).join(", "));
+      // a marker beside it too, so the listing has every artifact class to skip
+      writeFileSync(join(STORE, `${hash}.glb.ktx2.glb.tmp`), "mid-write");
+      const listing: { path: string }[] = await fetch(`${S.base}/library-list?dir=store`).then((r) => r.json());
+      const listedMine = listing.map((f) => f.path).filter((p) => p.includes(hash));
+      check("/library-list?dir=store lists the upload and NO artifact (variant, .failed, .tmp) — what the prefetcher fetches",
+        listedMine.length === 1 && listedMine[0] === `store/${hash}.glb`, listedMine.join(", "));
+      rmSync(join(STORE, `${hash}.glb.ktx2.glb.tmp`), { force: true });
 
-      // the variant is not there yet (or never will be — no encoder): the
-      // flagged answer is the original, and it must not be pinned
-      rmSync(variantPath);
-      const provisional = await get(true);
-      check("flagged, no variant → falls through to the original", provisional.status === 200 && same(provisional.bytes, glb),
-        `file=${whichFile(provisional.bytes)}`);
-      check("…PROVISIONAL: no-cache, never immutable", provisional.cc === "no-cache", provisional.cc);
-      check("…and a different ETag than the variant's, so the swap is a 200 not a 304", provisional.etag !== flagged.etag && provisional.etag !== "",
-        `${provisional.etag} vs ${flagged.etag}`);
-      const still = await get(false);
-      check("the unflagged answer stays immutable — the address IS content-addressed", still.cc.includes("immutable"), still.cc);
+      // exit 2's marker, through the pump: an untextured upload
+      const none = await fixtureGlb("untextured", 0);
+      const h2 = hashOf(none); mine.add(h2);
+      await S.upload(none, "untextured");
+      const marked = await until(() => existsSync(join(STORE, `${h2}.glb.ktx2.glb.failed`)), 30_000);
+      check("nothing to convert → the pump writes the .failed marker (exit 2) and no variant", marked && !existsSync(join(STORE, `${h2}.glb.ktx2.glb`)));
+      const listing2: { path: string }[] = await fetch(`${S.base}/library-list?dir=store`).then((r) => r.json());
+      check("…and the marker is not a listing entry either", !listing2.some((f) => f.path.includes(h2) && f.path !== `store/${h2}.glb`));
     }
   }
-  cleanup();
+  await S.stop();
 }
 
+// ---------------------------------------------- 5. boot queuing + exit 5 (fake encoder, fail-second)
+console.log("\n  the boot sweep — a partial conversion is refused, retryably:");
+{
+  const glb = await fixtureGlb("booted", 2);
+  const hash = hashOf(glb); mine.add(hash);
+  writeFileSync(join(STORE, `${hash}.glb`), glb);       // an original with no shadows, before the server exists
+  const counter = join(FAKE_DIR, `counter-${hash}`);
+  const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "fail-second", FAKE_TOKTX_COUNTER: counter });
+  check("child server came up", S.up, `:${S.PORT}`);
+  if (S.up) {
+    // the store sweep fires 5s after boot; store-min first, then --ktx2
+    const swept = await until(() => existsSync(join(STORE_MIN, `${hash}.glb`)) || existsSync(join(STORE_MIN, `${hash}.glb.failed`)), 40_000);
+    check("the boot sweep queued the pre-existing original (its store-min shadow or verdict appeared)", swept);
+    const refused = await until(() => /REFUSED — partial conversion/.test(S.log()), 30_000);
+    check("the --ktx2 pass converted 1 of 2 and was REFUSED (exit 5)", refused && /1\/2/.test(S.log()),
+      S.log().split("\n").filter((l) => l.includes("ktx2")).join(" | "));
+    check("…no variant written", !existsSync(join(STORE, `${hash}.glb.ktx2.glb`)));
+    check("…and NO .failed marker — environmental, retried next boot", !existsSync(join(STORE, `${hash}.glb.ktx2.glb.failed`)));
+    check("…and no ktx2Skip: the encoder is there (no 'no encoder' line)", !/no encoder/.test(S.log()));
+    const flagged = await S.get(withKtx2(`store/${hash}.glb`));
+    check("meanwhile a flagged fetch falls through, provisional (no-cache) — not pinned", flagged.status === 200 && !isKtx2Glb(flagged.bytes) && flagged.cc === "no-cache", flagged.cc);
+  }
+  await S.stop();
+}
+
+// ---------------------------------------------- 6. ktx2Skip — no encoder, once per boot, and uploads stop queueing
+console.log("\n  no encoder on the box — exit 3, once, and no marker:");
+{
+  const glb = await fixtureGlb("noenc", 1);
+  const hash = hashOf(glb); mine.add(hash);
+  writeFileSync(join(STORE, `${hash}.glb`), glb);
+  const S = await startServer(NO_ENCODER);
+  check("child server came up", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const said = await until(() => /no encoder/.test(S.log()), 40_000);
+    check("the sweep's --ktx2 item exited 3: 'no encoder … variants skipped this boot'", said);
+    check("…no variant, no marker (environmental)", !existsSync(join(STORE, `${hash}.glb.ktx2.glb`)) && !existsSync(join(STORE, `${hash}.glb.ktx2.glb.failed`)));
+    const glb2 = await fixtureGlb("noenc-upload", 1);
+    const h2 = hashOf(glb2); mine.add(h2);
+    await S.upload(glb2, "noenc-upload");
+    await until(() => existsSync(join(STORE_MIN, `${h2}.glb`)) || existsSync(join(STORE_MIN, `${h2}.glb.failed`)), 30_000);
+    await sleep(1500);
+    const noEncoderLines = S.log().split("\n").filter((l) => l.includes("no encoder")).length;
+    check("a later upload does not re-spawn an exit-3 pass — ktx2Skip held (the line appears exactly once)", noEncoderLines === 1, `${noEncoderLines} line(s)`);
+    check("…and got no marker either", !existsSync(join(STORE, `${h2}.glb.ktx2.glb.failed`)));
+  }
+  await S.stop();
+}
+
+// ---------------------------------------------- 7. the swap — If-None-Match across the variant landing
+console.log("\n  the swap a browser makes when the variant lands:");
+{
+  const glb = await fixtureGlb("swap", 1);
+  const variant = await fixtureGlb("swap-variant", 1, true);   // a stand-in: which FILE answers is the question here
+  const hash = hashOf(glb); mine.add(hash);
+  writeFileSync(join(STORE, `${hash}.glb`), glb);
+  writeFileSync(join(STORE_MIN, `${hash}.glb.failed`), "fixture");   // "already lean": the unflagged answer is the original, deterministically
+  const S = await startServer(NO_ENCODER);
+  check("child server came up", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const before = await S.get(withKtx2(`store/${hash}.glb`));
+    check("no variant yet: flagged → the original, no-cache, with an ETag", before.status === 200 && same(before.bytes, glb) && before.cc === "no-cache" && before.etag !== "",
+      `cc=${before.cc} etag=${before.etag}`);
+    const revalidated = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": before.etag });
+    check("revalidating while nothing changed is a 304 (no body), still no-cache", revalidated.status === 304 && revalidated.cc === "no-cache", `${revalidated.status} ${revalidated.cc}`);
+    writeFileSync(ktx2VariantPath(join(STORE, `${hash}.glb`)), variant);   // the variant lands
+    const swapped = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": before.etag });
+    check("the variant landed: the same If-None-Match now gets a 200 with the VARIANT — the swap", swapped.status === 200 && same(swapped.bytes, variant),
+      `${swapped.status} file=${whichFile(swapped.bytes)}`);
+    check("…immutable from here on, under a new ETag", swapped.cc.includes("immutable") && swapped.etag !== before.etag, `cc=${swapped.cc}`);
+    const settled = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": swapped.etag });
+    check("…and revalidating the variant is a 304 that says immutable", settled.status === 304 && settled.cc.includes("immutable"), `${settled.status} ${settled.cc}`);
+    const bare = await S.get(`store/${hash}.glb`);
+    check("the unflagged answer never moved: the original, immutable — the address IS content-addressed", same(bare.bytes, glb) && bare.cc.includes("immutable"), bare.cc);
+  }
+  await S.stop();
+}
+
+cleanup();
 console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Mica — Antra suggested (on X, to @gabriel_xnlg) that server-side texture compression on uploaded assets would help lower-end machines, and asked to have you review. Reading the tree first: the §20 arc already *is* that — for the library. This closes the gap it left in the store, and fixes the serving rules that would have kept the gap closed even after the fix.

*Round two (`663885d`) addresses the review's four points — see the thread. Summary below is current.*

## The gap

The KTX2 sweep (`upload.ts`) walks library models, avatars and the curated image dirs — never `store/`. Conjured props (Tripo/Orrery — most of what is in commons) only ever get the webp shadow. #122's own evidence is the shape: `store/305ea…glb?ktx2=1` → "draco + webp, and no KTX2 at all". §20.1 records why the store arm was left out — `basename()` collides for library rels — which doesn't apply to hash-named store files.

Why it's the bill a 6GB card feels first: webp decodes to full RGBA8 on the GPU (a 1024² map + mips ≈ 5.3MB of VRAM); KTX2 stays block-compressed (≈1.4MB) and skips `createImageBitmap` — §20's own 4–8×.

## What this does

- **`server/store-variants.ts`** (new, pure): `isStoreOriginal`, `isKtx2Variant`, `isServingArtifact`, `ktx2VariantPath`, `storeShadowsMissing`.
- **`shared/ktx2.js`** (new): the negotiation key as a **generation** — `KTX2_KEY = '2'`, `wantsKtx2`, `withKtx2` — imported by both the client (four fetch sites) and the sequencer. Every flagged store answer had been served `immutable` under `=1`, webp included, and no origin header can revalidate a browser's immutable entry; a fresh key is a fresh cache entry everywhere at once. A retired key is an unflagged fetch.
- **`upload.ts`**: `queueOptimize` also queues a `--ktx2` item per upload, from the **original** (the diet encodes from the best bytes; store-min has been wrong, #122), to `store/<hash>.glb.ktx2.glb` — the path `routes.ts` already resolves. The boot sweep queues an original lacking either shadow, never a variant. Honors `ktx2Skip`. Handles the new exit 5.
- **`optimize.ts`**: `optimizeGlbKtx2` is **all-or-nothing** — `ktx2CompressTextures` returns a tally and checks every encoder output for the KTX2 container magic; the GLB arm writes nothing unless every eligible texture converted. CLI **exit 5** = an encoder answered but the variant is refused: environmental (no `.failed`, retried next boot), not `ktx2Skip` (the encoder is there). Exit 2 stays "nothing to convert". On `main` the CLI would write a `.ktx2.glb` with png inside and serve it immutable (reproduced).
- **`routes.ts`**, three things:
  1. `/library-models` filters with `isStoreOriginal` — the ghost-listing rule (§20c) for the store.
  2. `/library-list` skips `isServingArtifact`: variants, `.failed` markers, `.tmp`. The prefetcher pushes every listed store path as a fetch — a listed variant downloads twice, a listed marker fetches as a model.
  3. **A flagged fetch that falls through is provisional** — `no-cache`, never `immutable`. Content-addressed makes the *address* immutable, not the flagged answer. `no-cache` rides the existing ETag (the `.vrm` doctrine in `serveFrom`): a 304 while nothing changed, the variant's bytes the moment it exists. Also closes the latent `.vrm` case — a stale variant under a fresh `?v=` fell through to the original *immutable* until the next re-upload.
- **`docs/ktx2-encoder.md`**: the Linux + systemd recipe (macOS and Windows were documented; the platform production runs on was not), and where the key lives.

## The show box, measured from outside (2026-08-24)

Every model probed on `eidoverse.animalabs.ai` with `?ktx2=1` — library and store — came back `extensionsRequired: [EXT_texture_webp, KHR_draco_mesh_compression]`, images `image/webp`; the store ones `cache-control: public, max-age=31536000, immutable`. `/library-list` shows 0 `.ktx2` entries across 118 library + 39 store files. So: **no encoder on the VPS; the whole §20 arc is built and dormant there.** When this lands: install the encoder (`docs/ktx2-encoder.md`, Linux section; `Environment=KTX2_TOKTX=…` in the unit) — the boot sweep does the rest, serially, off the request path. The key rotation takes care of what clients and nginx already pinned.

## The trade, stated

While no variant exists for a path (prod today), a flagged fetch revalidates per page load (a 304, no body) instead of caching. That's what avatars already do; it ends per-path the moment the variant lands. One string in `serveFrom` if you'd rather bound it.

## Receipts

`bun tools/store-variants-test.ts` — **83/83**, **no encoder needed** (Windows, bun 1.4.0; the one real-encoder check runs when toktx is present):
- the pure contract, incl. the serving-contract check that names the gap on main (routes resolved `${rel}.ktx2.glb`; nothing wrote it), and the key generation;
- the ghost-listing rule, all three predicates;
- the optimizer, spawned exactly as the pump spawns it, against a **fake toktx** (a bun script behind a `.cmd`/sh wrapper, `FAKE_TOKTX_MODE`): ok → a real KTX2 variant; all-fail → exit 5, nothing written; partial-fail (1/2) → exit 5, nothing written; exit-0-but-not-KTX2 bytes → exit 5; untextured → exit 2; corrupt → exit 1; no encoder → exit 3;
- the real sequencer, spawned with the fake in its environment: `POST /upload` → queue → variant served under the current key, immutable; retired key → an unflagged fetch; `/library-models` once, `/library-list` no variant / `.failed` / `.tmp`; an untextured upload → the pump's `.failed` marker; a pre-placed original swept at boot into a REFUSED partial — no variant, **no marker**, no `ktx2Skip`, flagged fetch provisional meanwhile; no encoder at all → exit 3 **once**, `ktx2Skip` holding across a later upload; and the `If-None-Match` round-trip — 304 while nothing changed, **200 with the variant the moment it lands**, 304 immutable after.

Also green on the patched routes/optimizer: `one-libvips-test.ts` 11/11, `deps-route-test.ts` 13/13; `git diff --check` clean. (`version-route-test.ts` crashes identically on clean `main` on this Windows box — its line 157, the PATH-without-git scenario — unrelated.) A real 34.5MB library GLB through `--ktx2` here: 20.5MB in 87s.

Negative control: the suite dies at import on `main` (no `store-variants.ts`, no `shared/ktx2.js`); of the serving checks, `main` fails "flagged → variant" and "fall-through is provisional"; of the optimizer checks, `main` writes the empty and the partial variant.

## Not in this PR

Decimated LODs (Antra's other suggestion). No mesh LOD exists today; `import-tripo-avatar.ts:180` already has a proven `weld()+simplify(MeshoptSimplifier)` recipe, and the client's residency tier (placeholder ↔ real) is the natural hook — but that's a change in the realizer and a design call about where selection lives. Happy to do it as a follow-up; tell me where you'd want the selection to sit.

`upload.ts` gains an `exit 5` branch *after* the `exit 3` one; #124's `exit 4` lands *before* it — adjacent, not overlapping. I'll rebase on whichever merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R65fLki4fxEvDbCL2hT9JF
