### PR TITLE
ktx2: the browser takes the negotiation key from the running sequencer, never from a served file

### DIFF
--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -8,7 +8,7 @@
 //   vrmPool    whole parsed VRM instances at rest (§19b — no clone exists
 //              for a bound rig, so released bodies are reworn intact)
 
-import { withKtx2 } from '../../shared/ktx2.js';
+import { keyFromVersion, negotiate } from '../../shared/ktx2.js';
 import { THREE, renderer, camera, scene, report, bus } from './core.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -152,6 +152,27 @@ const ktx2 = new KTX2Loader()
 /** Whether this GPU/browser negotiates KTX2 variants (?ktx2=<key>, shared/ktx2.js) — prefetch
  *  must warm the SAME cache key demand fetches will use. */
 export const ktx2Capable = () => !!ktx2.workerConfig;
+// The negotiation key comes from the RUNNING sequencer, never from a file it
+// merely serves. In the window between `git pull` and the restart the old
+// process serves the new shared/ktx2.js; a client that read the key off that
+// file asked a server that had never heard of it, got an unflagged answer
+// (webp, immutable), and nginx pinned it under the new key — the =2
+// collision of 2026-08-24, retired within minutes. /version is the running
+// process talking (no-store; resolved at ITS boot). No key there — an older
+// sequencer, a failed fetch — means no negotiation at all: an unflagged
+// fetch is always the right answer for its URL, so nothing can be pinned
+// wrong, on any deploy, in any order. One fetch per page, awaited by every
+// negotiating load (they are all async already; the prefetcher awaits it
+// once before building its queue).
+export const ktx2KeyReady = fetch('/version', { cache: 'no-store' })
+  .then((r) => (r.ok ? r.json() : null)).then(keyFromVersion).catch(() => null);
+/** The path a negotiating load fetches: the running server's key appended
+ *  when this GPU decodes KTX2 and `eligible` (the asset class negotiates),
+ *  the bare path otherwise. */
+async function negotiated(path, eligible) {
+  const key = eligible && ktx2.workerConfig ? await ktx2KeyReady : null;
+  return negotiate(path, key);
+}
 function makeLoader(vrm = false) {
   const l = new GLTFLoader();
   l.setDRACOLoader(draco);
@@ -284,7 +305,7 @@ export async function loadVRM(libPath, { priority = 1 } = {}) {
     // byteCache (variant and original are distinct byte entries — correct),
     // while the vrmPool and its vrmMeta ledger key on libPath UNTOUCHED, so
     // pool identity is unaffected by negotiation.
-    const url = libPath.split('?')[0].endsWith('.vrm') && ktx2.workerConfig ? withKtx2(libPath) : libPath;
+    const url = await negotiated(libPath, libPath.split('?')[0].endsWith('.vrm'));
     const buf = await fetchBytes(`/library/${url}`);
     work.phase('queued');
     // The parse and skeleton passes are the irreducibly-synchronous chunk of a
@@ -477,7 +498,7 @@ export async function loadGLB(libPath) {
         // paths — the server answers with the variant when one exists, the
         // original otherwise. The full URL keys byteCache, so variant and
         // original are distinct entries, which is correct.
-        const url = libPath.endsWith('.glb') && ktx2.workerConfig ? withKtx2(libPath) : libPath;
+        const url = await negotiated(libPath, libPath.endsWith('.glb'));
         const buf = await fetchBytes(`/library/${url}`);
         work.phase('queued');
         return await enqueue(async () => {
@@ -775,7 +796,7 @@ export async function primeFiles(paths, { concurrency = 6 } = {}) {
         // cache (§16.2.B), and every toolkit module see the same identities —
         // the bytes just arrive GPU-native, and loadImageTexture sniffs the
         // container magic to tell which shape it got.
-        const url = ktx2Capable() && /\.(png|jpe?g)$/i.test(p) ? withKtx2(p) : p;
+        const url = await negotiated(p, /\.(png|jpe?g)$/i.test(p));
         const buf = await fetchBytes(`/library/${url}`);
         denoFiles.set(p, new Uint8Array(buf));
       } catch (e) { missing.push(p); }

--- a/client/lib/prefetch.js
+++ b/client/lib/prefetch.js
@@ -21,11 +21,11 @@
 //      policy — assets that get USED are the ones that stay warm, and a newly
 //      needed asset displaces stale speculative ones by construction.
 
-import { withKtx2 } from '../../shared/ktx2.js';
+import { negotiate } from '../../shared/ktx2.js';
 import { bus, CONFIG, report } from './core.js';
 import { whenBooted } from './boot.js';
 import { whenCalm } from './governor.js';
-import { demandState, listLibrary, ktx2Capable } from './assets.js';
+import { demandState, listLibrary, ktx2Capable, ktx2KeyReady } from './assets.js';
 
 const QUIET_MS = 1500;      // demand-free time required before (re)taking the wire
 const SESSION_CAP = 600e6;  // max bytes streamed per session — a long visit warms a lot, a peek doesn't
@@ -94,6 +94,9 @@ async function quotaTight() {
 async function buildQueue() {
   const q = [];
   const seen = new Set();
+  // the running sequencer's key, or null — the same answer every demand
+  // fetch gets, so warmth lands in the same cache entry (assets.js)
+  const key = ktx2Capable() ? await ktx2KeyReady : null;
   const push = (path, size = 0) => {
     let url = path.startsWith('/') ? path : `/library/${path}`;
     // Warm the SAME cache key demand fetches will use (§20c gate finding):
@@ -104,9 +107,9 @@ async function buildQueue() {
     // other images are consumed unflagged, and flagging them here would be
     // the same wasted-warmth bug in the other direction.
     const bare = url.split('?')[0];
-    if (ktx2Capable() && (/\.(glb|vrm)$/.test(bare)
+    if (key && (/\.(glb|vrm)$/.test(bare)
       || (/^\/library\/eidoverse\/assets\/(grass|sky|particle_textures)\//.test(bare) && /\.(png|jpe?g)$/i.test(bare)))) {
-      url = withKtx2(url);
+      url = negotiate(url, key);
     }
     if (!seen.has(url) && seen.add(url)) q.push({ url, size });
   };

--- a/docs/ktx2-encoder.md
+++ b/docs/ktx2-encoder.md
@@ -73,11 +73,17 @@ lands.
 ## Either platform
 
 The negotiation key a client sends (`?ktx2=<key>`) is a generation, defined
-once in `shared/ktx2.js` and imported by both the client and the sequencer.
-Bump it when a flagged answer has been served with the wrong caching — the
-old key's cache entries are simply never asked for again (a purge cannot
-reach browsers). The fall-through answer under the current key is served
-`no-cache` until a variant exists, then the variant is served immutable.
+once in `shared/ktx2.js` and **published by the running sequencer on
+`/version`** (`ktx2Key`, no-store). The browser uses only what `/version`
+handed it — never the served file: in the `git pull` → restart window the old
+process serves the new file, and a client that read the key off disk asked a
+server that did not know it and got pinned (the =2 collision, 2026-08-24).
+No key on `/version` (an older sequencer) means the client does not negotiate
+at all, which is always safe. Bump the key when a flagged answer has been
+served with the wrong caching — the old key's cache entries are simply never
+asked for again (a purge cannot reach browsers). The fall-through answer under
+the current key is served `no-cache` until a variant exists, then the variant
+is served immutable.
 
 `KTX2_TOKTX` may point at either `toktx` or the newer `ktx` binary — the
 probe (`findKtx2Encoder`) detects which by name. Without the env it also

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,7 +14,7 @@ import { join, normalize } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ROOT, WORLDS_DIR, LIBRARY_DIR, OPT_DIR, PATCH_DIR, JOIN_TOKEN } from "./config.ts";
 import { isStoreOriginal, isServingArtifact } from "./store-variants.ts";
-import { wantsKtx2 } from "../shared/ktx2.js";
+import { wantsKtx2, KTX2_KEY } from "../shared/ktx2.js";
 import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_ISSUER_KEY, HN_ISS, HN_AUD, HN_LOGIN_URL, HN_REQUIRE_LOGIN } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
@@ -440,10 +440,15 @@ const ROUTES: Route[] = [
     // challenge-response the SERVER answers is the portable proof; the OS check
     // stays as a second, stricter opinion where the platform offers one.
     match: (u) => u.pathname === "/version",
+    // `ktx2Key` is the negotiation key THIS process imported at boot — the
+    // only key a browser may use (shared/ktx2.js: a client that reads it off
+    // the served file instead asks a server that may not know it yet, and
+    // nginx pins the wrong answer — the =2 collision). no-store, so it is
+    // always the running process answering, never nginx remembering one.
     handler: () => new Response(
       JSON.stringify(process.env.WORLD_INSTANCE_NONCE
-        ? { ...BUILD, instance: process.env.WORLD_INSTANCE_NONCE }
-        : BUILD),
+        ? { ...BUILD, ktx2Key: KTX2_KEY, instance: process.env.WORLD_INSTANCE_NONCE }
+        : { ...BUILD, ktx2Key: KTX2_KEY }),
       { headers: { "content-type": "application/json", "cache-control": "no-store" } }),
   },
   {

--- a/shared/ktx2.js
+++ b/shared/ktx2.js
@@ -1,17 +1,28 @@
-// ktx2 — the texture negotiation KEY, one constant both sides import.
+// ktx2 — the texture negotiation KEY: defined here, PUBLISHED by the running
+// sequencer, and only ever used by a client that got it from that sequencer.
 //
 // A KTX2-capable client asks for a library or store asset with ?ktx2=<key>
 // and the sequencer answers with the GPU-native variant when one exists, the
 // original otherwise (routes.ts, the §20 negotiation). The key is a
-// GENERATION, not a boolean, and it lives here rather than as a literal in
-// four client fetch sites and one server branch, because rotating it is the
-// only way to walk away from a poisoned cache: an answer served
-// `max-age=31536000, immutable` under ?ktx2=1 — which is what every store
-// upload's flagged answer WAS, webp included (2026-08-24, the show box) —
-// never revalidates, not in a browser, not in nginx (it keys on the full
-// query string), no matter what the origin says afterwards. A fresh key is
-// a fresh cache entry everywhere at once; the old one simply stops being
-// asked for. Bump this when a flagged answer has been pinned wrong.
+// GENERATION, not a boolean: rotating it is the only way to walk away from a
+// poisoned cache — an answer served `max-age=31536000, immutable` under an
+// old key never revalidates, not in a browser, not in nginx (it keys on the
+// full query string), no matter what the origin says afterwards. A fresh key
+// is a fresh cache entry everywhere at once; the old one simply stops being
+// asked for.
+//
+// WHO READS IT is the second half of the contract, learned on rollout day.
+// The sequencer imports this file at boot. The browser used to import it too
+// — off the sequencer's DISK — and in the window between `git pull` and the
+// restart the old process was serving the new file: a client read key 2 off
+// disk and asked a server that had never heard of it, which answered as if
+// unflagged (webp, immutable), and nginx pinned that under ?ktx2=2. The =2
+// generation was retired within minutes of being born. So the browser no
+// longer reads the key from any file: it asks the RUNNING process (/version
+// carries `ktx2Key`, no-store, resolved at that process's boot) and uses
+// exactly what it was handed. No key handed — an older sequencer, a failed
+// fetch — means NO negotiation: an unflagged fetch is always the right answer
+// for its URL, so nothing can be pinned wrong, on any deploy, in any order.
 //
 // Generations: 1 — the §20 launch key (2026-08-10), retired 2026-08-24 because
 // provisional fall-throughs had been served immutable under it. 2 — the PR #142
@@ -27,8 +38,25 @@ export function wantsKtx2(params) {
   return params.get('ktx2') === KTX2_KEY;
 }
 
-/** Append the negotiation to a URL that may already carry a query
- *  (avatar URLs carry ?v=<mtime>). */
+/** The key the running sequencer published, read off its /version body —
+ *  or null when it published none (an older sequencer, or not JSON at all),
+ *  which the client must treat as "do not negotiate". Never a default. */
+export function keyFromVersion(json) {
+  const k = json && typeof json === 'object' ? json.ktx2Key : undefined;
+  return typeof k === 'string' && /^[A-Za-z0-9._-]{1,32}$/.test(k) ? k : null;
+}
+
+/** Append the negotiation to a URL that may already carry a query (avatar
+ *  URLs carry ?v=<mtime>) — with the key GIVEN, which for a browser is the
+ *  one /version handed it. No key → the URL untouched: an unflagged fetch. */
+export function negotiate(url, key) {
+  if (!key) return url;
+  return url + (url.includes('?') ? '&' : '?') + `ktx2=${key}`;
+}
+
+/** The sequencer's own spelling (tests, tools): negotiate with the key this
+ *  file defines. A BROWSER must not call this — it would be reading the key
+ *  off disk again, which is the collision. */
 export function withKtx2(url) {
-  return url + (url.includes('?') ? '&' : '?') + KTX2_QUERY;
+  return negotiate(url, KTX2_KEY);
 }

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -15,7 +15,9 @@
 // enumerated as an asset, not by the store catalog (/library-models), not by
 // the listing the prefetcher warms from (/library-list), not by the boot
 // sweep; the negotiation key is a GENERATION (shared/ktx2.js): the current
-// key negotiates, a retired one is an unflagged fetch; and a flagged fetch
+// key negotiates, a retired one is an unflagged fetch, and a browser only
+// ever uses the key the RUNNING sequencer published on /version — none
+// published, none used (the rollout collision, made impossible); and a flagged fetch
 // answered by the webp shadow is PROVISIONAL — no-cache, never immutable —
 // so the variant's bytes get through the moment it exists, which the
 // If-None-Match round-trip here demonstrates.
@@ -45,7 +47,7 @@ import { Document, NodeIO } from "@gltf-transform/core";
 import { PNG } from "pngjs";
 import { isStoreOriginal, isKtx2Variant, isServingArtifact, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX } from "../server/store-variants.ts";
 import { findKtx2Encoder, isKtx2Container } from "../server/optimize.ts";
-import { KTX2_KEY, KTX2_QUERY, wantsKtx2, withKtx2 } from "../shared/ktx2.js";
+import { KTX2_KEY, KTX2_QUERY, wantsKtx2, withKtx2, keyFromVersion, negotiate } from "../shared/ktx2.js";
 
 let failures = 0;
 const check = (label: string, ok: boolean, detail?: string) => {
@@ -109,6 +111,18 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts, shared/ktx2.js):\n");
   check("no key does not", !wantsKtx2(new URLSearchParams("v=123")));
   check("withKtx2 appends with ? on a bare path", withKtx2("store/x.glb") === "store/x.glb?ktx2=3");
   check("…and with & when ?v= is already there (avatar URLs)", withKtx2("eidoverse/assets/vrms/a.vrm?v=9") === "eidoverse/assets/vrms/a.vrm?v=9&ktx2=3");
+
+  // The browser's half: the key it uses is the one the RUNNING sequencer
+  // published on /version — never one read off a served file.
+  check("keyFromVersion reads the published key", keyFromVersion({ sha: "abc", ktx2Key: "3" }) === "3");
+  check("…an older sequencer publishes none → null (the rollout collision, made impossible)", keyFromVersion({ sha: "abc", commitTime: "…" }) === null);
+  check("…garbage is not a key", keyFromVersion(null) === null && keyFromVersion("3") === null && keyFromVersion({ ktx2Key: "" }) === null && keyFromVersion({ ktx2Key: "a b?" }) === null);
+  check("negotiate with a key appends it", negotiate("store/x.glb", "3") === "store/x.glb?ktx2=3" && negotiate("a.vrm?v=9", "3") === "a.vrm?v=9&ktx2=3");
+  check("negotiate with NO key is the bare URL — an unflagged fetch, never pinned wrong", negotiate("store/x.glb", null) === "store/x.glb");
+  // the collision itself, as a table: what the client asked vs what the server knew
+  const onDisk = "2", running = null;                   // pull landed, restart pending
+  check("rollout window: the client, taking the key from /version, does not negotiate (old: it asked ?ktx2=2 off disk and got pinned)",
+    negotiate("store/x.glb", keyFromVersion({ sha: "old", ktx2Key: running })) === "store/x.glb" && onDisk !== running);
 }
 
 // ---------------------------------------------- 2. the ghost-listing rule
@@ -374,7 +388,9 @@ async function startServer(extra: Record<string, string | undefined>) {
     return { status: res.status, body: res.ok ? await res.json() : await res.text() };
   };
   const stop = async () => { try { proc.kill(); } catch { /* gone */ } live = null; await sleep(300); };
-  return { up, PORT, base, get, upload, stop, log: () => log };
+  // the key THIS child publishes — what a browser would use (assets.js)
+  const key = up ? keyFromVersion(await fetch(`${base}/version`).then((r) => r.json()).catch(() => null)) : null;
+  return { up, PORT, base, get, upload, stop, log: () => log, key };
 }
 const same = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
 const whichFile = (b: Uint8Array) => { try { return String(glbJson(b).nodes?.[0]?.name ?? "?").split("-")[0]; } catch { return "unparseable"; } };
@@ -387,6 +403,7 @@ console.log("\n  the real sequencer — an upload becomes a served variant:");
   if (S.up) {
     const glb = await fixtureGlb("uploaded", 2);
     const hash = hashOf(glb); mine.add(hash);
+    check("the running sequencer publishes its key on /version — the one a browser negotiates with", S.key === KTX2_KEY, `published ${S.key}, defined ${KTX2_KEY}`);
     const up = await S.upload(glb, "store-variants-test");
     check("POST /upload landed it content-addressed", up.status === 200 && up.body?.path === `store/${hash}.glb`, `${up.status} ${JSON.stringify(up.body)}`);
     // ownership: only the tree we spawned from holds this run's fixture
@@ -398,14 +415,14 @@ console.log("\n  the real sequencer — an upload becomes a served variant:");
       // The pump runs store-min then --ktx2, serially, off the request path.
       // Until the variant lands, the flagged answer is whatever the unflagged
       // one is, marked provisional; once it lands, the variant, immutable.
-      const early = await S.get(withKtx2(`store/${hash}.glb`));
+      const early = await S.get(negotiate(`store/${hash}.glb`, S.key));
       const earlyIsVariant = isKtx2Glb(early.bytes);
       check("a flagged fetch is answered either way, and its caching says which", early.status === 200
         && (earlyIsVariant ? early.cc.includes("immutable") : early.cc === "no-cache"), `variant=${earlyIsVariant} cc=${early.cc}`);
       const landed = await until(() => existsSync(ktx2VariantPath(join(STORE, `${hash}.glb`))), 30_000);
       check("the queue built the KTX2 shadow beside the original", landed, ktx2VariantPath(join(STORE, `${hash}.glb`)));
       check("…and it says so in the sequencer's log", /\[ktx2\] .*→ .*\.ktx2\.glb/.test(S.log()), S.log().split("\n").filter((l) => l.includes("ktx2")).join(" | "));
-      const flagged = await S.get(withKtx2(`store/${hash}.glb`));
+      const flagged = await S.get(negotiate(`store/${hash}.glb`, S.key));
       check("flagged (current key) → the variant, really KTX2, immutable", flagged.status === 200 && isKtx2Glb(flagged.bytes) && flagged.cc.includes("immutable"),
         `cc=${flagged.cc} ktx2=${isKtx2Glb(flagged.bytes)}`);
       const retired = await S.get(`store/${hash}.glb?ktx2=2`);
@@ -459,7 +476,7 @@ console.log("\n  the boot sweep — a partial conversion is refused, retryably:"
     check("…no variant written", !existsSync(join(STORE, `${hash}.glb.ktx2.glb`)));
     check("…and NO .failed marker — environmental, retried next boot", !existsSync(join(STORE, `${hash}.glb.ktx2.glb.failed`)));
     check("…and no ktx2Skip: the encoder is there (no 'no encoder' line)", !/no encoder/.test(S.log()));
-    const flagged = await S.get(withKtx2(`store/${hash}.glb`));
+    const flagged = await S.get(negotiate(`store/${hash}.glb`, S.key));
     check("meanwhile a flagged fetch falls through, provisional (no-cache) — not pinned", flagged.status === 200 && !isKtx2Glb(flagged.bytes) && flagged.cc === "no-cache", flagged.cc);
   }
   await S.stop();
@@ -500,17 +517,17 @@ console.log("\n  the swap a browser makes when the variant lands:");
   const S = await startServer(NO_ENCODER);
   check("child server came up", S.up, `:${S.PORT}`);
   if (S.up) {
-    const before = await S.get(withKtx2(`store/${hash}.glb`));
+    const before = await S.get(negotiate(`store/${hash}.glb`, S.key));
     check("no variant yet: flagged → the original, no-cache, with an ETag", before.status === 200 && same(before.bytes, glb) && before.cc === "no-cache" && before.etag !== "",
       `cc=${before.cc} etag=${before.etag}`);
-    const revalidated = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": before.etag });
+    const revalidated = await S.get(negotiate(`store/${hash}.glb`, S.key), { "if-none-match": before.etag });
     check("revalidating while nothing changed is a 304 (no body), still no-cache", revalidated.status === 304 && revalidated.cc === "no-cache", `${revalidated.status} ${revalidated.cc}`);
     writeFileSync(ktx2VariantPath(join(STORE, `${hash}.glb`)), variant);   // the variant lands
-    const swapped = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": before.etag });
+    const swapped = await S.get(negotiate(`store/${hash}.glb`, S.key), { "if-none-match": before.etag });
     check("the variant landed: the same If-None-Match now gets a 200 with the VARIANT — the swap", swapped.status === 200 && same(swapped.bytes, variant),
       `${swapped.status} file=${whichFile(swapped.bytes)}`);
     check("…immutable from here on, under a new ETag", swapped.cc.includes("immutable") && swapped.etag !== before.etag, `cc=${swapped.cc}`);
-    const settled = await S.get(withKtx2(`store/${hash}.glb`), { "if-none-match": swapped.etag });
+    const settled = await S.get(negotiate(`store/${hash}.glb`, S.key), { "if-none-match": swapped.etag });
     check("…and revalidating the variant is a 304 that says immutable", settled.status === 304 && settled.cc.includes("immutable"), `${settled.status} ${settled.cc}`);
     const bare = await S.get(`store/${hash}.glb`);
     check("the unflagged answer never moved: the original, immutable — the address IS content-addressed", same(bare.bytes, glb) && bare.cc.includes("immutable"), bare.cc);

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -17,7 +17,8 @@
 // sweep; the negotiation key is a GENERATION (shared/ktx2.js): the current
 // key negotiates, a retired one is an unflagged fetch, and a browser only
 // ever uses the key the RUNNING sequencer published on /version — none
-// published, none used (the rollout collision, made impossible); and a flagged fetch
+// published, none used — and section 8 replays the collision itself as a canary:
+// a pull landing under a running sequencer cannot poison the next key; and a flagged fetch
 // answered by the webp shadow is PROVISIONAL — no-cache, never immutable —
 // so the variant's bytes get through the moment it exists, which the
 // If-None-Match round-trip here demonstrates.
@@ -533,6 +534,55 @@ console.log("\n  the swap a browser makes when the variant lands:");
     check("the unflagged answer never moved: the original, immutable — the address IS content-addressed", same(bare.bytes, glb) && bare.cc.includes("immutable"), bare.cc);
   }
   await S.stop();
+}
+
+// ---------------------------------------------- 8. the canary — pull before restart cannot poison
+// The =2 incident, replayed: a sequencer is RUNNING, then `git pull` lands a
+// shared/ktx2.js with a new key on its disk. The old process keeps serving
+// that new file (/shared/ktx2.js) while its own key — the one it imported at
+// boot — is unchanged. A client that read the key off the served file asked
+// with the new key and got pinned; a client that reads /version asks with
+// the running key and is answered correctly. Both fetches are made here, so
+// the poison is demonstrated, not assumed. The served file is rewritten IN
+// PLACE for the duration and restored byte-for-byte (finally + exit hook).
+console.log("\n  the canary — a pull lands under a running sequencer:");
+{
+  const SHARED = join(ROOT, "shared", "ktx2.js");
+  const pristine = readFileSync(SHARED);
+  const restore = () => { try { writeFileSync(SHARED, pristine); } catch { /* best effort */ } };
+  process.on("exit", restore);
+  const glb = await fixtureGlb("canary", 1);
+  const variant = await fixtureGlb("canary-variant", 1, true);
+  const hash = hashOf(glb); mine.add(hash);
+  writeFileSync(join(STORE, `${hash}.glb`), glb);
+  writeFileSync(ktx2VariantPath(join(STORE, `${hash}.glb`)), variant);
+  writeFileSync(join(STORE_MIN, `${hash}.glb.failed`), "fixture");
+  const S = await startServer(NO_ENCODER);
+  check("child server came up — with the PRISTINE key in memory", S.up && S.key === KTX2_KEY, `${S.up} key=${S.key}`);
+  try {
+    if (S.up) {
+      const NEXT = "99";   // the pulled generation, not yet running anywhere
+      const bumped = pristine.toString("utf8").replace(`export const KTX2_KEY = '${KTX2_KEY}';`, `export const KTX2_KEY = '${NEXT}';`);
+      check("(fixture) the pull rewrites the key on disk", bumped !== pristine.toString("utf8"));
+      writeFileSync(SHARED, bumped);
+      const served = await fetch(`${S.base}/shared/ktx2.js`, { cache: "no-store" }).then((r) => r.text());
+      check("the running sequencer now SERVES the pulled file — key 99 — to any client that reads it", served.includes(`KTX2_KEY = '${NEXT}'`));
+      const version = keyFromVersion(await fetch(`${S.base}/version`).then((r) => r.json()));
+      check("…but /version still publishes the key the process RUNS with", version === KTX2_KEY, `published ${version}`);
+      // the new client: keyed from /version
+      const good = await S.get(negotiate(`store/${hash}.glb`, version));
+      check("a client keyed from /version asks with the running key → the variant, immutable: correct", good.status === 200 && same(good.bytes, variant) && good.cc.includes("immutable"), `file=${whichFile(good.bytes)} cc=${good.cc}`);
+      // the old client: keyed off the served file — the incident
+      const bad = await S.get(negotiate(`store/${hash}.glb`, NEXT));
+      check("a client keyed off the served file asks ?ktx2=99 → the server does not know it: unflagged, NOT the variant, immutable — this is the poison, and it would have been pinned under the NEXT generation before it ever ran",
+        bad.status === 200 && !same(bad.bytes, variant) && bad.cc.includes("immutable"), `file=${whichFile(bad.bytes)} cc=${bad.cc}`);
+      check("the two answers differ — the split brain is real, and only the on-disk path walks into it", good.etag !== bad.etag);
+    }
+  } finally {
+    restore();
+    await S.stop();
+  }
+  check("the served file is restored byte-for-byte", same(new Uint8Array(readFileSync(SHARED)), new Uint8Array(pristine)));
 }
 
 cleanup();


### PR DESCRIPTION
Mica, Antra — the follow-up from the `=2` collision (89d72f5), as agreed in-world: the browser takes the negotiation key from the **running** sequencer, never from a file it merely serves.

## The window this closes

Between `git pull` and the restart, the old process serves the new `shared/ktx2.js`. A client that read key 2 off that file asked a server that had never heard of it; the server answered as if unflagged — webp, immutable — and nginx pinned it under `?ktx2=2`. Rotating to 3 was the right emergency lever; this makes the emergency impossible.

## Mica's four conditions, point by point

1. **The capability response is `no-store`** — it *is* `/version`, which already was. `ktx2Key` rides in that body.
2. **Bound to the same server/build epoch** — same document as `sha` / `commitTime` / `startedAt`: one fetch, one epoch, resolved at *that* process's boot. There is no second document that could drift from the first.
3. **Fails safely to unflagged originals** — `keyFromVersion` returns a validated key or `null`, never a default; `negotiate(url, null)` is the bare URL. An older sequencer (no field), a failed fetch, a garbage body → the client does not negotiate at all, which is always the right answer for an unflagged URL.
4. **A canary proving pull-before-restart cannot poison the next key** — `tools/store-variants-test.ts` §8 replays the incident against a live child: the sequencer runs with key 3; the test rewrites `shared/ktx2.js` on its disk to key 99 (the pull); `/shared/ktx2.js` now serves 99 while `/version` still publishes 3; a client keyed from `/version` gets the variant, immutable; a client keyed off the served file asks `?ktx2=99` and gets unflagged-immutable — the poison, demonstrated, and never asked for by the new path. The file is restored byte-for-byte (`finally` + exit hook).

The static constant stays as the server's definition and the tests' fixture; `withKtx2` says in its comment that a browser must not call it.

## What changes

- **`server/routes.ts`**: `/version` publishes `ktx2Key`.
- **`shared/ktx2.js`**: `keyFromVersion(json)`, `negotiate(url, key)`; contract restated in the header.
- **`client/lib/assets.js`**: `ktx2KeyReady` — one `no-store` fetch of `/version` per page, awaited by the three negotiating loads (all async already).
- **`client/lib/prefetch.js`**: awaits the same key once before building its queue — warmth lands in the same cache entry as demand fetches, or nowhere flagged at all.
- `docs/ktx2-encoder.md`: the contract, restated.

Server-side negotiation (`wantsKtx2`, provisional/immutable, variants) is untouched. Key rotation remains the lever for a poisoned cache; it just no longer needs a coordinated restart to be safe.

## Receipts

`bun tools/store-variants-test.ts` — **99/99**, no encoder needed. New since #142:
- `keyFromVersion`: the published key; an older sequencer's `/version` → `null`; garbage → `null`.
- `negotiate`: `?`/`&` appending; **no key → the bare URL**.
- every real-sequencer section now takes its key from the child's `/version` the way a browser does, asserts it equals the definition, and negotiates with *that* — upload→queue→variant, boot sweep, `ktx2Skip`, and the `If-None-Match` swap all pass under the browser's actual path.
- **§8, the canary** (above).

Also: `deps-route-test` 13/13; `bun build` and a transpile of the client modules clean; `git diff --check` clean; the tree is clean after the run (the canary's rewrite restored, fixtures and manifest entries removed).

Field receipt: this branch's sequencer, opened in a real Chrome on the sponsor's machine — `/version` answered `{"sha":…,"startedAt":"2026-08-25T05:55:36.978Z","ktx2Key":"3"}` to the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R65fLki4fxEvDbCL2hT9JF
