### PR TITLE
ktx2: the store variant keeps the shadow's texel budget — and a size verdict carries its recipe

### DIFF
--- a/server/optimize.ts
+++ b/server/optimize.ts
@@ -27,6 +27,7 @@ import { NodeIO, type Document } from "@gltf-transform/core";
 import { ALL_EXTENSIONS, KHRTextureBasisu } from "@gltf-transform/extensions";
 import { dedup, prune, resample, textureCompress, draco, listTextureSlots } from "@gltf-transform/functions";
 import draco3d from "draco3dgltf";
+import { capTexels, recipeStamp } from "./store-variants.ts";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, basename, dirname } from "node:path";
@@ -195,10 +196,14 @@ const COLOR_SLOT = /baseColor|emissive/i;
  *  (λ=1.0, quality-preserving) + zstd 18 — raw UASTC is a flat 8bpp and zstd
  *  alone barely dents it (the crow's 2048² maps came out 2.6× the JPEG
  *  source; RDO is what makes zstd bite). --genmipmap always: compressed mips
- *  can't be generated at runtime. */
-function ktx2EncodeArgs(encoder: string, isToktx: boolean, srgb: boolean, uastc: boolean, inPath: string, outPath: string): string[] {
+ *  can't be generated at runtime. `resize` (the GLB arm's texel budget,
+ *  store-variants.ts capTexels) rides toktx's own --resize — the encoder
+ *  scales before it generates mips, and libvips is nowhere in the loop. */
+function ktx2EncodeArgs(encoder: string, isToktx: boolean, srgb: boolean, uastc: boolean, inPath: string, outPath: string,
+  resize: [number, number] | null = null): string[] {
   return isToktx
     ? [encoder, "--t2", "--genmipmap", "--assign_oetf", srgb ? "srgb" : "linear",
+       ...(resize ? ["--resize", `${resize[0]}x${resize[1]}`] : []),
        ...(uastc ? ["--encode", "uastc", "--uastc_quality", "2", "--uastc_rdo_l", "1.0", "--zcmp", "18"]
                  : ["--encode", "etc1s", "--qlevel", "128"]),
        outPath, inPath]
@@ -273,7 +278,10 @@ async function ktx2CompressTextures(doc: Document, encoder: string): Promise<Ktx
         failed.push(label); continue;
       }
       const outPath = join(tmp, `${i}.ktx2`);
-      const args = ktx2EncodeArgs(encoder, isToktx, srgb, uastc, inPath, outPath);
+      // the house texel budget: the shadow's 1024², never more (store-variants.ts)
+      const resize = capTexels(size as [number, number] | null);
+      if (resize && !isToktx) console.error(`[optimize] ktx2: ${label} is ${size![0]}x${size![1]} — ktx create has no --resize here, encoding at source size`);
+      const args = ktx2EncodeArgs(encoder, isToktx, srgb, uastc, inPath, outPath, isToktx ? resize : null);
       const proc = Bun.spawn(args, { stdout: "ignore", stderr: "pipe" });
       const code = await proc.exited;
       const err = (await new Response(proc.stderr).text()).trim();
@@ -906,7 +914,9 @@ if (import.meta.main) {
     // VRAM), not just wire bytes — accept anything not grossly bigger than
     // the ORIGINAL source (>1.25×).
     if (out.length >= src.length * (ktx2Mode ? 1.25 : 0.95)) {
-      console.error(`[optimize] not smaller (${src.length} -> ${out.length}, ${ms}ms) — keeping original`);
+      // the KTX2 verdict carries its recipe: a later recipe re-measures it
+      // (store-variants.ts verdictStands) instead of inheriting the refusal
+      console.error(`[optimize] not smaller (${src.length} -> ${out.length}, ${ms}ms)${ktx2Mode ? ` ${recipeStamp()}` : ""} — keeping original`);
       process.exit(2);
     }
     // …and the same care about CONTENT: a GLB whose images are not images is

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -37,11 +37,55 @@
 //
 // DOM-free and side-effect-free: unit-tested in tools/store-variants-test.ts.
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 
 /** The variant suffix. `<hash>.glb` + this = the KTX2 shadow's file name. */
 export const KTX2_SUFFIX = ".ktx2.glb";
+
+// ---- the texel budget ------------------------------------------------------
+// The unflagged answer — the webp shadow every client without a KTX2 decoder
+// gets — is capped at 1024² (optimize.ts, `resize: [1024, 1024]`; the
+// library's day-one mirror is "draco+webp@1024" too). That is the house
+// budget: what a model is allowed to look like in this world. The KTX2 arm
+// used to encode from the full-resolution source instead — a Tripo conjure's
+// 2048² maps, three of them, two UASTC — and the "variant" came out 1.5× the
+// ORIGINAL on the wire (the show box, 2026-08-25: `not smaller (17600988 ->
+// 26716692)`, sixteen times over), which the size gate rightly refused. A
+// flagged fetch was a silent quality UPGRADE over the unflagged one at ~13×
+// the bytes of the webp shadow. So: same budget as the shadow, GPU-native —
+// downscale (never up) so the longest side is KTX2_TEXEL_CAP, 4-aligned for
+// the block format. toktx does it (--resize) and libvips never touches it.
+export const KTX2_TEXEL_CAP = 1024;
+
+/** The resize a texture of `size` needs to fit the budget, or null when it
+ *  already does. Aspect kept; both sides rounded to a multiple of 4. */
+export function capTexels(size: [number, number] | null | undefined, cap = KTX2_TEXEL_CAP): [number, number] | null {
+  if (!size || !(size[0] > 0) || !(size[1] > 0)) return null;
+  const [w, h] = size;
+  if (w <= cap && h <= cap) return null;
+  const k = cap / Math.max(w, h);
+  const r = (v: number) => Math.max(4, Math.round((v * k) / 4) * 4);
+  return [r(w), r(h)];
+}
+
+// A size-gate verdict (`.failed` = "not smaller") is only as durable as the
+// RECIPE that produced it: change the recipe and every refusal is a question
+// again. So the CLI stamps the recipe into the verdict, and the sweeps treat
+// a size verdict without the CURRENT stamp as stale — re-measured once, then
+// re-stamped. The sixteen refusals above get retried the first boot after
+// this lands, with no operator step. Content verdicts ("no convertible raster
+// images", a corrupt container) carry no stamp and stand.
+export const KTX2_RECIPE = "texel1024";
+export const recipeStamp = (recipe = KTX2_RECIPE) => `recipe=${recipe}`;
+
+/** Does a `.failed` verdict still stand under the current recipe? A size
+ *  verdict ("not smaller") stands only if it carries the current stamp;
+ *  anything else stands regardless. */
+export function verdictStands(content: string, recipe = KTX2_RECIPE): boolean {
+  if (!/not smaller/i.test(content)) return true;
+  return content.includes(recipeStamp(recipe));
+}
 
 /** Any KTX2 serving artifact, of any asset class: `<rel>.ktx2.glb` (models,
  *  library and store), `<rel>.ktx2.vrm` (bodies, §20c), `<img>.ktx2` (loose
@@ -77,17 +121,20 @@ export function ktx2VariantPath(original: string): string {
 
 /** Which shadows a store original still lacks. A `.failed` marker counts as
  *  present — the pass already gave its answer (not smaller / not convertible)
- *  and the sweep must not re-measure it every boot. `exists` is injectable
- *  for tests; production passes nothing and reads the disk. */
+ *  and the sweep must not re-measure it every boot — EXCEPT a KTX2 size
+ *  verdict from an older recipe (verdictStands), which is a question again.
+ *  `exists`/`read` are injectable for tests; production reads the disk. */
 export function storeShadowsMissing(
   original: string,
   minDir: string,
   exists: (p: string) => boolean = existsSync,
+  read: (p: string) => string = (p) => { try { return readFileSync(p, "utf8"); } catch { return ""; } },
 ): { min: boolean; ktx2: boolean } {
   const min = join(minDir, basename(original));
   const k = ktx2VariantPath(original);
+  const kFailed = `${k}.failed`;
   return {
     min: !exists(min) && !exists(`${min}.failed`),
-    ktx2: !exists(k) && !exists(`${k}.failed`),
+    ktx2: !exists(k) && !(exists(kFailed) && verdictStands(read(kFailed))),
   };
 }

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -6,10 +6,10 @@
 // the deferred boot sweep that queues whatever accumulated while the server
 // was down. routes.ts delegates the endpoint here; nothing else changes hands.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync, rmSync } from "node:fs";
 import { join, basename, dirname, relative } from "node:path";
 import { JOIN_TOKEN, UPLOAD_CAP, ROOT, OPT_DIR, STORE_MIN, LIBRARY_DIR } from "./config.ts";
-import { isStoreOriginal, ktx2VariantPath, storeShadowsMissing } from "./store-variants.ts";
+import { isStoreOriginal, ktx2VariantPath, storeShadowsMissing, verdictStands } from "./store-variants.ts";
 import { agentTokens, HN_ISSUER_KEY, HN_ISS, HN_AUD } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { worlds } from "./world.ts";
@@ -56,7 +56,9 @@ async function pumpOptimize() {
       const { src, dest, mode } = optQueue.shift()!;
       const base = basename(src);                      // <hash>.glb / <model>.glb
       const failed = `${dest}.failed`;
-      if (!existsSync(src) || existsSync(failed)) continue;
+      // a KTX2 size verdict from an older recipe does not stand (store-variants.ts)
+      const refused = existsSync(failed) && (!mode || verdictStands(readFileSync(failed, "utf8")));
+      if (!existsSync(src) || refused) continue;
       // Store shadows are content-addressed — existing means done forever.
       // KTX2 variants shadow MUTABLE library files, so a variant older than
       // its source rebuilds (the sweep filters too, but a file can change
@@ -69,6 +71,8 @@ async function pumpOptimize() {
       const code = await proc.exited;
       const err = (await new Response(proc.stderr).text()).trim();
       if (code === 0) {
+        // a verdict that was re-measured and answered differently is history
+        if (existsSync(failed)) try { rmSync(failed); } catch { /* best effort */ }
         const ratio = (Bun.file(src).size / Math.max(1, Bun.file(dest).size)).toFixed(1);
         console.log(mode ? `[ktx2] ${base} → ${basename(dest)} (${ratio}x)` : `[store] optimized ${base} (${ratio}x)`);
       } else if (code === 2) {
@@ -166,7 +170,7 @@ setTimeout(() => {
       // a loose image's variant IS the ktx2 (<rel>.ktx2 — routes.ts serves it
       // as image/ktx2)
       const dest = join(OPT_DIR, mode === "--ktx2-img" ? `${rel}.ktx2` : `${rel}.ktx2${ext}`);
-      if (existsSync(`${dest}.failed`)) continue;
+      if (existsSync(`${dest}.failed`) && verdictStands(readFileSync(`${dest}.failed`, "utf8"))) continue;
       // mtime, not mere existence: library files are mutable — an updated
       // model/body/texture rebuilds its variant next boot
       if (existsSync(dest) && statSync(dest).mtimeMs > statSync(p).mtimeMs) continue;

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -18,7 +18,11 @@
 // key negotiates, a retired one is an unflagged fetch, and a browser only
 // ever uses the key the RUNNING sequencer published on /version — none
 // published, none used — and section 8 replays the collision itself as a canary:
-// a pull landing under a running sequencer cannot poison the next key; and a flagged fetch
+// a pull landing under a running sequencer cannot poison the next key; the KTX2
+// arm keeps the shadow's TEXEL BUDGET (1024², capTexels → toktx --resize) so a
+// variant is never a 1.5× quality upgrade the size gate refuses, and a size
+// verdict carries its recipe (verdictStands) so a new recipe re-measures the
+// old refusals at the next boot; and a flagged fetch
 // answered by the webp shadow is PROVISIONAL — no-cache, never immutable —
 // so the variant's bytes get through the moment it exists, which the
 // If-None-Match round-trip here demonstrates.
@@ -46,7 +50,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Document, NodeIO } from "@gltf-transform/core";
 import { PNG } from "pngjs";
-import { isStoreOriginal, isKtx2Variant, isServingArtifact, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX } from "../server/store-variants.ts";
+import { isStoreOriginal, isKtx2Variant, isServingArtifact, ktx2VariantPath, storeShadowsMissing, KTX2_SUFFIX,
+  capTexels, verdictStands, recipeStamp, KTX2_TEXEL_CAP } from "../server/store-variants.ts";
 import { findKtx2Encoder, isKtx2Container } from "../server/optimize.ts";
 import { KTX2_KEY, KTX2_QUERY, wantsKtx2, withKtx2, keyFromVersion, negotiate } from "../shared/ktx2.js";
 
@@ -103,6 +108,32 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts, shared/ktx2.js):\n");
   check("a variant .failed counts as answered too", m.min && !m.ktx2);
   m = missing([join(minDir, `${hash}.glb`), ktx2VariantPath(original)]);
   check("both present → nothing to queue", !m.min && !m.ktx2);
+
+  // the texel budget: the shadow's 1024², never more, never UP
+  check("the budget is the webp shadow's 1024²", KTX2_TEXEL_CAP === 1024);
+  check("a 1024² texture is within budget — no resize", capTexels([1024, 1024]) === null);
+  check("a 512² texture is not upscaled", capTexels([512, 512]) === null);
+  check("2048² → 1024²", JSON.stringify(capTexels([2048, 2048])) === "[1024,1024]");
+  check("2048×1024 → 1024×512 (aspect kept)", JSON.stringify(capTexels([2048, 1024])) === "[1024,512]");
+  check("4096×3072 → 1024×768", JSON.stringify(capTexels([4096, 3072])) === "[1024,768]");
+  check("2048×1500 → 1024×752 (4-aligned for the block format)", JSON.stringify(capTexels([2048, 1500])) === "[1024,752]");
+  check("no size → no resize", capTexels(null) === null && capTexels([0, 0]) === null);
+
+  // the verdict: a size refusal is only as durable as its recipe
+  const prodMarker = "[optimize] not smaller (17600988 -> 26716692, 91234ms) — keeping original";   // the show box, 2026-08-25, ×16
+  check("the show box's sixteen refusals carry no stamp → stale, a question again", !verdictStands(prodMarker));
+  check("a refusal under the CURRENT recipe stands", verdictStands(`[optimize] not smaller (1 -> 2, 3ms) ${recipeStamp()} — keeping original`));
+  check("a refusal under an OLDER recipe does not", !verdictStands(`[optimize] not smaller (1 -> 2, 3ms) ${recipeStamp("texel2048")} — keeping original`));
+  check("a content verdict stands regardless (nothing to convert)", verdictStands("[optimize] ktx2: no convertible raster images (12ms) — keeping original"));
+  check("…and so does a hard failure", verdictStands("exit 1") && verdictStands(""));
+  {
+    const minDir2 = join(OPT, "store-min");
+    const marker = `${ktx2VariantPath(original)}.failed`;
+    const m1 = storeShadowsMissing(original, minDir2, (p) => p === marker, () => prodMarker);
+    check("storeShadowsMissing: a stale size verdict → the KTX2 shadow is MISSING (retry)", m1.ktx2);
+    const m2 = storeShadowsMissing(original, minDir2, (p) => p === marker, () => `not smaller ${recipeStamp()}`);
+    check("…a current one → not missing (no retry)", !m2.ktx2);
+  }
 
   // the negotiation key is a generation, shared by both sides
   check("the current key is 3 (1 and rollout-key 2 retired — their flagged answers had been pinned immutable)", KTX2_KEY === "3" && KTX2_QUERY === "ktx2=3");
@@ -173,12 +204,12 @@ function pngBytes(seed: number, W = 64): Uint8Array {
 }
 /** `textures`: 0 = untextured mesh, 1 = baseColor, 2 = baseColor + normal
  *  (the normal takes the UASTC branch — a different encoder argv). */
-async function fixtureGlb(tag: string, textures: 0 | 1 | 2, extraNode = false): Promise<Uint8Array> {
+async function fixtureGlb(tag: string, textures: 0 | 1 | 2, extraNode = false, texSize = 64): Promise<Uint8Array> {
   const doc = new Document();
   const buf = doc.createBuffer();
   const mat = doc.createMaterial("probeMat");
-  if (textures >= 1) mat.setBaseColorTexture(doc.createTexture("base").setImage(pngBytes(1)).setMimeType("image/png"));
-  if (textures >= 2) mat.setNormalTexture(doc.createTexture("normal").setImage(pngBytes(7)).setMimeType("image/png"));
+  if (textures >= 1) mat.setBaseColorTexture(doc.createTexture("base").setImage(pngBytes(1, texSize)).setMimeType("image/png"));
+  if (textures >= 2) mat.setNormalTexture(doc.createTexture("normal").setImage(pngBytes(7, texSize)).setMimeType("image/png"));
   const prim = doc.createPrimitive().setMaterial(mat)
     .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf)
       .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])))
@@ -198,6 +229,17 @@ const hashOf = (b: Uint8Array) => new Bun.CryptoHasher("sha256").update(b).diges
 const glbJson = (bytes: Uint8Array) => {
   const dv = new DataView(bytes.buffer, bytes.byteOffset);
   return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + dv.getUint32(12, true))));
+};
+/** [pixelWidth, pixelHeight] of every embedded image, read off the KTX2
+ *  header (u32 at 20 and 24) — the encoder's own statement of the size. */
+const ktx2Dims = (bytes: Uint8Array): [number, number][] => {
+  const j = glbJson(bytes);
+  const dv = new DataView(bytes.buffer, bytes.byteOffset);
+  const jsonLen = dv.getUint32(12, true), binOff = 20 + jsonLen + 8;
+  return (j.images ?? []).map((im: any) => {
+    const v = j.bufferViews[im.bufferView], o = binOff + (v.byteOffset ?? 0);
+    return [dv.getUint32(o + 20, true), dv.getUint32(o + 24, true)] as [number, number];
+  });
 };
 const isKtx2Glb = (bytes: Uint8Array) => {
   try {
@@ -224,6 +266,7 @@ writeFileSync(FAKE_SCRIPT, `// fake toktx — argv shape is toktx's: [...flags, 
 const argv = process.argv.slice(2);
 const outPath = argv[argv.length - 2], inPath = argv[argv.length - 1];
 const mode = process.env.FAKE_TOKTX_MODE ?? "ok";
+if (process.env.FAKE_TOKTX_ARGLOG) (await import("node:fs")).appendFileSync(process.env.FAKE_TOKTX_ARGLOG, argv.join(" ") + String.fromCharCode(10));
 const counter = process.env.FAKE_TOKTX_COUNTER;
 let n = 1;
 if (counter) {
@@ -234,6 +277,10 @@ if (counter) {
 if (mode === "fail" || (mode === "fail-second" && n % 2 === 0)) { console.error("fake toktx: refusing " + inPath); process.exit(1); }
 const fs = await import("node:fs");
 if (mode === "garbage") { fs.writeFileSync(outPath, fs.readFileSync(inPath)); process.exit(0); }   // exit 0, bytes are the PNG
+if (mode === "bloat") {   // a real KTX2 header followed by a megabyte of padding — bigger than any fixture source
+  const canned = fs.readFileSync(new URL("./canned.ktx2", import.meta.url));
+  fs.writeFileSync(outPath, Buffer.concat([canned, Buffer.alloc(1 << 20)])); process.exit(0);
+}
 fs.copyFileSync(new URL("./canned.ktx2", import.meta.url), outPath);
 process.exit(0);
 `);
@@ -303,12 +350,31 @@ console.log("\n  the optimizer, against the fake encoder:");
     r = await runKtx2(one, ktx2VariantPath(one) + ".noenc", { KTX2_TOKTX: join(tmp, "no-such-toktx"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
     check("no encoder anywhere → exit 3 (the env-skip, unchanged)", r.code === 3 && !r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
 
+    // the texel budget, as the encoder is asked for it: a 2048² source gets
+    // --resize 1024x1024 in its argv, a 64² source does not
+    const big = place(await fixtureGlb("big", 2, false, 2048));
+    const arglog = join(tmp, "argv.log");
+    r = await runKtx2(big, ktx2VariantPath(big), { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok", FAKE_TOKTX_ARGLOG: arglog });
+    let argv = existsSync(arglog) ? readFileSync(arglog, "utf8") : "";
+    check("2048² textures: the encoder is asked to --resize 1024x1024, once per texture", r.code === 0 && (argv.match(/--resize 1024x1024/g) ?? []).length === 2, argv.trim().split("\n").map((l) => l.slice(0, 80)).join(" | "));
+    rmSync(arglog, { force: true });
+    r = await runKtx2(two, ktx2VariantPath(two) + ".small", { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok", FAKE_TOKTX_ARGLOG: arglog });
+    argv = existsSync(arglog) ? readFileSync(arglog, "utf8") : "";
+    check("64² textures: no --resize (never upscaled)", r.code === 0 && !argv.includes("--resize"));
+    // a size refusal names its recipe
+    r = await runKtx2(two, ktx2VariantPath(two) + ".bloat", { KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "bloat" });
+    check("a size refusal (exit 2) carries the recipe stamp — a later recipe can tell it is stale", r.code === 2 && !r.wrote && r.err.includes(recipeStamp()), `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
     const real = findKtx2Encoder();
     if (!real) console.log("  - real encoder: skipped — none on this box (KTX2_TOKTX / toktx / ktx; docs/ktx2-encoder.md)");
     else {
       r = await runKtx2(two, ktx2VariantPath(two) + ".real", { KTX2_TOKTX: real });
       check(`the real encoder (${real.split(/[\\/]/).pop()}): exit 0, a KTX2 variant`, r.code === 0 && r.wrote && isKtx2Glb(new Uint8Array(readFileSync(ktx2VariantPath(two) + ".real"))),
         `exit ${r.code}: ${r.err.split("\n").pop()}`);
+      r = await runKtx2(big, ktx2VariantPath(big) + ".real", { KTX2_TOKTX: real });
+      const dims = r.wrote ? ktx2Dims(new Uint8Array(readFileSync(ktx2VariantPath(big) + ".real"))) : [];
+      check("…and a 2048² source comes out 1024² in the KTX2 headers — the shadow's budget, GPU-native", r.code === 0 && dims.length === 2 && dims.every((d) => d[0] === 1024 && d[1] === 1024),
+        `exit ${r.code} dims=${JSON.stringify(dims)}`);
     }
   } finally { rmSync(tmp, { recursive: true, force: true }); }
 }
@@ -422,7 +488,9 @@ console.log("\n  the real sequencer — an upload becomes a served variant:");
         && (earlyIsVariant ? early.cc.includes("immutable") : early.cc === "no-cache"), `variant=${earlyIsVariant} cc=${early.cc}`);
       const landed = await until(() => existsSync(ktx2VariantPath(join(STORE, `${hash}.glb`))), 30_000);
       check("the queue built the KTX2 shadow beside the original", landed, ktx2VariantPath(join(STORE, `${hash}.glb`)));
-      check("…and it says so in the sequencer's log", /\[ktx2\] .*→ .*\.ktx2\.glb/.test(S.log()), S.log().split("\n").filter((l) => l.includes("ktx2")).join(" | "));
+      // the parent logs a beat after the child's rename lands the file — poll
+      const logged = await until(() => /\[ktx2\] .*→ .*\.ktx2\.glb/.test(S.log()), 5_000);
+      check("…and it says so in the sequencer's log", logged, S.log().split("\n").filter((l) => l.includes("ktx2")).join(" | "));
       const flagged = await S.get(negotiate(`store/${hash}.glb`, S.key));
       check("flagged (current key) → the variant, really KTX2, immutable", flagged.status === 200 && isKtx2Glb(flagged.bytes) && flagged.cc.includes("immutable"),
         `cc=${flagged.cc} ktx2=${isKtx2Glb(flagged.bytes)}`);
@@ -479,6 +547,36 @@ console.log("\n  the boot sweep — a partial conversion is refused, retryably:"
     check("…and no ktx2Skip: the encoder is there (no 'no encoder' line)", !/no encoder/.test(S.log()));
     const flagged = await S.get(negotiate(`store/${hash}.glb`, S.key));
     check("meanwhile a flagged fetch falls through, provisional (no-cache) — not pinned", flagged.status === 200 && !isKtx2Glb(flagged.bytes) && flagged.cc === "no-cache", flagged.cc);
+  }
+  await S.stop();
+}
+
+// ---------------------------------------------- 5b. the boot sweep re-measures a stale verdict — and only a stale one
+// The show box holds sixteen `not smaller` markers from the native-source
+// recipe. Under the texel budget they are questions again: the first boot
+// after this lands retries them, with no operator step. A verdict that
+// carries the current stamp is not retried.
+console.log("\n  the boot sweep — a stale size verdict is re-measured, a current one stands:");
+{
+  const stale = await fixtureGlb("stale", 1);
+  const current = await fixtureGlb("current", 1);
+  const hs = hashOf(stale), hc = hashOf(current); mine.add(hs); mine.add(hc);
+  writeFileSync(join(STORE, `${hs}.glb`), stale);
+  writeFileSync(join(STORE, `${hc}.glb`), current);
+  // both have a store-min verdict so only the KTX2 arm is in play
+  writeFileSync(join(STORE_MIN, `${hs}.glb.failed`), "fixture"); writeFileSync(join(STORE_MIN, `${hc}.glb.failed`), "fixture");
+  writeFileSync(`${ktx2VariantPath(join(STORE, `${hs}.glb`))}.failed`, "[optimize] not smaller (17600988 -> 26716692, 91234ms) — keeping original");   // prod's shape
+  writeFileSync(`${ktx2VariantPath(join(STORE, `${hc}.glb`))}.failed`, `[optimize] not smaller (1 -> 2, 3ms) ${recipeStamp()} — keeping original`);
+  const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX, FAKE_TOKTX_MODE: "ok" });
+  check("child server came up", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const landed = await until(() => existsSync(ktx2VariantPath(join(STORE, `${hs}.glb`))), 40_000);
+    check("the stale verdict was re-measured: its variant landed", landed);
+    check("…and the old verdict is gone (a landed variant retires it)", landed && !existsSync(`${ktx2VariantPath(join(STORE, `${hs}.glb`))}.failed`));
+    await sleep(1500);
+    check("the current verdict stands: no variant, marker intact", !existsSync(ktx2VariantPath(join(STORE, `${hc}.glb`))) && existsSync(`${ktx2VariantPath(join(STORE, `${hc}.glb`))}.failed`));
+    const flagged = await S.get(negotiate(`store/${hs}.glb`, S.key));
+    check("…and the re-measured one now serves its variant", flagged.status === 200 && isKtx2Glb(flagged.bytes));
   }
   await S.stop();
 }


### PR DESCRIPTION
Mica, Antra — the sixteen store models the sweep never converts. Preregistered in devchat; this is the branch.

## What the markers say

Sixteen `not smaller` verdicts, e.g. `17600988 -> 26716692` (Mica's journal check — my JPEG-decoder guess was wrong). The `--ktx2` diet encodes from the full-resolution source: a Tripo conjure's three 2048² maps, two of them UASTC (a flat 8 bpp before zstd), and the "variant" comes out **1.5× the original on the wire** — which the 1.25× gate rightly refuses, with a permanent marker, so the count never moves across restarts.

Meanwhile the **unflagged** answer — the webp shadow every non-KTX2 client gets — is capped at **1024²** (`optimize.ts`, `resize: [1024, 1024]`; the library's day-one mirror is "draco+webp@1024" too). The flagged fetch was a silent 2048² quality upgrade over it at ~13× the bytes of the shadow. Same texel budget as the shadow, GPU-native, is the fix.

## What changes

- **`store-variants.ts`**: `KTX2_TEXEL_CAP = 1024`; `capTexels(size)` → the resize that fits (aspect kept, 4-aligned for the block format, never *up*), or `null`. And a recipe stamp — `KTX2_RECIPE`, `recipeStamp()`, `verdictStands(content)`: a size verdict is only as durable as the recipe that produced it, so the CLI stamps it and the sweeps re-measure any size verdict without the current stamp. Content verdicts (nothing to convert, a corrupt container) stand regardless. `storeShadowsMissing` reads the marker for that.
- **`optimize.ts`**: `ktx2EncodeArgs` takes `resize` and rides toktx's own `--resize` (applied before mip generation; libvips nowhere in the loop; `ktx create` has no equivalent here and logs that it encoded at source size). The size-gate refusal prints the stamp.
- **`upload.ts`**: the pump and both sweeps ask `verdictStands`; a landed variant retires its old marker.

The sixteen get re-measured on the first boot after this lands — no operator step.

## Measured

The 34.5 MB library car (`inanna_tech_…_vehicle_car_light.glb`), same box, same toktx 4.4.2:

| recipe | variant | ratio | encode |
|---|---|---|---|
| native source (main) | 20.5 MB | 1.7× | 87 s |
| **texel budget** | **1.9 MB** | **18×** | **10 s** |

Every texture 1024² in its KTX2 header.

**Preregistered prediction** for `0445768…` (17,600,988 bytes; refused at 26,716,692): the branch's `--ktx2` produces a variant **under 6 MB**, every texture 1024² by header. If that misses, this PR is wrong.

## Receipts

`bun tools/store-variants-test.ts` — **123/123**, no encoder needed. New:
- `capTexels`: 1024² and 512² untouched; 2048² → 1024²; 2048×1024 → 1024×512; 4096×3072 → 1024×768; 2048×1500 → 1024×752 (4-aligned); null in → null out.
- `verdictStands`: the show box's own marker text → stale; a current-stamped one → stands; an older recipe's → stale; "no convertible raster images" and a hard failure → stand. `storeShadowsMissing` with an injected reader: stale → missing (retry), current → not.
- the fake encoder now logs its argv: a 2048² source gets `--resize 1024x1024` once per texture, a 64² source gets none; a "bloat" mode drives the size gate and asserts the stamp in the refusal.
- the real encoder (when present): a 2048² source comes out 1024² by KTX2 header.
- a real sequencer: two pre-placed originals, one with a prod-shaped stale marker, one with a current-stamped one — the boot sweep re-measures the first into a served variant and retires its marker; the second is untouched.

Also green: `one-libvips-test` 11/11, `deps-route-test` 13/13, `git diff --check`, tree clean after the run.

Scope note: the cap applies to the whole `--ktx2` arm, library included — existing library variants are not rebuilt (the sweep only rebuilds when the source is newer), so nothing served today changes; new or re-measured ones come out at the shadow's budget. If you'd rather the library keep source resolution, it's a one-line branch on `rel.startsWith("store/")` — say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R65fLki4fxEvDbCL2hT9JF
