### PR TITLE
foliage: the meadow can stand still now, and only for you

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.11.1",
         "playwright": "^1.62.1",
+        "ws": "^8.21.1",
       },
     },
   },

--- a/client/lib/build.js
+++ b/client/lib/build.js
@@ -15,6 +15,7 @@ import { loadGLB, libLabels, listLibrary } from './assets.js';
 import { makeLightGizmo } from './lights.js';
 import { entities, entityMeta, comps, findPart, editHolds } from './world.js';
 import { surfaceUnder, reindexCollider } from './colliders.js';
+import { getGrassMotion, setGrassMotion } from './terrain.js';
 import { heightAt, GRASS_QUALITY, getGrassQuality, setGrassQuality,
   getGrassDensity, getGrassShed, getGrassApplied } from './terrain.js';
 import { sendVerb, sendDrag } from './net.js';
@@ -1152,6 +1153,36 @@ function paintSky(body) {
   syncGrassRow();
   bus.on('grass-budget', syncGrassRow);   // governor sheds repaint immediately
   body.appendChild(gqRow);
+
+  // Whether YOUR meadow sways. A second local dial rather than a fifth rung on
+  // the cap: density and motion are different costs for different reasons —
+  // "my poor gpu" is one, "the swaying makes me ill" is another, and someone
+  // who wants a still meadow at full detail should not have to mow it to get
+  // one. Off/static/full (#42) are the two dials' named points, reachable here
+  // or as `/foliage full|static|off`.
+  const gm = document.createElement('input');
+  gm.type = 'checkbox';
+  gm.style.cssText = 'accent-color:var(--accent); margin:0;';
+  gm.setAttribute('aria-label', 'grass sway — local only, never shared with the world');
+  const gmRow = mkRow('sway⚙', gm);
+  const syncMotionRow = () => {
+    gm.checked = getGrassMotion() === 'on';
+    // Nothing is drawn at cap off, so nothing can sway: disable rather than
+    // offer a control that would silently do nothing.
+    const nothingToMove = getGrassQuality() === 'off';
+    gm.disabled = nothingToMove;
+    gmRow.title = nothingToMove
+      ? 'nothing to sway — the grass cap is off'
+      : `your meadow ${gm.checked ? 'sways' : 'is still'} — local setting, not shared with the world`;
+  };
+  gm.onchange = () => {
+    setGrassMotion(gm.checked ? 'on' : 'off');
+    syncMotionRow();
+    flashHint(`grass sway: ${gm.checked ? 'on' : 'off'} (yours only)`);
+  };
+  syncMotionRow();
+  bus.on('grass-budget', syncMotionRow);
+  body.appendChild(gmRow);
 
   // Render scale is YOURS too (§22k) — the whole frame's pixel budget, the
   // one lever a pixel-bound machine actually answers to (§22j's tables).

--- a/client/lib/chat.js
+++ b/client/lib/chat.js
@@ -690,6 +690,9 @@ function runCommand(raw) {
     case 'pushable':
       bus.emit('command', { cmd: 'pushable', arg });
       return true;
+    case 'foliage': case 'grass':
+      bus.emit('command', { cmd: 'foliage', arg });
+      return true;
     case 'eyes':
       bus.emit('command', { cmd: 'eyes', arg });
       return true;

--- a/client/lib/commands/handlers.js
+++ b/client/lib/commands/handlers.js
@@ -22,6 +22,10 @@ import { toggleHelp, flashHint } from '../ui.js';
 import { sceneAttach, sceneDetach } from '../scenegraph.js';
 import { EMOTE_ORDER, EMOTES } from '../avatar.js';
 import { setPushable, pushable } from '../consent.js';
+import {
+  GRASS_QUALITY, getGrassQuality, setGrassQuality, getGrassShed,
+  getGrassMotion, setGrassMotion, setFoliagePreset, getFoliagePreset,
+} from '../terrain.js';
 import { trySitOn } from '../localbody.js';
 import { getMe } from '../mybody.js';
 import { setMyReach, clearMyReach } from '../reachnet.js';
@@ -224,6 +228,34 @@ register('pushable', (arg) => {
   const v = (arg || '').trim().toLowerCase();
   if (v === 'on' || v === 'off') setPushable(v === 'on');
   return logChat('*', `shoves and blasts ${pushable() ? 'CAN' : 'can NOT'} knock you over${v ? '' : ' — /pushable on|off to change'}`);
+});
+
+// The meadow through YOUR eyes. Two local dials — how much is drawn (the
+// resident's cap, #60) and whether it sways — plus the three names #42 uses
+// for the points that matter: full, static, off.
+//
+// Nothing here is a verb. The shared field — species, seed, extent, who
+// planted it — is world state and stays exactly as its author left it; how
+// many blades this machine fills pixels with, and whether they move, is not
+// world state and never was. Another viewer standing beside you sees their
+// own answer, unchanged. (Proof, not assertion: tools/foliage-door-test.mjs.)
+register('foliage', (arg) => {
+  const v = (arg || '').trim().toLowerCase();
+  const say = () => {
+    const preset = getFoliagePreset();
+    const shed = getGrassShed();
+    return logChat('*', `your meadow: ${getGrassQuality()} · sway ${getGrassMotion()}`
+      + (preset ? ` (${preset})` : '')
+      + (shed < 1 ? ` — the auto governor is thinning to ×${shed}` : '')
+      + ' — yours only, never shared. /foliage full|static|off|medium|low|sway on|off');
+  };
+  if (!v) return say();
+  if (v === 'full' || v === 'static' || v === 'off') { setFoliagePreset(v); return say(); }
+  if (GRASS_QUALITY.includes(v)) { setGrassQuality(v); return say(); }
+  const m = /^(?:sway|motion|wind)\s+(on|off)$/.exec(v);
+  if (m) { setGrassMotion(m[1]); return say(); }
+  if (v === 'sway' || v === 'motion' || v === 'wind') { setGrassMotion(getGrassMotion() === 'on' ? 'off' : 'on'); return say(); }
+  return logChat('*', `no such foliage setting "${v}" — try full, static, off, medium, low, or sway on|off`);
 });
 
 register('boom', (arg) => {

--- a/client/lib/grass_quality.js
+++ b/client/lib/grass_quality.js
@@ -19,13 +19,32 @@
 export const GRASS_QUALITY = ['full', 'medium', 'low', 'off'];
 export const QUALITY_DENSITY = { full: 1, medium: 0.6, low: 0.35, off: 0 };
 
+// A SECOND local dial, orthogonal to the first: whether the meadow MOVES.
+//
+// The cap answers "how many blades does this machine fill pixels with". It
+// cannot answer "draw them, but stop them swaying", and that is a different
+// question with a different answer — a machine can be fill-bound or bound by
+// the per-vertex wind and pusher work, and #42's field evidence points at the
+// second (grass out of frame: 40fps → 120fps on an M3 Max). Density and motion
+// are not one ladder, so they are not modelled as one.
+//
+// The three names #42 asks about are POINTS in that two-dial space, not a
+// third dial:
+//   full   = cap 'full'  + motion on
+//   static = cap 'full'  + motion off      (drawn, not animated)
+//   off    = cap 'off'                     (not drawn; motion moot)
+export const GRASS_MOTION = ['on', 'off'];
+
 const KEY = 'ew-grass-quality';
+const MOTION_KEY = 'ew-grass-motion';
 
 /** The dial state. `store` is localStorage in the browser, anything with
  *  getItem/setItem in tests, or absent (state then lives for the session). */
 export function makeGrassQuality(store) {
   const saved = store?.getItem?.(KEY);
   let quality = GRASS_QUALITY.includes(saved) ? saved : 'full';
+  const savedMotion = store?.getItem?.(MOTION_KEY);
+  let motion = GRASS_MOTION.includes(savedMotion) ? savedMotion : 'on';
   let shed = 1;
   return {
     /** the resident's chosen level ('full' | 'medium' | 'low' | 'off') */
@@ -47,6 +66,34 @@ export function makeGrassQuality(store) {
     shedTo(f) {
       shed = Math.min(1, Math.max(0, Number.isFinite(f) ? f : 1));
       return shed;
+    },
+
+    /** does this viewer's meadow sway? ('on' | 'off') */
+    get motion() { return motion; },
+    setMotion(m) {
+      if (!GRASS_MOTION.includes(m)) return motion;
+      motion = m;
+      store?.setItem?.(MOTION_KEY, m);
+      return motion;
+    },
+    /** Nothing is drawn at cap 'off', so nothing can be animated either —
+     *  reporting motion 'on' for an invisible meadow would be a lie the UI
+     *  then has to explain. */
+    animates() { return motion === 'on' && this.effective() > 0; },
+
+    /** The preset an onlooker would name for the current pair, or null when
+     *  the two dials sit somewhere without a common name. */
+    preset() {
+      if (QUALITY_DENSITY[quality] <= 0) return 'off';
+      if (quality !== 'full') return null;
+      return motion === 'on' ? 'full' : 'static';
+    },
+    /** Apply one of #42's three names. Returns the pair it set. */
+    setPreset(name) {
+      if (name === 'off') this.setQuality('off');
+      else if (name === 'static') { this.setQuality('full'); this.setMotion('off'); }
+      else if (name === 'full') { this.setQuality('full'); this.setMotion('on'); }
+      return { quality, motion };
     },
   };
 }

--- a/client/lib/terrain.js
+++ b/client/lib/terrain.js
@@ -6,7 +6,8 @@
 
 import { scene, ground, grid, bus } from './core.js';
 import { retireField } from './flora_field.js';
-import { makeGrassQuality, GRASS_QUALITY } from './grass_quality.js';
+import { makeGrassQuality, GRASS_QUALITY, GRASS_MOTION } from './grass_quality.js';
+import { autoHooks, releaseHook } from './autohooks.js';
 
 let current = null;
 
@@ -74,8 +75,13 @@ export function setGrass(field) {
   currentGrass = field ?? null;
   // sticky budget: a machine that had to thin its meadow keeps it thin
   // across re-grows, instead of re-discovering the same slow frame rate —
-  // and a resident's chosen cap (persisted) survives them the same way
-  if (field && budget.effective() < 1) applyGrassBudget();
+  // and a resident's chosen cap (persisted) survives them the same way.
+  // The motion dial is sticky for the same reason and by the same route: a
+  // re-grow that quietly restarted the sway would undo the choice without
+  // saying so. (Both are re-applied against the NEW field — the old field's
+  // frozen hooks left with it, so the freeze state is rebuilt, not carried.)
+  frozenHooks = []; frozenWind = [];
+  if (field && (budget.effective() < 1 || !budget.animates())) applyGrassBudget();
 }
 export const clearGrass = () => setGrass(null);
 export const hasGrass = () => currentGrass !== null;
@@ -86,8 +92,60 @@ export const getGrassField = () => currentGrass;
 // shed (grass_quality.js owns the semantics — effective is their min).
 const budget = makeGrassQuality(globalThis.localStorage);
 
+// ---- the motion dial (the 'static' half of #42's off/static/full) ----------
+//
+// Freezing foliage animation must touch ONLY foliage. The engine's per-frame
+// hook array is shared with the sky and with every entity emitter, so the
+// coarse move — emptying it, which is what the grassdiag phase does for one
+// measured second — would stop the clouds and every particle system in the
+// world for as long as a resident left the setting on.
+//
+// So: by identity, and narrowly.
+//   · each stroke's own `update(t){ uT.value = t }` (vegetation.js) — the wind
+//     clock. Released from the array, put back on the way out.
+//   · that stroke's `base`/`gust` wind amplitudes, zeroed. Freezing the clock
+//     alone leaves the blades stopped mid-gust, leaning; zeroing the amplitude
+//     settles them upright, which is what "static" should look like.
+//
+// NOT frozen: the per-tile ticks. They re-settle LOD and visibility against
+// the camera, so freezing them leaves a stale meadow behind a walking viewer —
+// a still meadow is the ask, a wrong one is not. And not the pushers: a
+// motionless field that still parts around your feet is honest interaction,
+// not ambient animation.
+//
+// ⚠ This is a COMFORT setting, not established as a performance one. The
+// shader still evaluates its wind term with the amplitude at zero, and no
+// measurement on this hardware separates static from full (both sit on the
+// vsync interval — tools/receipts-42/). Claim what is measured: 'off' is the
+// lever that removes work.
+let frozenHooks = [];
+let frozenWind = [];   // [{ u, base, gust }] — the amplitudes we zeroed
+
+function applyGrassMotion() {
+  const want = budget.animates();
+  if (!currentGrass) { frozenHooks = []; frozenWind = []; return; }
+  const strokes = currentGrass._strokes ?? [];
+  if (!want && !frozenHooks.length && !frozenWind.length) {
+    for (const st of strokes) {
+      if (typeof st.update === 'function' && releaseHook(st.update)) frozenHooks.push(st.update);
+      const u = st.uniforms;
+      if (u?.base && u?.gust) {
+        frozenWind.push({ u, base: u.base.value, gust: u.gust.value });
+        u.base.value = 0; u.gust.value = 0;
+      }
+    }
+  } else if (want && (frozenHooks.length || frozenWind.length)) {
+    // plain push, not pushHostHook: these were never marked host-owned, and
+    // restoring must leave the array exactly as it was found
+    if (frozenHooks.length) autoHooks().push(...frozenHooks);
+    for (const f of frozenWind) { f.u.base.value = f.base; f.u.gust.value = f.gust; }
+    frozenHooks = []; frozenWind = [];
+  }
+}
+
 function applyGrassBudget() {
   const eff = budget.effective();
+  applyGrassMotion();
   if (currentGrass) {
     // `off` retires the draw entirely: count 0 stops the fill, and hiding the
     // group spares raycasts/shadows too. The field object stays whole — shared
@@ -176,4 +234,26 @@ export function setGrassQuality(q) {
 export const getGrassQuality = () => budget.quality;
 /** the governor's uncapped session dial, for inspection */
 export const getGrassShed = () => budget.shed;
-export { GRASS_QUALITY };
+
+/** The resident's second dial: does their meadow sway? Local, persisted,
+ *  never a verb — exactly like the cap. */
+export function setGrassMotion(m) {
+  const applied = budget.setMotion(m);
+  applyGrassBudget();
+  return applied;
+}
+export const getGrassMotion = () => budget.motion;
+/** Whether the meadow is animating right now — 'off' at cap 0, where there
+ *  is nothing drawn to animate. */
+export const grassAnimates = () => budget.animates();
+
+/** #42's three names, as one call. Returns the dial pair it landed on. */
+export function setFoliagePreset(name) {
+  const pair = budget.setPreset(name);
+  applyGrassBudget();
+  return pair;
+}
+/** The name for the current pair, or null when the dials sit between names. */
+export const getFoliagePreset = () => budget.preset();
+
+export { GRASS_QUALITY, GRASS_MOTION };

--- a/client/lib/terrain.js
+++ b/client/lib/terrain.js
@@ -126,8 +126,25 @@ function applyGrassMotion() {
   if (!currentGrass) { frozenHooks = []; frozenWind = []; return; }
   const strokes = currentGrass._strokes ?? [];
   if (!want && !frozenHooks.length && !frozenWind.length) {
+    // Record WHERE each hook sat, and take them out back-to-front so the
+    // recorded indices stay valid as the array shortens. Restoring by
+    // appending would have put them back in the array in a different order
+    // than it found them — the engine drains the list in order, and a claim
+    // that the array is restored as found has to be true rather than nearly
+    // true (#151 review).
+    const live = autoHooks();
+    const mine = [];
     for (const st of strokes) {
-      if (typeof st.update === 'function' && releaseHook(st.update)) frozenHooks.push(st.update);
+      if (typeof st.update !== 'function') continue;
+      const at = live.indexOf(st.update);
+      if (at >= 0) mine.push({ fn: st.update, at });
+    }
+    mine.sort((a, b) => b.at - a.at);
+    for (const h of mine) if (releaseHook(h.fn)) frozenHooks.push(h);
+    // Amplitudes are a separate pass over the strokes: a stroke can carry
+    // uniforms without having had a live hook to release, and folding the two
+    // loops together silently skipped its wind.
+    for (const st of strokes) {
       const u = st.uniforms;
       if (u?.base && u?.gust) {
         frozenWind.push({ u, base: u.base.value, gust: u.gust.value });
@@ -137,7 +154,13 @@ function applyGrassMotion() {
   } else if (want && (frozenHooks.length || frozenWind.length)) {
     // plain push, not pushHostHook: these were never marked host-owned, and
     // restoring must leave the array exactly as it was found
-    if (frozenHooks.length) autoHooks().push(...frozenHooks);
+    // ascending, so each splice lands before the ones still to come
+    if (frozenHooks.length) {
+      const live = autoHooks();
+      for (const h of [...frozenHooks].sort((a, b) => a.at - b.at)) {
+        live.splice(Math.min(h.at, live.length), 0, h.fn);
+      }
+    }
     for (const f of frozenWind) { f.u.base.value = f.base; f.u.gust.value = f.gust; }
     frozenHooks = []; frozenWind = [];
   }

--- a/docs/foliage-local-eye.md
+++ b/docs/foliage-local-eye.md
@@ -67,7 +67,11 @@ name — `medium` is a legitimate place to be, and it is not `static`.
 `terrain.js` `applyGrassMotion()`, narrowly and by identity:
 
 - each stroke's own wind-clock hook is **released from the shared array by
-  identity** (`autohooks.releaseHook`) and pushed back on the way out;
+  identity** (`autohooks.releaseHook`), with **its index recorded**, and spliced
+  back at that index on the way out. Hooks are taken out back-to-front so the
+  recorded indices stay valid, and put back front-to-back so each splice lands
+  before the ones still to come. The engine drains that array in order, so
+  "restored as found" has to include the order, not only the membership;
 - that stroke's `base` and `gust` wind amplitudes are **zeroed**, and restored
   to their exact prior values. Freezing the clock alone leaves the blades
   stopped mid-gust, leaning; zeroing amplitude settles them upright, which is
@@ -133,14 +137,48 @@ Three sources of truth, because a weaker one alone would pass a broken build:
    view moved would pass while proving nothing.
 
 ```bash
-node tools/foliage-door-test.mjs      # node, not bun — see docs/browser-perf-receipt.md
+node tools/foliage-door-test.mjs      # node, not bun — Playwright's launch hangs under bun on Windows
 ```
 
-**24 checks green on this branch** (`tools/receipts-foliage/door-on-branch.txt`).
+**Runtime:** node 18+. The global `WebSocket` only arrived in node 22, so the
+socket constructor is resolved through `tools/owned-lifecycle.mjs` — global
+where there is one, the `ws` package (a declared devDependency) where there is
+not. Verified by running the whole test on **node 20.20.2**, where it reports
+`ws package (node 20.20.2 has no global)` and passes.
 
-**Negative control: 13 named failures on `origin/main` `6006d6d`** with only the
-test file copied in (`door-fail-on-main.txt`) — no `/foliage` route, no motion
-dial, Ash's meadow does not go dark, the wind keeps blowing. The world-log
+**Lifecycle:** everything the run spawns — sequencer, seed socket, browser, both
+viewer contexts — is registered with one idempotent `Lifecycle` the moment it
+exists, bound to the process so a throw, a signal, or an unhandled rejection all
+unwind through the same owner. The child sequencer is **proven** ours by nonce
+echo (`EIDO_BOOT_NONCE` on `/version`), never inferred from a 200, and its port
+is checked free before spawning and after teardown.
+
+### The harness's own controls
+
+They run first, because a product receipt from a harness that cannot fail is
+not a receipt:
+
+1. **the runtime contract** — the global is deleted at runtime to reproduce node
+   20, and the `ws` fallback must carry the test. The file is also scanned for a
+   bare `new WebSocket(` reintroducing the defect.
+2. **ownership** — an impostor HTTP server answering a healthy 200 (and even a
+   `/version` without a nonce, and another echoing somebody else's) must all be
+   REFUSED. Generic HTTP readiness would have accepted the first one.
+3. **a pre-viewer failure** — a real throw right after the child is up, then a
+   TCP check proving the port is free and the child gone. `--fault=post-server`
+   runs the same thing as a by-hand leak check.
+
+**43 checks green on this branch**, on both runtimes:
+`door-on-branch.txt` (node 24.18.0) and `door-node20.txt` (node 20.20.2, the
+runtime the previous version died on). `lifecycle-fault.txt` carries the
+deliberate-fault run with the listener census before and after.
+
+**Negative control: 14 named failures on `origin/main` `6006d6d`** with only the
+test files copied in (`door-fail-on-main.txt`, also on node 20) — no `/foliage`
+route, no motion dial, Ash's meadow does not go dark, the wind keeps blowing,
+and the hook array never loses a member during `static` (5 → 5). The harness's
+own three controls PASS on main, which is right: they test the harness, not the
+feature. The world-log
 assertions *pass* on main, and should: a build with no local foliage control
 authors nothing because it can do nothing. Those passes are the invariant, not
 the feature.

--- a/docs/foliage-local-eye.md
+++ b/docs/foliage-local-eye.md
@@ -1,0 +1,169 @@
+# The local foliage eye — what already existed, and the one thing that didn't
+
+A viewer-local way to turn the meadow down was the ask. Most of it was already
+built. This documents what the source map found, what was actually missing, and
+how the missing piece was added without inventing a parallel control beside the
+one already shipping.
+
+## What already existed
+
+| control | where | scope | persisted | a verb? |
+|---|---|---|---|---|
+| resident's cap `full · medium · low · off` | `client/lib/grass_quality.js` — `makeGrassQuality`, `GRASS_QUALITY`, `QUALITY_DENSITY` | this browser | `ew-grass-quality` | **no** |
+| governor's shed | `client/lib/governor.js` → `terrain.setGrassDensity` | this session | no | no |
+| what the field draws | `terrain.js` `applyGrassBudget()` — `min(cap, shed)`; at `0` it sets `count 0` **and** hides the group | | | |
+| applied truth | `terrain.js` `getGrassApplied()`, `grassTiles()` | | | |
+| the `grass⚙` row | `client/lib/build.js` — select + aria-live state, repaints on the `grass-budget` bus event | | | |
+| **the field itself** | the `grass` verb — rank 2, owner-only (`server/rights.ts`) | **the world** | the world log | **yes** |
+| wind | each stroke's `update(t){ uT.value = t }`, pushed into `globalThis._autoParticleSystems` (the vegetation module) | per-frame hook | | |
+| pushers | `flora.js` `wirePushers`, gated by `freezePushers` | | | |
+| per-tile ticks | `f._tileTick` via `pushHostHook`, tracked on `field.autoHooks` | | | |
+| measurement-only levers | `forceBladeLod`, `setDiagDensityScope`, `grassdiag.js` (§22) | | | |
+
+`grass_quality.js` had already drawn the line this task is about, in its own
+header: *"Neither dial is ever a verb — the shared field (species, seed, extent,
+provenance) is world state; how many blades THIS machine fills pixels with is
+not."*
+
+So **off** and **full** were done. `off` was already the real thing — zero
+instances, group hidden, field object intact, shared state untouched.
+
+## What was missing
+
+**`static`.** There was no way to keep the meadow *drawn* and stop it *moving*.
+The only route to it was the diagnostic path, which empties
+`_autoParticleSystems` wholesale for a measured second — a bucket that also
+carries the sky and every entity emitter. Fine for four seconds of A/B; not
+something a resident can leave switched on.
+
+That is a real gap and not a cosmetic one. #42's own field evidence points at
+motion rather than fill: N8python's M3 Max sat at ~40fps with the meadow in
+frame and ~120 with it out, and grassdiag exists because the suspicion was the
+shader-side pusher displacement rather than the blades' pixels.
+
+## The addition — one dial, not a fifth rung
+
+Density and motion are different costs for different reasons. "My poor GPU" is
+one; "the swaying makes me ill" is another, and someone who wants a still
+meadow at full detail should not have to mow it to get one. So the cap keeps its
+four levels, and motion is a **second, orthogonal dial** — `on | off`, persisted
+under `ew-grass-motion`, alongside the cap and by exactly the same rules.
+
+#42's three names are then *points* in that two-dial space, not a third dial:
+
+| name | cap | motion |
+|---|---|---|
+| `full` | full | on |
+| `static` | full | **off** — drawn, not animated |
+| `off` | off | *moot: nothing drawn can move* |
+
+`animates()` returns false at cap `off` whatever the motion dial says, so no
+surface ever has to explain a meadow that claims to be swaying while invisible.
+`preset()` returns `null` when the two dials sit somewhere without a common
+name — `medium` is a legitimate place to be, and it is not `static`.
+
+### How the freeze is applied
+
+`terrain.js` `applyGrassMotion()`, narrowly and by identity:
+
+- each stroke's own wind-clock hook is **released from the shared array by
+  identity** (`autohooks.releaseHook`) and pushed back on the way out;
+- that stroke's `base` and `gust` wind amplitudes are **zeroed**, and restored
+  to their exact prior values. Freezing the clock alone leaves the blades
+  stopped mid-gust, leaning; zeroing amplitude settles them upright, which is
+  what "static" should look like.
+
+Deliberately **not** frozen:
+
+- **the per-tile ticks.** They re-settle LOD and visibility against the camera.
+  Freeze them and a walking viewer drags a stale meadow behind them — a still
+  meadow is the ask, a wrong one is not.
+- **the pushers.** A motionless field that still parts around your feet is
+  interaction, not ambient animation.
+- **anything that is not foliage.** Emptying `_autoParticleSystems` would stop
+  the clouds, the weather and every entity emitter in the world for as long as
+  one resident left one setting on.
+
+A re-grow re-applies the choice against the new field, the same way the cap is
+already sticky across re-grows: the old field's frozen hooks left with it, so
+the freeze is rebuilt rather than carried.
+
+### Honest limits
+
+**`static` is a comfort setting, not an established performance one.** The
+shader still evaluates its wind term with the amplitude at zero, and no
+measurement on this hardware separates static from full — both sit on the vsync
+interval (`tools/receipts-42/`). The lever that demonstrably removes work is
+`off`. Claiming otherwise would be inventing a benefit; if `static` should also
+be cheap, the next step is measuring whether a zero amplitude lets the compiler
+fold the wind term, on hardware where the frame is not already free.
+
+## The surface
+
+```
+/foliage                     what your meadow is doing, and how to change it
+/foliage full | static | off #42's three names
+/foliage medium | low        the cap's other rungs
+/foliage sway on|off         the motion dial alone
+```
+
+`/grass` is an alias. In the settings panel, `sway⚙` sits under `grass⚙`, is
+disabled when the cap is `off` (nothing to move), and repaints on the same
+`grass-budget` event.
+
+## The product-door test
+
+`tools/foliage-door-test.mjs` — the claim is a product claim, so the proof is a
+product proof. Two real viewers in one real world, one of them moves their dial
+through the real command path, and then the world and the other viewer are asked
+whether anything happened to them.
+
+Two separate browser **contexts**, not two tabs: `localStorage` is per origin,
+and two tabs of one profile share the resident's dial by design. Isolating them
+is what makes them two people rather than one person twice.
+
+Three sources of truth, because a weaker one alone would pass a broken build:
+
+1. **the world log on disk** — the world IS its log; if it did not grow, nothing
+   was authored. This is the load-bearing one, and it is checked byte-identical
+   from first assertion to last.
+2. **the other viewer's rendered meadow** — blades drawn, applied density, wind
+   amplitudes, their `localStorage` — read from their page, not inferred.
+3. **the acting viewer's own meadow, which must change.** A test where nobody's
+   view moved would pass while proving nothing.
+
+```bash
+node tools/foliage-door-test.mjs      # node, not bun — see docs/browser-perf-receipt.md
+```
+
+**24 checks green on this branch** (`tools/receipts-foliage/door-on-branch.txt`).
+
+**Negative control: 13 named failures on `origin/main` `6006d6d`** with only the
+test file copied in (`door-fail-on-main.txt`) — no `/foliage` route, no motion
+dial, Ash's meadow does not go dark, the wind keeps blowing. The world-log
+assertions *pass* on main, and should: a build with no local foliage control
+authors nothing because it can do nothing. Those passes are the invariant, not
+the feature.
+
+`tools/grass-quality-test.ts` covers the dial itself headless — **76 passed, 0
+failed**, including that `terrain.js` freezes by identity rather than by
+emptying the shared array, that the per-tile ticks are not in the freeze, and
+that the `/foliage` handler's own body sends no verb of any kind.
+
+## Open questions for review
+
+1. **Persistence.** The brief said "no durable state". This reads that as *no
+   shared* durable state and follows the shipped precedent — `consent.js` and
+   `grass_quality.js` are both `localStorage`-backed so a choice survives the
+   session that made it. If the intent was no persistence at all, dropping the
+   `ew-grass-motion` write is a one-line change; the test's "reload" section
+   then inverts.
+2. **`static` at other caps.** `preset()` currently names only `full`+motion.
+   `medium` with motion off is reachable and legal but unnamed. Should there be
+   a name for it, or is unnamed correct?
+3. **Whether `static` should be cheap.** See the honest limit above. If the
+   answer is yes, that is a measurement task on hardware where the frame is not
+   already free — not a change to this dial.
+4. **The sway row's placement.** It sits under `grass⚙` in the same panel. It
+   could instead be an accessibility setting, since motion sensitivity is the
+   strongest reason to want it.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.11.1",
-    "playwright": "^1.62.1"
+    "playwright": "^1.62.1",
+    "ws": "^8.21.1"
   }
 }

--- a/tools/foliage-door-test.mjs
+++ b/tools/foliage-door-test.mjs
@@ -11,8 +11,8 @@
 // broken build:
 //   · the WORLD LOG on disk — the world IS its log; if the log did not grow,
 //     nothing was authored. This is the load-bearing one.
-//   · the OTHER VIEWER's rendered meadow — blades drawn, applied density,
-//     motion — read from their page, not inferred.
+//   · the OTHER VIEWER's rendered meadow — blades drawn, applied density, wind
+//     amplitudes, hook array, localStorage — read from their page, not inferred.
 //   · the ACTING viewer's own meadow, which MUST change. A test where nobody's
 //     view moved would pass while proving nothing.
 //
@@ -20,29 +20,36 @@
 // two tabs of one profile share the resident's dial by design. Isolating them
 // is what makes them two people rather than one person twice.
 //
-// 🔴 node, not bun — Playwright's launch hangs under bun on Windows over
-// --remote-debugging-pipe (see docs/browser-perf-receipt.md).
+// RUNTIME AND LIFECYCLE (#151 review). The first version used the global
+// `WebSocket`, which arrived in node 22 — on the reviewer's node 20.20.2 it
+// died with `ReferenceError: WebSocket is not defined` AFTER spawning the
+// sequencer and BEFORE reaching its try/finally, leaving a bun process
+// listening on :9471 to be killed by hand. Both halves are fixed here: the
+// WebSocket is resolved portably, and everything spawned is registered with one
+// idempotent Lifecycle the moment it exists, bound to the process so a throw, a
+// signal or an unhandled rejection all unwind through the same owner. The child
+// is PROVEN ours by nonce echo rather than assumed from a 200.
 //
 //   node tools/foliage-door-test.mjs
-//   node tools/foliage-door-test.mjs --keep-open --browser=chrome
+//   node tools/foliage-door-test.mjs --keep-open
+//   node tools/foliage-door-test.mjs --fault=post-server   # by-hand leak check
+//
+// 🔴 node, not bun — Playwright's launch hangs under bun on Windows.
 
-import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { createServer } from 'node:http';
+import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { chromium } from 'playwright';
+import {
+  Lifecycle, ownedWorld, proveOurs, portIsOpen, resolveWebSocket, NODE_MIN_GLOBAL_WS,
+} from './owned-lifecycle.mjs';
 
 const argv = Object.fromEntries(process.argv.slice(2)
   .filter((a) => a.startsWith('--'))
   .map((a) => { const i = a.indexOf('='); return i < 0 ? [a.slice(2), 'true'] : [a.slice(2, i), a.slice(i + 1)]; }));
 
-const BROWSER = argv.browser ?? 'chrome';
-const KEY = 'door-test';
+const FAULT = argv.fault ?? null;
 const WORLD = `foliagedoor${Math.random().toString(36).slice(2, 7)}`;
-const PORT = 8990 + Math.floor(Math.random() * 500);
-const WORLDS = mkdtempSync(join(tmpdir(), 'foliage-door-'));
-const BUN = process.env.BUN_PATH || 'C:\\Users\\madal\\.bun\\bin\\bun.exe';
-const EIDO = process.env.EIDOVERSE_DIR || join(process.cwd(), '..', 'eidoverse-video');
 
 let failures = 0;
 const check = (label, ok, detail) => {
@@ -51,139 +58,237 @@ const check = (label, ok, detail) => {
 };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// ---- a world this run owns --------------------------------------------------
+// ============================================================================
+// CONTROLS — mutations of this harness's own contract, run FIRST. A product
+// receipt from a harness that cannot fail is not a receipt.
+// ============================================================================
 
-console.log(`\nfoliage door test — world "${WORLD}" on :${PORT}, worlds dir ${WORLDS}\n`);
-const srv = spawn(BUN, ['run', 'server/server.ts'], {
-  env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: KEY, WORLDS_DIR: WORLDS, EIDOVERSE_DIR: EIDO },
-  stdio: ['ignore', 'pipe', 'pipe'],
-});
-const srvOut = [];
-srv.stdout.on('data', (d) => srvOut.push(String(d)));
-srv.stderr.on('data', (d) => srvOut.push(String(d)));
+console.log('\n--- harness controls -------------------------------------------------');
 
-const origin = `http://127.0.0.1:${PORT}`;
-for (let i = 0; i < 80; i++) {
-  try { if ((await fetch(`${origin}/`)).ok) break; } catch { /* not up yet */ }
-  await sleep(250);
-}
-
-/** The world's log on disk — the only authority on what was authored. */
-const logPath = () => join(WORLDS, WORLD, 'log.jsonl');
-const logEntries = () => (existsSync(logPath())
-  ? readFileSync(logPath(), 'utf8').split('\n').filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean)
-  : []);
-
-// ---- plant a meadow, as its owner ------------------------------------------
-
+// ---- control 1: the runtime contract ---------------------------------------
+console.log('\nthe WebSocket contract, on this node and on node 20');
+let WS;
 {
-  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
-  const msgs = [];
-  ws.onmessage = (ev) => { try { msgs.push(JSON.parse(String(ev.data))); } catch { /* not ours */ } };
-  await new Promise((r) => { ws.onopen = r; });
-  ws.send(JSON.stringify({ type: 'join', token: KEY, name: 'planter', world: WORLD }));
-  for (let i = 0; i < 60 && !msgs.some((m) => m.type === 'snapshot'); i++) await sleep(100);
-  ws.send(JSON.stringify({ type: 'verb', verb: 'grass',
-    args: { species: 'grass', width: 60, depth: 60, center: [0, 0], density: 1, height: 0.42, wind: 1 } }));
-  await sleep(1200);
-  const refused = msgs.filter((m) => m.type === 'error');
-  if (refused.length) console.log('  ⚠ seed refusals:', JSON.stringify(refused.slice(0, 2)));
-  ws.close();
-}
+  const resolved = await resolveWebSocket();
+  WS = resolved.WebSocket;
+  check(`a WebSocket resolves here — ${resolved.source}`, typeof WS === 'function');
 
-// ---- two viewers, two profiles ---------------------------------------------
-
-const browser = await chromium.launch({ headless: false, channel: BROWSER, timeout: 90_000 });
-/** Poll from THIS side with page.evaluate.
- *
- *  page.waitForFunction with an ASYNC predicate resolved immediately here —
- *  the dynamic `import()` a terrain probe needs makes the predicate a promise,
- *  and the wait returned before a single blade was planted. Both viewers then
- *  baselined at zero and every later comparison was against nothing. Evaluate
- *  awaits properly; loop out here where the awaiting is not in doubt. */
-async function until(page, fn, label, ms = 180_000) {
-  const t0 = Date.now();
-  while (Date.now() - t0 < ms) {
-    if (await page.evaluate(fn)) return true;
-    await sleep(500);
+  // MUTATION: take the global away, which is exactly node 20's situation, and
+  // prove the fallback carries the door test rather than a ReferenceError.
+  const realGlobal = globalThis.WebSocket;
+  try {
+    delete globalThis.WebSocket;
+    const fallback = await resolveWebSocket();
+    check(`with no global WebSocket (node < ${NODE_MIN_GLOBAL_WS}) it falls back to the ws package`,
+      typeof fallback.WebSocket === 'function' && /ws package/.test(fallback.source), fallback.source);
+  } catch (e) {
+    check(`with no global WebSocket (node < ${NODE_MIN_GLOBAL_WS}) it falls back to the ws package`,
+      false, String(e.message ?? e).slice(0, 200));
+  } finally {
+    if (realGlobal) globalThis.WebSocket = realGlobal;
   }
-  throw new Error(`timed out after ${Math.round(ms / 1000)}s waiting for ${label}`);
+
+  // …and that THIS file uses the resolved constructor. A reintroduced bare
+  // `new WebSocket(...)` would pass on node 22 and fail on the house's node 20,
+  // which is precisely the defect being fixed.
+  // Comments are stripped first: the paragraph above NAMES the construct it
+  // forbids, and the first version of this check convicted its own prose.
+  const self = readFileSync(new URL(import.meta.url), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n').filter((l) => !/^\s*\/\//.test(l)).join('\n');
+  const bareGlobalUse = /(?<![.\w])new\s+WebSocket\s*\(/.test(self);
+  check('this file never reaches for the bare global WebSocket', !bareGlobalUse,
+    'use the constructor from resolveWebSocket(), not the global');
 }
 
-/** Is this page drawing a meadow yet? */
-const PLANTED = async () => {
-  const t = await import('/lib/terrain.js');
-  if (!t.hasGrass()) return false;
-  return (t.grassTiles().strokes ?? []).reduce((n, s) => n + (s.drawn ?? 0), 0) > 0;
-};
+// ---- control 2: an impostor cannot pass for our child -----------------------
+console.log('\nownership is proven, not inferred from a 200');
+{
+  const impostorLife = new Lifecycle({ bindSignals: false });
+  const healthyPort = 8899, wrongPort = 8898;
+  try {
+    const squatter = createServer((req, res) => {
+      if (req.url.startsWith('/version')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        return res.end('{"sha":"deadbee","dirty":false}');   // healthy, and not ours
+      }
+      res.writeHead(200); res.end('ok');
+    });
+    await new Promise((r) => squatter.listen(healthyPort, '127.0.0.1', r));
+    impostorLife.own('impostor', () => new Promise((r) => squatter.close(r)));
 
-/** A viewer is a CONTEXT: its own localStorage, so its own dial. */
-async function viewer(name) {
-  const ctx = await browser.newContext({ viewport: { width: 900, height: 640 } });
-  const page = await ctx.newPage();
-  await page.goto(`${origin}/?name=${name}&world=${WORLD}&key=${KEY}`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-  await until(page, () => (globalThis.EW?.renderer?.info?.render?.calls ?? 0) > 0, `${name} to draw`);
-  // hasGrass() is true the moment the FIELD object exists; its tiles are
-  // planted after that, and a baseline taken in the gap reads zero blades and
-  // an empty stroke list.
-  await until(page, PLANTED, `${name}'s meadow to plant`);
-  await sleep(1500);
-  return { name, ctx, page };
+    const generic = await fetch(`http://127.0.0.1:${healthyPort}/`).then((r) => r.ok).catch(() => false);
+    check('the impostor answers 200 — generic HTTP readiness would accept it', generic);
+
+    const noNonce = await proveOurs(`http://127.0.0.1:${healthyPort}`, 'our-nonce', { tries: 2, gapMs: 50 });
+    check('…but the nonce proof refuses it', !noNonce.ours && /no nonce field/.test(noNonce.reason), noNonce.reason);
+
+    const wrong = createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"nonce":"somebody-elses"}');
+    });
+    await new Promise((r) => wrong.listen(wrongPort, '127.0.0.1', r));
+    impostorLife.own('wrong-nonce', () => new Promise((r) => wrong.close(r)));
+    const mismatch = await proveOurs(`http://127.0.0.1:${wrongPort}`, 'our-nonce', { tries: 2, gapMs: 50 });
+    check("…and refuses a listener echoing somebody else's nonce",
+      !mismatch.ours && /wrong nonce/.test(mismatch.reason), mismatch.reason);
+  } finally {
+    await impostorLife.dispose('impostor control');
+  }
+  check('the control cleaned up after itself', !(await portIsOpen(healthyPort)));
 }
 
-/** Everything about this viewer's meadow that a person could see. */
-// Reads defensively: on a build without the motion dial this must produce
-// NAMED failures, not a stack trace. A negative control that crashes proves
-// only that it crashed.
-const meadow = (v) => v.page.evaluate(async () => {
-  const t = await import('/lib/terrain.js');
-  const call = (name, fallback = null) => { try { return t[name]?.() ?? fallback; } catch { return fallback; } };
-  const strokes = t.grassTiles().strokes ?? [];
-  const field = t.getGrassField();
-  return {
-    quality: call('getGrassQuality'), motion: call('getGrassMotion'), preset: call('getFoliagePreset'),
-    animates: call('grassAnimates'), density: call('getGrassDensity'),
-    applied: call('getGrassApplied')?.status ?? null,
-    // which of the dials this build even HAS — the control's first answer
-    surface: ['getGrassMotion', 'setGrassMotion', 'setFoliagePreset', 'getFoliagePreset', 'grassAnimates']
-      .filter((n) => typeof t[n] === 'function'),
-    visible: !!field?.mesh?.visible,
-    blades: field?.mesh?.visible ? strokes.reduce((n, s) => n + (s.drawn ?? 0), 0) : 0,
-    // the wind amplitudes the shader is actually reading
-    wind: (field?._strokes ?? []).map((st) => [st.uniforms?.base?.value ?? null, st.uniforms?.gust?.value ?? null]),
-    storage: { quality: localStorage.getItem('ew-grass-quality'), motion: localStorage.getItem('ew-grass-motion') },
-  };
-});
+// ---- control 3: a pre-viewer failure leaks nothing --------------------------
+console.log('\na failure before the viewers exist leaks no child');
+{
+  const life3 = new Lifecycle({ bindSignals: false });
+  let port = null, pid = null;
+  try {
+    const w = await ownedWorld(life3, { key: 'control' });
+    port = w.port; pid = w.childPid;
+    check(`a child came up and PROVED it is ours (:${port}, pid ${pid})`, !!w.origin);
+    check('…and the port really is listening', await portIsOpen(port));
+    // the exact shape of the reported leak: a throw after the spawn, before
+    // anything the old code had inside a try
+    throw new Error('injected pre-viewer failure');
+  } catch (e) {
+    check('the injected failure propagated',
+      /injected pre-viewer failure/.test(String(e.message ?? e)), String(e.message ?? e).slice(0, 140));
+  } finally {
+    await life3.dispose('control 3');
+  }
+  await sleep(700);
+  check('…and the child is gone: nothing listens on that port',
+    port !== null && !(await portIsOpen(port)), `:${port} still answers`);
+  const second = await new Lifecycle({ bindSignals: false }).dispose();
+  check('…and dispose is idempotent (a second call is a no-op)', Array.isArray(second) && second.length === 0);
+}
 
-/** Drive the REAL door: the slash command a resident types. */
-const say = (v, text) => v.page.evaluate(async (t) => {
-  const chat = await import('/lib/chat.js');
-  const fn = chat.handleCommand ?? chat.runCommand ?? chat.tryCommand ?? null;
-  if (fn) return { via: 'chat', handled: fn(t) };
-  const { bus } = await import('/lib/core.js');
-  const [cmd, ...rest] = t.replace(/^\//, '').split(/\s+/);
-  bus.emit('command', { cmd, arg: rest.join(' ') });
-  return { via: 'bus', handled: true };
-}, text);
+if (FAULT === 'post-server') {
+  console.log('\n--fault=post-server: failing deliberately after the child is up');
+  const lifeF = new Lifecycle();
+  const w = await ownedWorld(lifeF, { key: 'fault' });
+  console.log(`  child on :${w.port} pid ${w.childPid} — throwing now; nothing should survive it`);
+  try { throw new Error('deliberate --fault=post-server'); } finally { await lifeF.dispose('fault'); }
+}
 
-let A, B;
+// ============================================================================
+// THE PRODUCT DOOR
+// ============================================================================
+
+console.log('\n--- the product door -------------------------------------------------');
+
+const life = new Lifecycle();
+let world = null;
+
 try {
-  A = await viewer('ash');
-  B = await viewer('brook');
+  world = await ownedWorld(life, { key: 'door-test' });
+  console.log(`\nfoliage door test — world "${WORLD}" on :${world.port}, proven ours by nonce\n`);
+
+  const logPath = () => join(world.worldsDir, WORLD, 'log.jsonl');
+  const logEntries = () => (existsSync(logPath())
+    ? readFileSync(logPath(), 'utf8').split('\n').filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean)
+    : []);
+
+  // ---- plant a meadow, as its owner ----------------------------------------
+  {
+    const ws = new WS(`ws://127.0.0.1:${world.port}/ws`);
+    life.own('seed socket', () => { try { ws.close(); } catch { /* already closed */ } });
+    const msgs = [];
+    ws.onmessage = (ev) => { try { msgs.push(JSON.parse(String(ev.data))); } catch { /* not ours */ } };
+    await new Promise((res, rej) => {
+      ws.onopen = res;
+      ws.onerror = (e) => rej(new Error(`seed socket failed: ${String(e?.message ?? e)}`));
+    });
+    ws.send(JSON.stringify({ type: 'join', token: world.key, name: 'planter', world: WORLD }));
+    for (let i = 0; i < 80 && !msgs.some((m) => m.type === 'snapshot'); i++) await sleep(100);
+    if (!msgs.some((m) => m.type === 'snapshot')) throw new Error('the seed socket never received a snapshot');
+    ws.send(JSON.stringify({ type: 'verb', verb: 'grass',
+      args: { species: 'grass', width: 60, depth: 60, center: [0, 0], density: 1, height: 0.42, wind: 1 } }));
+    await sleep(1500);
+    const refused = msgs.filter((m) => m.type === 'error');
+    if (refused.length) console.log('  ⚠ seed refusals:', JSON.stringify(refused.slice(0, 2)));
+    ws.close();
+  }
+
+  if (FAULT === 'pre-viewer') throw new Error('deliberate --fault=pre-viewer (seeded, no browser yet)');
+
+  // ---- two viewers, two profiles -------------------------------------------
+  const browser = await chromium.launch({ headless: false, channel: argv.browser ?? 'chrome', timeout: 90_000 });
+  life.own('browser', () => browser.close());
+
+  const PLANTED = async () => {
+    const t = await import('/lib/terrain.js');
+    if (!t.hasGrass()) return false;
+    return (t.grassTiles().strokes ?? []).reduce((n, s) => n + (s.drawn ?? 0), 0) > 0;
+  };
+  // page.waitForFunction with an ASYNC predicate resolves immediately (the
+  // dynamic import a terrain probe needs makes the predicate a promise), so
+  // both viewers once baselined at zero blades. Poll from this side instead.
+  const until = async (page, fn, label, ms = 180_000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) { if (await page.evaluate(fn)) return true; await sleep(500); }
+    throw new Error(`timed out waiting for ${label}`);
+  };
+  async function viewer(nm) {
+    const ctx = await browser.newContext({ viewport: { width: 900, height: 640 } });
+    life.own(`viewer ${nm}`, () => ctx.close());
+    const page = await ctx.newPage();
+    await page.goto(`${world.origin}/?name=${nm}&world=${WORLD}&key=${world.key}`,
+      { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await until(page, () => (globalThis.EW?.renderer?.info?.render?.triangles ?? 0) > 0, `${nm} to draw`);
+    await until(page, PLANTED, `${nm}'s meadow to plant`);
+    await sleep(1500);
+    return { name: nm, ctx, page };
+  }
+
+  // Reads defensively: on a build without the motion dial this must produce
+  // NAMED failures, not a stack trace.
+  const meadow = (v) => v.page.evaluate(async () => {
+    const t = await import('/lib/terrain.js');
+    const { autoHooks } = await import('/lib/autohooks.js');
+    const call = (n, fb = null) => { try { return t[n]?.() ?? fb; } catch { return fb; } };
+    const field = t.getGrassField();
+    const strokes = t.grassTiles().strokes ?? [];
+    return {
+      quality: call('getGrassQuality'), motion: call('getGrassMotion'), preset: call('getFoliagePreset'),
+      animates: call('grassAnimates'), density: call('getGrassDensity'),
+      applied: call('getGrassApplied')?.status ?? null,
+      surface: ['getGrassMotion', 'setGrassMotion', 'setFoliagePreset', 'getFoliagePreset', 'grassAnimates']
+        .filter((n) => typeof t[n] === 'function'),
+      visible: !!field?.mesh?.visible,
+      blades: field?.mesh?.visible ? strokes.reduce((n, s) => n + (s.drawn ?? 0), 0) : 0,
+      wind: (field?._strokes ?? []).map((st) => [st.uniforms?.base?.value ?? null, st.uniforms?.gust?.value ?? null]),
+      // the exact contents AND ORDER of the shared per-frame hook array
+      hookOrder: autoHooks().map((fn) => fn.name || 'anon'),
+      hookCount: autoHooks().length,
+      storage: { quality: localStorage.getItem('ew-grass-quality'), motion: localStorage.getItem('ew-grass-motion') },
+    };
+  });
+
+  const say = (v, text) => v.page.evaluate(async (t) => {
+    const chat = await import('/lib/chat.js');
+    const fn = chat.handleCommand ?? chat.runCommand ?? chat.tryCommand ?? null;
+    if (fn) return { via: 'chat', handled: fn(t) };
+    const { bus } = await import('/lib/core.js');
+    const [cmd, ...rest] = t.replace(/^\//, '').split(/\s+/);
+    bus.emit('command', { cmd, arg: rest.join(' ') });
+    return { via: 'bus', handled: true };
+  }, text);
+
+  const A = await viewer('ash');
+  const B = await viewer('brook');
   console.log('two viewers standing in one meadow\n');
 
-  // runCommand is module-local to chat.js, so the driver dispatches on the bus
-  // — the same event chat.js emits. Check the typed alias exists too, or the
-  // test would pass for a command no resident can actually reach.
-  const chatSrc = await (await fetch(`${origin}/lib/chat.js`)).text();
-  check("chat.js routes a typed /foliage to the handler", /case 'foliage'/.test(chatSrc));
-  check("…and /grass as its alias", /case 'grass'/.test(chatSrc));
+  const chatSrc = await (await fetch(`${world.origin}/lib/chat.js`)).text();
+  check('chat.js routes a typed /foliage to the handler', /case 'foliage'/.test(chatSrc));
+  check('…and /grass as its alias', /case 'grass'/.test(chatSrc));
 
   const logBefore = logEntries();
   const bBefore = await meadow(B);
   const aBefore = await meadow(A);
-  check('this build has the local motion dial at all',
-    aBefore.surface.length === 5, `only: ${JSON.stringify(aBefore.surface)}`);
+  check('this build has the local motion dial at all', aBefore.surface.length === 5, JSON.stringify(aBefore.surface));
   check('both viewers start from the same meadow',
     aBefore.blades > 0 && aBefore.blades === bBefore.blades, `${aBefore.blades} vs ${bBefore.blades}`);
   check('both start animating', aBefore.animates && bBefore.animates);
@@ -196,17 +301,18 @@ try {
   const log1 = logEntries();
 
   check(`the command reached a handler (via ${r1.via})`, r1.handled !== false);
-  check("ASH's meadow went dark", a1.blades === 0 && !a1.visible, JSON.stringify({ blades: a1.blades, visible: a1.visible }));
+  check("ASH's meadow went dark", a1.blades === 0 && !a1.visible,
+    JSON.stringify({ blades: a1.blades, visible: a1.visible }));
   check("BROOK's meadow is untouched", b1.blades === bBefore.blades && b1.visible,
     `${bBefore.blades} → ${b1.blades}`);
   check("BROOK's dials never moved", b1.quality === bBefore.quality && b1.motion === bBefore.motion,
     `${bBefore.quality}/${bBefore.motion} → ${b1.quality}/${b1.motion}`);
   check('the WORLD LOG did not grow', log1.length === logBefore.length,
     `${logBefore.length} → ${log1.length}: ${JSON.stringify(log1.slice(logBefore.length).map((e) => e.verb))}`);
-  check('no grass verb was authored', log1.filter((e) => e.verb === 'grass').length
-    === logBefore.filter((e) => e.verb === 'grass').length);
-  check("BROOK's browser storage is untouched", JSON.stringify(b1.storage) === JSON.stringify(bBefore.storage),
-    JSON.stringify(b1.storage));
+  check('no grass verb was authored',
+    log1.filter((e) => e.verb === 'grass').length === logBefore.filter((e) => e.verb === 'grass').length);
+  check("BROOK's browser storage is untouched",
+    JSON.stringify(b1.storage) === JSON.stringify(bBefore.storage), JSON.stringify(b1.storage));
 
   // ---- 2. static ------------------------------------------------------------
   console.log('\nash types /foliage static');
@@ -216,13 +322,16 @@ try {
   const log2 = logEntries();
 
   check('ASH sees the meadow again', a2.blades > 0 && a2.visible, `${a2.blades} blades`);
-  check('…and it is STILL: wind amplitude zeroed', a2.wind.length > 0 && a2.wind.every(([b, g]) => b === 0 && g === 0),
-    JSON.stringify(a2.wind));
+  check('…and it is STILL: wind amplitude zeroed',
+    a2.wind.length > 0 && a2.wind.every(([b, g]) => b === 0 && g === 0), JSON.stringify(a2.wind));
   check('…and it reads as the static preset', a2.preset === 'static' && a2.animates === false,
     `${a2.preset}/${a2.animates}`);
-  check("BROOK's wind is still blowing", b2.wind.length > 0 && b2.wind.some(([b, g]) => b > 0 || g > 0),
-    JSON.stringify(b2.wind));
+  check("BROOK's wind is still blowing",
+    b2.wind.length > 0 && b2.wind.some(([b, g]) => b > 0 || g > 0), JSON.stringify(b2.wind));
   check("BROOK's meadow is still untouched", b2.blades === bBefore.blades && b2.animates);
+  check("…and BROOK's hook array was never touched",
+    JSON.stringify(b2.hookOrder) === JSON.stringify(bBefore.hookOrder),
+    `${JSON.stringify(bBefore.hookOrder)} → ${JSON.stringify(b2.hookOrder)}`);
   check('the WORLD LOG still did not grow', log2.length === logBefore.length,
     `${logBefore.length} → ${log2.length}`);
 
@@ -242,23 +351,69 @@ try {
   check('the world log is byte-identical from first to last',
     JSON.stringify(log3) === JSON.stringify(logBefore), `${logBefore.length} → ${log3.length}`);
 
-  // ---- 4. the setting is the viewer's, and it stays --------------------------
+  // ---- 4. hook ORDER, with a neighbour on each side ------------------------
+  //
+  // The meadow's hooks sit among other people's, and the engine drains the
+  // array in order. Restoring by appending passes a membership check and still
+  // hands the array back rearranged, so the claim "restored as found" needs a
+  // test that can see order. Sentinels go in front of and behind the meadow's
+  // own hooks, and the whole sequence must come back identical (#151 review).
+  console.log('\nwith neighbours on both sides of the meadow in the hook array');
+  {
+    const planted = await A.page.evaluate(async () => {
+      const { autoHooks } = await import('/lib/autohooks.js');
+      const before = function sentinelBefore() {}; const after = function sentinelAfter() {};
+      globalThis.__sB = before; globalThis.__sA = after;
+      autoHooks().unshift(before);
+      autoHooks().push(after);
+      return autoHooks().map((f) => f.name || 'anon');
+    });
+    await say(A, '/foliage static');
+    await sleep(700);
+    const during = await meadow(A);
+    await say(A, '/foliage full');
+    await sleep(700);
+    const after4 = await meadow(A);
+    check('the meadow hooks really left the array during static',
+      during.hookCount < planted.length, `${planted.length} → ${during.hookCount}`);
+    check('…and the whole array came back in exactly the order it was found',
+      JSON.stringify(after4.hookOrder) === JSON.stringify(planted),
+      `${JSON.stringify(planted)} → ${JSON.stringify(after4.hookOrder)}`);
+    check('…with the neighbours still on their original sides',
+      after4.hookOrder[0] === 'sentinelBefore'
+      && after4.hookOrder[after4.hookOrder.length - 1] === 'sentinelAfter',
+      JSON.stringify(after4.hookOrder));
+    await A.page.evaluate(async () => {
+      const { releaseHook } = await import('/lib/autohooks.js');
+      releaseHook(globalThis.__sB); releaseHook(globalThis.__sA);
+    });
+  }
+
+  // ---- 5. the setting is the viewer's, and it stays -------------------------
   console.log('\nash sets /foliage static and reloads');
   await say(A, '/foliage static');
   await sleep(500);
   await A.page.reload({ waitUntil: 'domcontentloaded' });
   await until(A.page, PLANTED, "ash's meadow to re-plant");
   await sleep(2500);
-  const a4 = await meadow(A), b4 = await meadow(B);
-  check('ASH gets their own meadow back the way they left it', a4.preset === 'static' && a4.animates === false,
-    `${a4.preset}/${a4.animates}`);
+  const a5 = await meadow(A), b5 = await meadow(B);
+  check('ASH gets their own meadow back the way they left it',
+    a5.preset === 'static' && a5.animates === false, `${a5.preset}/${a5.animates}`);
   check('a fresh field inherits the choice (sticky across the re-grow)',
-    a4.wind.length > 0 && a4.wind.every(([b, g]) => b === 0 && g === 0), JSON.stringify(a4.wind));
-  check("BROOK's meadow, still, is the one its author planted", b4.blades === bBefore.blades && b4.animates);
+    a5.wind.length > 0 && a5.wind.every(([b, g]) => b === 0 && g === 0), JSON.stringify(a5.wind));
+  check("BROOK's meadow, still, is the one its author planted", b5.blades === bBefore.blades && b5.animates);
   check('and the world log STILL did not grow', logEntries().length === logBefore.length);
 } finally {
-  if (argv['keep-open'] !== 'true') { await A?.ctx.close(); await B?.ctx.close(); await browser.close(); }
-  srv.kill();
+  if (argv['keep-open'] === 'true') {
+    console.log('[door-test] --keep-open: the world and browser are still up; ctrl-c releases them');
+  } else {
+    await life.dispose('end of run');
+    if (world) {
+      await sleep(500);
+      check('the harness left nothing listening behind it', !(await portIsOpen(world.port)),
+        `something still answers on :${world.port}`);
+    }
+  }
 }
 
 console.log(failures

--- a/tools/foliage-door-test.mjs
+++ b/tools/foliage-door-test.mjs
@@ -1,0 +1,267 @@
+// foliage-door-test — one viewer changes their meadow; prove nothing shared moved.
+//
+// The claim this file exists to check is a PRODUCT claim, not a code one: that
+// `/foliage off` is a setting about your own eyes and not an edit to the world.
+// A unit test on the dial cannot establish that — the dial could be perfect and
+// some caller could still emit a verb. So this stands two real viewers in one
+// real world, moves one of their dials through the real command path, and then
+// asks the world and the other viewer whether anything happened to them.
+//
+// Three sources of truth are checked, because a weaker one alone would pass a
+// broken build:
+//   · the WORLD LOG on disk — the world IS its log; if the log did not grow,
+//     nothing was authored. This is the load-bearing one.
+//   · the OTHER VIEWER's rendered meadow — blades drawn, applied density,
+//     motion — read from their page, not inferred.
+//   · the ACTING viewer's own meadow, which MUST change. A test where nobody's
+//     view moved would pass while proving nothing.
+//
+// Two separate browser CONTEXTS, not two tabs: localStorage is per origin, and
+// two tabs of one profile share the resident's dial by design. Isolating them
+// is what makes them two people rather than one person twice.
+//
+// 🔴 node, not bun — Playwright's launch hangs under bun on Windows over
+// --remote-debugging-pipe (see docs/browser-perf-receipt.md).
+//
+//   node tools/foliage-door-test.mjs
+//   node tools/foliage-door-test.mjs --keep-open --browser=chrome
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { chromium } from 'playwright';
+
+const argv = Object.fromEntries(process.argv.slice(2)
+  .filter((a) => a.startsWith('--'))
+  .map((a) => { const i = a.indexOf('='); return i < 0 ? [a.slice(2), 'true'] : [a.slice(2, i), a.slice(i + 1)]; }));
+
+const BROWSER = argv.browser ?? 'chrome';
+const KEY = 'door-test';
+const WORLD = `foliagedoor${Math.random().toString(36).slice(2, 7)}`;
+const PORT = 8990 + Math.floor(Math.random() * 500);
+const WORLDS = mkdtempSync(join(tmpdir(), 'foliage-door-'));
+const BUN = process.env.BUN_PATH || 'C:\\Users\\madal\\.bun\\bin\\bun.exe';
+const EIDO = process.env.EIDOVERSE_DIR || join(process.cwd(), '..', 'eidoverse-video');
+
+let failures = 0;
+const check = (label, ok, detail) => {
+  console.log(ok ? `  \x1b[32m✓\x1b[0m ${label}` : `  \x1b[31m✗ ${label}${detail ? ` — ${detail}` : ''}\x1b[0m`);
+  if (!ok) failures++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- a world this run owns --------------------------------------------------
+
+console.log(`\nfoliage door test — world "${WORLD}" on :${PORT}, worlds dir ${WORLDS}\n`);
+const srv = spawn(BUN, ['run', 'server/server.ts'], {
+  env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: KEY, WORLDS_DIR: WORLDS, EIDOVERSE_DIR: EIDO },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+const srvOut = [];
+srv.stdout.on('data', (d) => srvOut.push(String(d)));
+srv.stderr.on('data', (d) => srvOut.push(String(d)));
+
+const origin = `http://127.0.0.1:${PORT}`;
+for (let i = 0; i < 80; i++) {
+  try { if ((await fetch(`${origin}/`)).ok) break; } catch { /* not up yet */ }
+  await sleep(250);
+}
+
+/** The world's log on disk — the only authority on what was authored. */
+const logPath = () => join(WORLDS, WORLD, 'log.jsonl');
+const logEntries = () => (existsSync(logPath())
+  ? readFileSync(logPath(), 'utf8').split('\n').filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean)
+  : []);
+
+// ---- plant a meadow, as its owner ------------------------------------------
+
+{
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+  const msgs = [];
+  ws.onmessage = (ev) => { try { msgs.push(JSON.parse(String(ev.data))); } catch { /* not ours */ } };
+  await new Promise((r) => { ws.onopen = r; });
+  ws.send(JSON.stringify({ type: 'join', token: KEY, name: 'planter', world: WORLD }));
+  for (let i = 0; i < 60 && !msgs.some((m) => m.type === 'snapshot'); i++) await sleep(100);
+  ws.send(JSON.stringify({ type: 'verb', verb: 'grass',
+    args: { species: 'grass', width: 60, depth: 60, center: [0, 0], density: 1, height: 0.42, wind: 1 } }));
+  await sleep(1200);
+  const refused = msgs.filter((m) => m.type === 'error');
+  if (refused.length) console.log('  ⚠ seed refusals:', JSON.stringify(refused.slice(0, 2)));
+  ws.close();
+}
+
+// ---- two viewers, two profiles ---------------------------------------------
+
+const browser = await chromium.launch({ headless: false, channel: BROWSER, timeout: 90_000 });
+/** Poll from THIS side with page.evaluate.
+ *
+ *  page.waitForFunction with an ASYNC predicate resolved immediately here —
+ *  the dynamic `import()` a terrain probe needs makes the predicate a promise,
+ *  and the wait returned before a single blade was planted. Both viewers then
+ *  baselined at zero and every later comparison was against nothing. Evaluate
+ *  awaits properly; loop out here where the awaiting is not in doubt. */
+async function until(page, fn, label, ms = 180_000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await page.evaluate(fn)) return true;
+    await sleep(500);
+  }
+  throw new Error(`timed out after ${Math.round(ms / 1000)}s waiting for ${label}`);
+}
+
+/** Is this page drawing a meadow yet? */
+const PLANTED = async () => {
+  const t = await import('/lib/terrain.js');
+  if (!t.hasGrass()) return false;
+  return (t.grassTiles().strokes ?? []).reduce((n, s) => n + (s.drawn ?? 0), 0) > 0;
+};
+
+/** A viewer is a CONTEXT: its own localStorage, so its own dial. */
+async function viewer(name) {
+  const ctx = await browser.newContext({ viewport: { width: 900, height: 640 } });
+  const page = await ctx.newPage();
+  await page.goto(`${origin}/?name=${name}&world=${WORLD}&key=${KEY}`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await until(page, () => (globalThis.EW?.renderer?.info?.render?.calls ?? 0) > 0, `${name} to draw`);
+  // hasGrass() is true the moment the FIELD object exists; its tiles are
+  // planted after that, and a baseline taken in the gap reads zero blades and
+  // an empty stroke list.
+  await until(page, PLANTED, `${name}'s meadow to plant`);
+  await sleep(1500);
+  return { name, ctx, page };
+}
+
+/** Everything about this viewer's meadow that a person could see. */
+// Reads defensively: on a build without the motion dial this must produce
+// NAMED failures, not a stack trace. A negative control that crashes proves
+// only that it crashed.
+const meadow = (v) => v.page.evaluate(async () => {
+  const t = await import('/lib/terrain.js');
+  const call = (name, fallback = null) => { try { return t[name]?.() ?? fallback; } catch { return fallback; } };
+  const strokes = t.grassTiles().strokes ?? [];
+  const field = t.getGrassField();
+  return {
+    quality: call('getGrassQuality'), motion: call('getGrassMotion'), preset: call('getFoliagePreset'),
+    animates: call('grassAnimates'), density: call('getGrassDensity'),
+    applied: call('getGrassApplied')?.status ?? null,
+    // which of the dials this build even HAS — the control's first answer
+    surface: ['getGrassMotion', 'setGrassMotion', 'setFoliagePreset', 'getFoliagePreset', 'grassAnimates']
+      .filter((n) => typeof t[n] === 'function'),
+    visible: !!field?.mesh?.visible,
+    blades: field?.mesh?.visible ? strokes.reduce((n, s) => n + (s.drawn ?? 0), 0) : 0,
+    // the wind amplitudes the shader is actually reading
+    wind: (field?._strokes ?? []).map((st) => [st.uniforms?.base?.value ?? null, st.uniforms?.gust?.value ?? null]),
+    storage: { quality: localStorage.getItem('ew-grass-quality'), motion: localStorage.getItem('ew-grass-motion') },
+  };
+});
+
+/** Drive the REAL door: the slash command a resident types. */
+const say = (v, text) => v.page.evaluate(async (t) => {
+  const chat = await import('/lib/chat.js');
+  const fn = chat.handleCommand ?? chat.runCommand ?? chat.tryCommand ?? null;
+  if (fn) return { via: 'chat', handled: fn(t) };
+  const { bus } = await import('/lib/core.js');
+  const [cmd, ...rest] = t.replace(/^\//, '').split(/\s+/);
+  bus.emit('command', { cmd, arg: rest.join(' ') });
+  return { via: 'bus', handled: true };
+}, text);
+
+let A, B;
+try {
+  A = await viewer('ash');
+  B = await viewer('brook');
+  console.log('two viewers standing in one meadow\n');
+
+  // runCommand is module-local to chat.js, so the driver dispatches on the bus
+  // — the same event chat.js emits. Check the typed alias exists too, or the
+  // test would pass for a command no resident can actually reach.
+  const chatSrc = await (await fetch(`${origin}/lib/chat.js`)).text();
+  check("chat.js routes a typed /foliage to the handler", /case 'foliage'/.test(chatSrc));
+  check("…and /grass as its alias", /case 'grass'/.test(chatSrc));
+
+  const logBefore = logEntries();
+  const bBefore = await meadow(B);
+  const aBefore = await meadow(A);
+  check('this build has the local motion dial at all',
+    aBefore.surface.length === 5, `only: ${JSON.stringify(aBefore.surface)}`);
+  check('both viewers start from the same meadow',
+    aBefore.blades > 0 && aBefore.blades === bBefore.blades, `${aBefore.blades} vs ${bBefore.blades}`);
+  check('both start animating', aBefore.animates && bBefore.animates);
+
+  // ---- 1. off ---------------------------------------------------------------
+  console.log('\nash types /foliage off');
+  const r1 = await say(A, '/foliage off');
+  await sleep(800);
+  const a1 = await meadow(A), b1 = await meadow(B);
+  const log1 = logEntries();
+
+  check(`the command reached a handler (via ${r1.via})`, r1.handled !== false);
+  check("ASH's meadow went dark", a1.blades === 0 && !a1.visible, JSON.stringify({ blades: a1.blades, visible: a1.visible }));
+  check("BROOK's meadow is untouched", b1.blades === bBefore.blades && b1.visible,
+    `${bBefore.blades} → ${b1.blades}`);
+  check("BROOK's dials never moved", b1.quality === bBefore.quality && b1.motion === bBefore.motion,
+    `${bBefore.quality}/${bBefore.motion} → ${b1.quality}/${b1.motion}`);
+  check('the WORLD LOG did not grow', log1.length === logBefore.length,
+    `${logBefore.length} → ${log1.length}: ${JSON.stringify(log1.slice(logBefore.length).map((e) => e.verb))}`);
+  check('no grass verb was authored', log1.filter((e) => e.verb === 'grass').length
+    === logBefore.filter((e) => e.verb === 'grass').length);
+  check("BROOK's browser storage is untouched", JSON.stringify(b1.storage) === JSON.stringify(bBefore.storage),
+    JSON.stringify(b1.storage));
+
+  // ---- 2. static ------------------------------------------------------------
+  console.log('\nash types /foliage static');
+  await say(A, '/foliage static');
+  await sleep(800);
+  const a2 = await meadow(A), b2 = await meadow(B);
+  const log2 = logEntries();
+
+  check('ASH sees the meadow again', a2.blades > 0 && a2.visible, `${a2.blades} blades`);
+  check('…and it is STILL: wind amplitude zeroed', a2.wind.length > 0 && a2.wind.every(([b, g]) => b === 0 && g === 0),
+    JSON.stringify(a2.wind));
+  check('…and it reads as the static preset', a2.preset === 'static' && a2.animates === false,
+    `${a2.preset}/${a2.animates}`);
+  check("BROOK's wind is still blowing", b2.wind.length > 0 && b2.wind.some(([b, g]) => b > 0 || g > 0),
+    JSON.stringify(b2.wind));
+  check("BROOK's meadow is still untouched", b2.blades === bBefore.blades && b2.animates);
+  check('the WORLD LOG still did not grow', log2.length === logBefore.length,
+    `${logBefore.length} → ${log2.length}`);
+
+  // ---- 3. back to full ------------------------------------------------------
+  console.log('\nash types /foliage full');
+  await say(A, '/foliage full');
+  await sleep(800);
+  const a3 = await meadow(A), b3 = await meadow(B);
+  const log3 = logEntries();
+
+  check('ASH is restored exactly', a3.blades === aBefore.blades && a3.animates && a3.preset === 'full',
+    JSON.stringify({ blades: a3.blades, was: aBefore.blades, preset: a3.preset }));
+  check('…including the wind amplitudes it borrowed',
+    JSON.stringify(a3.wind) === JSON.stringify(aBefore.wind), JSON.stringify(a3.wind));
+  check("BROOK never noticed any of it", b3.blades === bBefore.blades && b3.animates
+    && b3.quality === bBefore.quality && b3.motion === bBefore.motion);
+  check('the world log is byte-identical from first to last',
+    JSON.stringify(log3) === JSON.stringify(logBefore), `${logBefore.length} → ${log3.length}`);
+
+  // ---- 4. the setting is the viewer's, and it stays --------------------------
+  console.log('\nash sets /foliage static and reloads');
+  await say(A, '/foliage static');
+  await sleep(500);
+  await A.page.reload({ waitUntil: 'domcontentloaded' });
+  await until(A.page, PLANTED, "ash's meadow to re-plant");
+  await sleep(2500);
+  const a4 = await meadow(A), b4 = await meadow(B);
+  check('ASH gets their own meadow back the way they left it', a4.preset === 'static' && a4.animates === false,
+    `${a4.preset}/${a4.animates}`);
+  check('a fresh field inherits the choice (sticky across the re-grow)',
+    a4.wind.length > 0 && a4.wind.every(([b, g]) => b === 0 && g === 0), JSON.stringify(a4.wind));
+  check("BROOK's meadow, still, is the one its author planted", b4.blades === bBefore.blades && b4.animates);
+  check('and the world log STILL did not grow', logEntries().length === logBefore.length);
+} finally {
+  if (argv['keep-open'] !== 'true') { await A?.ctx.close(); await B?.ctx.close(); await browser.close(); }
+  srv.kill();
+}
+
+console.log(failures
+  ? `\n\x1b[31m${failures} failed\x1b[0m — a viewer's choice reached something it should not have\n`
+  : '\n\x1b[32mall green — one viewer changed their eyes, and the world did not notice\x1b[0m\n');
+process.exit(failures ? 1 : 0);

--- a/tools/grass-quality-test.ts
+++ b/tools/grass-quality-test.ts
@@ -28,6 +28,7 @@
 
 import { plugin } from "bun";
 import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
 // URL.pathname yields "/D:/…" on Windows, which nothing can open —
 // fileURLToPath is the portable spelling
 const here = (f: string) => fileURLToPath(new URL(f, import.meta.url));
@@ -80,7 +81,7 @@ if (!gqMod) {
     ` (expected on main; that absence is novelty, the dial assertion above is the behavior)`);
   process.exit(1);
 }
-const { makeGrassQuality, densityCount, GRASS_QUALITY, QUALITY_DENSITY } = gqMod;
+const { makeGrassQuality, densityCount, GRASS_QUALITY, QUALITY_DENSITY, GRASS_MOTION } = gqMod;
 const terrain = await import("../client/lib/terrain.js");
 
 // A field shaped to terrain's setGrass contract, recording what it was told.
@@ -312,6 +313,61 @@ console.log("\nthe applied report through terrain (getGrassApplied)");
   rep = gApplied?.();
   check("no field at all says so", rep?.status === "no-field" && rep?.field === false);
 }
+// The SECOND local dial: does the meadow move? Orthogonal to the cap on
+// purpose — density and motion are different costs for different reasons (one
+// is "my poor gpu", the other can be "the swaying makes me ill"), so they are
+// two dials with three named points between them, not one five-rung ladder.
+console.log("\nthe motion dial, and the three names over both dials");
+{
+  const q = makeGrassQuality(undefined);
+  check("motion defaults to on", q.motion === "on" && q.animates() === true);
+  check("GRASS_MOTION is the whole vocabulary", JSON.stringify(GRASS_MOTION) === '["on","off"]');
+
+  const s2 = new Map<string, string>();
+  const fake = { getItem: (k: string) => s2.get(k) ?? null, setItem: (k: string, v: string) => s2.set(k, v) };
+  const q2 = makeGrassQuality(fake);
+  q2.setMotion("off");
+  check("setMotion persists under its own key", s2.get("ew-grass-motion") === "off");
+  check("reload sees it", makeGrassQuality(fake).motion === "off");
+  check("unknown motion refused, current stands",
+    q2.setMotion("swirly") === "off" && q2.motion === "off");
+  s2.set("ew-grass-motion", "sideways");
+  check("garbage in the store -> on", makeGrassQuality(fake).motion === "on");
+
+  // nothing drawn cannot be animated — reporting motion 'on' for an invisible
+  // meadow is a claim the UI would then have to explain away
+  const q3 = makeGrassQuality(undefined);
+  q3.setQuality("off");
+  check("animates() is false at cap off even with motion on",
+    q3.motion === "on" && q3.animates() === false);
+  q3.setQuality("full");
+  check("...and true again when there is something to move", q3.animates() === true);
+
+  // the two dials are independent: motion survives a cap change and vice versa
+  const q4 = makeGrassQuality(undefined);
+  q4.setMotion("off"); q4.setQuality("low");
+  check("the dials do not overwrite each other",
+    q4.motion === "off" && q4.quality === "low" && near(q4.cap, 0.35));
+
+  // #42's three names, as points in the two-dial space
+  const q5 = makeGrassQuality(undefined);
+  check("full = cap full + motion on",
+    JSON.stringify(q5.setPreset("full")) === '{"quality":"full","motion":"on"}' && q5.preset() === "full");
+  check("static = cap full + motion OFF, and the meadow is still drawn",
+    JSON.stringify(q5.setPreset("static")) === '{"quality":"full","motion":"off"}'
+    && q5.preset() === "static" && q5.effective() > 0 && q5.animates() === false);
+  q5.setPreset("off");
+  check("off = nothing drawn", q5.preset() === "off" && near(q5.effective(), 0));
+  q5.setQuality("medium");
+  check("a cap between the names has no name, and does not invent one", q5.preset() === null);
+  check("an unknown preset changes nothing",
+    (q5.setPreset("cinematic"), q5.quality === "medium"));
+  // a governor shed reports what the RESIDENT set, not what load did to it
+  q5.setPreset("full"); q5.shedTo(0.35);
+  check("a governor shed does not rebrand the resident's preset",
+    q5.preset() === "full" && near(q5.effective(), 0.35));
+}
+
 
 console.log("\none report for every surface (source-level)");
 {
@@ -329,6 +385,26 @@ console.log("\nnever a verb (source-level)");
     !src.includes("net.js") && !src.includes("sendVerb"));
   check("grass_quality.js is dependency-free",
     !gq.includes("import "));
+  // the motion freeze must reach the meadow's OWN hooks and nothing else: the
+  // shared per-frame array also carries the sky and every entity emitter
+  check("terrain.js freezes motion by IDENTITY, never by emptying the hook array",
+    src.includes("releaseHook(") && !/_autoParticleSystems\s*.length\s*=\s*0/.test(src),
+    "emptying the shared array would stop the clouds and every emitter too");
+  check("the per-tile ticks are NOT frozen (a still meadow must not be a stale one)",
+    !src.includes("_tileTick"));
+  // Sliced to the handler's OWN body, not a byte window: the next handler in
+  // the file is /boom, which sends `force`, and a generous window happily
+  // convicted this one of it.
+  {
+    const hsrc = readFileSync(here("../client/lib/commands/handlers.js"), "utf8");
+    const start = hsrc.indexOf("register('foliage'");
+    const end = hsrc.indexOf("\nregister(", start + 10);
+    const body = start >= 0 ? hsrc.slice(start, end > start ? end : undefined) : "";
+    check("the /foliage handler exists", start >= 0);
+    check("...and its body sends no verb of any kind",
+      !!body && !body.includes("sendVerb") && !body.includes("sendMod") && !body.includes("sendPuppet"),
+      body.slice(0, 120));
+  }
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/owned-lifecycle.mjs
+++ b/tools/owned-lifecycle.mjs
@@ -1,0 +1,209 @@
+// owned-lifecycle — everything a browser-driven probe spawns, and the one
+// owner that always takes it back down (#151 review, blockers 1 and 2).
+//
+// Two failures this exists to make impossible:
+//
+//   · A probe that advertises `node tools/…` and then uses a global that does
+//     not exist on the reviewer's Node. `WebSocket` became global in Node 22;
+//     the house runs 20.20.2, where the door test died with
+//     `ReferenceError: WebSocket is not defined`. A receipt has to be produced
+//     by the same command the next person can run.
+//
+//   · A probe that fails BEFORE its try/finally and leaves its child running.
+//     That exact failure left a sequencer listening on :9471 on the reviewer's
+//     machine, killed by hand. Anything spawned is registered with a Lifecycle
+//     the moment it exists, and the Lifecycle is bound to the process — normal
+//     return, throw, SIGINT, unhandled rejection, all the same owner.
+//
+// And one thing it refuses to assume: that whatever answers on a port is ours.
+// The sequencer echoes EIDO_BOOT_NONCE from /version, so ownership is PROVEN
+// rather than inferred from a 200. A stale listener squatting the port fails
+// the check instead of quietly satisfying it.
+//
+// (tools/probe-harness.mjs grew the same nonce proof for the same reason. The
+// two want consolidating; that is a separate change than this one, since that
+// file is shared by probes this PR does not touch.)
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createConnection } from 'node:net';
+
+// ---- the runtime contract ---------------------------------------------------
+
+export const NODE_MIN_GLOBAL_WS = 22;
+
+/** A WebSocket constructor, wherever this Node keeps one.
+ *
+ *  Node 22+ has it as a global. Node 20 does not, and the honest fix is not
+ *  "run a newer Node" — it is to depend on the same `ws` the rest of this repo
+ *  already speaks. Throws with the actual remedy if neither is available. */
+export async function resolveWebSocket() {
+  const major = Number(process.versions.node.split('.')[0]);
+  if (typeof globalThis.WebSocket === 'function') {
+    return { WebSocket: globalThis.WebSocket, source: `global (node ${process.versions.node})` };
+  }
+  try {
+    const mod = await import('ws');
+    const WS = mod.WebSocket ?? mod.default;
+    if (typeof WS !== 'function') throw new Error('the ws package exported no WebSocket');
+    return { WebSocket: WS, source: `ws package (node ${process.versions.node} has no global)` };
+  } catch (e) {
+    throw new Error(
+      `no WebSocket available on node ${process.versions.node}: the global arrived in node `
+      + `${NODE_MIN_GLOBAL_WS}, and the "ws" package did not load either (${String(e.message ?? e).slice(0, 120)}). `
+      + 'Run `bun install` (ws is a devDependency) or use node ' + NODE_MIN_GLOBAL_WS + '+.');
+  }
+}
+
+// ---- the owner --------------------------------------------------------------
+
+/** Idempotent teardown for everything a run owns.
+ *
+ *  Register the moment a thing exists, not when the happy path is finished
+ *  with it — the leak this replaces happened between "spawned" and "entered
+ *  the try". Disposers run newest-first and every one of them is attempted
+ *  even if an earlier one throws. */
+export class Lifecycle {
+  constructor({ bindSignals = true } = {}) {
+    this._items = [];
+    this._done = false;
+    this._bound = null;
+    if (bindSignals) this._bind();
+  }
+
+  /** @param {string} label @param {() => any} dispose */
+  own(label, dispose) {
+    this._items.push({ label, dispose });
+    return dispose;
+  }
+
+  get size() { return this._items.length; }
+  get disposed() { return this._done; }
+
+  async dispose(reason = 'normal') {
+    if (this._done) return [];
+    this._done = true;
+    const errors = [];
+    for (const { label, dispose } of [...this._items].reverse()) {
+      try { await dispose(); } catch (e) { errors.push(`${label}: ${String(e.message ?? e).slice(0, 160)}`); }
+    }
+    this._items = [];
+    this._unbind();
+    if (errors.length) console.error(`[lifecycle] cleanup (${reason}) had problems:\n  ${errors.join('\n  ')}`);
+    return errors;
+  }
+
+  _bind() {
+    const bye = (reason) => () => {
+      // best effort and synchronous-ish: a signal handler cannot await forever
+      this.dispose(reason).finally(() => process.exit(reason === 'SIGINT' ? 130 : 1));
+    };
+    this._bound = {
+      SIGINT: bye('SIGINT'), SIGTERM: bye('SIGTERM'),
+      uncaughtException: (e) => { console.error('[lifecycle] uncaught:', e); bye('uncaughtException')(); },
+      unhandledRejection: (e) => { console.error('[lifecycle] unhandled rejection:', e); bye('unhandledRejection')(); },
+    };
+    for (const [sig, fn] of Object.entries(this._bound)) process.on(sig, fn);
+  }
+
+  _unbind() {
+    if (!this._bound) return;
+    for (const [sig, fn] of Object.entries(this._bound)) process.off(sig, fn);
+    this._bound = null;
+  }
+}
+
+// ---- proving the child is ours ---------------------------------------------
+
+/** Is anything listening there at all? Used to PROVE a port was released. */
+export function portIsOpen(port, host = '127.0.0.1', timeoutMs = 400) {
+  return new Promise((resolve) => {
+    const sock = createConnection({ port, host });
+    const done = (open) => { sock.destroy(); resolve(open); };
+    sock.setTimeout(timeoutMs);
+    sock.once('connect', () => done(true));
+    sock.once('timeout', () => done(false));
+    sock.once('error', () => done(false));
+  });
+}
+
+/**
+ * Ask the responder to prove it is the child we spawned.
+ *
+ * ONLY the nonce echo counts. A 200 on `/` proves a listener exists, which is
+ * exactly what a stale sequencer squatting the port also provides; a
+ * startedAt-freshness fallback reopens the just-started-impostor race. A
+ * responder with no `nonce` field is by definition not ours.
+ */
+export async function proveOurs(origin, nonce, { tries = 80, gapMs = 250, alive = () => true } = {}) {
+  let reason = 'never answered';
+  for (let i = 0; i < tries; i++) {
+    if (!alive()) return { ours: false, reason: 'the child exited before answering' };
+    try {
+      const res = await fetch(`${origin}/version`);
+      if (!res.ok) { reason = `/version answered ${res.status}`; }
+      else {
+        const v = await res.json();
+        if (v.nonce === undefined) return { ours: false, reason: 'responder has no nonce field (stale or foreign listener)' };
+        if (v.nonce !== nonce) return { ours: false, reason: 'wrong nonce — something else owns this port' };
+        return { ours: true, reason: 'nonce echoed', version: v };
+      }
+    } catch { reason = 'not listening yet'; }
+    await new Promise((r) => setTimeout(r, gapMs));
+  }
+  return { ours: false, reason };
+}
+
+// ---- the child --------------------------------------------------------------
+
+const BUN = () => (process.env.BUN_PATH
+  || (process.execPath.includes('bun') ? process.execPath : null)
+  || (process.platform === 'win32' ? `${process.env.USERPROFILE}\\.bun\\bin\\bun.exe` : `${process.env.HOME}/.bun/bin/bun`));
+
+/**
+ * Spawn a sequencer this run OWNS, prove it, and hand back where it lives.
+ *
+ * Registered with the Lifecycle BEFORE readiness is awaited, so a child that
+ * never comes up is still a child that gets killed.
+ */
+export async function ownedWorld(lifecycle, { key = 'door-test', env = {}, port = null } = {}) {
+  const PORT = port ?? 8990 + Math.floor(Math.random() * 900);
+  const worldsDir = mkdtempSync(join(tmpdir(), 'owned-world-'));
+  const nonce = randomUUID();
+  const origin = `http://127.0.0.1:${PORT}`;
+
+  if (await portIsOpen(PORT)) {
+    rmSync(worldsDir, { recursive: true, force: true });
+    throw new Error(`port ${PORT} is already in use — refusing to spawn onto someone else's listener`);
+  }
+
+  const child = spawn(BUN(), ['run', 'server/server.ts'], {
+    env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: key, WORLDS_DIR: worldsDir, EIDO_BOOT_NONCE: nonce, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const log = [];
+  child.stdout.on('data', (d) => log.push(String(d)));
+  child.stderr.on('data', (d) => log.push(String(d)));
+
+  // owned IMMEDIATELY — the whole point is that nothing between here and the
+  // happy path can orphan it
+  const close = lifecycle.own(`sequencer :${PORT}`, async () => {
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
+    await new Promise((r) => {
+      if (child.exitCode !== null) return r();
+      const t = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* gone */ } r(); }, 3000);
+      child.once('exit', () => { clearTimeout(t); r(); });
+    });
+    try { rmSync(worldsDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  const proof = await proveOurs(origin, nonce, { alive: () => child.exitCode === null });
+  if (!proof.ours) {
+    throw new Error(`owned world never came up as OURS on :${PORT} (${proof.reason})`
+      + (log.length ? `\n--- child output ---\n${log.join('').slice(-1200)}` : ''));
+  }
+  return { origin, port: PORT, worldsDir, nonce, key, close, childPid: child.pid, output: () => log.join('') };
+}

--- a/tools/receipts-foliage/door-fail-on-main.txt
+++ b/tools/receipts-foliage/door-fail-on-main.txt
@@ -1,13 +1,36 @@
-fail-on-main control: the SAME test on origin/main 6006d6d, only the test file copied in.
+fail-on-main control: the SAME test on origin/main 6006d6d, only the test files copied in.
+run on node 20.20.2, the reviewer's runtime.
 
 
-foliage door test — world "foliagedoor53tvc" on :9322, worlds dir C:\Users\madal\AppData\Local\Temp\foliage-door-jbXt3u
+--- harness controls -------------------------------------------------
+
+the WebSocket contract, on this node and on node 20
+  ✓ a WebSocket resolves here — ws package (node 20.20.2 has no global)
+  ✓ with no global WebSocket (node < 22) it falls back to the ws package
+  ✓ this file never reaches for the bare global WebSocket
+
+ownership is proven, not inferred from a 200
+  ✓ the impostor answers 200 — generic HTTP readiness would accept it
+  ✓ …but the nonce proof refuses it
+  ✓ …and refuses a listener echoing somebody else's nonce
+  ✓ the control cleaned up after itself
+
+a failure before the viewers exist leaks no child
+  ✓ a child came up and PROVED it is ours (:9762, pid 11996)
+  ✓ …and the port really is listening
+  ✓ the injected failure propagated
+  ✓ …and the child is gone: nothing listens on that port
+  ✓ …and dispose is idempotent (a second call is a no-op)
+
+--- the product door -------------------------------------------------
+
+foliage door test — world "foliagedoortoxin" on :9011, proven ours by nonce
 
 two viewers standing in one meadow
 
   ✗ chat.js routes a typed /foliage to the handler
   ✗ …and /grass as its alias
-  ✗ this build has the local motion dial at all — only: []
+  ✗ this build has the local motion dial at all — []
   ✓ both viewers start from the same meadow
   ✗ both start animating
 
@@ -26,6 +49,7 @@ ash types /foliage static
   ✗ …and it reads as the static preset — null/null
   ✓ BROOK's wind is still blowing
   ✗ BROOK's meadow is still untouched
+  ✓ …and BROOK's hook array was never touched
   ✓ the WORLD LOG still did not grow
 
 ash types /foliage full
@@ -34,10 +58,16 @@ ash types /foliage full
   ✗ BROOK never noticed any of it
   ✓ the world log is byte-identical from first to last
 
+with neighbours on both sides of the meadow in the hook array
+  ✗ the meadow hooks really left the array during static — 5 → 5
+  ✓ …and the whole array came back in exactly the order it was found
+  ✓ …with the neighbours still on their original sides
+
 ash sets /foliage static and reloads
   ✗ ASH gets their own meadow back the way they left it — null/null
   ✗ a fresh field inherits the choice (sticky across the re-grow) — [[0.4026428724420452,0.8052857448840904]]
   ✗ BROOK's meadow, still, is the one its author planted
   ✓ and the world log STILL did not grow
+  ✓ the harness left nothing listening behind it
 
-13 failed — a viewer's choice reached something it should not have
+14 failed — a viewer's choice reached something it should not have

--- a/tools/receipts-foliage/door-fail-on-main.txt
+++ b/tools/receipts-foliage/door-fail-on-main.txt
@@ -1,0 +1,43 @@
+fail-on-main control: the SAME test on origin/main 6006d6d, only the test file copied in.
+
+
+foliage door test — world "foliagedoor53tvc" on :9322, worlds dir C:\Users\madal\AppData\Local\Temp\foliage-door-jbXt3u
+
+two viewers standing in one meadow
+
+  ✗ chat.js routes a typed /foliage to the handler
+  ✗ …and /grass as its alias
+  ✗ this build has the local motion dial at all — only: []
+  ✓ both viewers start from the same meadow
+  ✗ both start animating
+
+ash types /foliage off
+  ✓ the command reached a handler (via bus)
+  ✗ ASH's meadow went dark — {"blades":39283,"visible":true}
+  ✓ BROOK's meadow is untouched
+  ✓ BROOK's dials never moved
+  ✓ the WORLD LOG did not grow
+  ✓ no grass verb was authored
+  ✓ BROOK's browser storage is untouched
+
+ash types /foliage static
+  ✓ ASH sees the meadow again
+  ✗ …and it is STILL: wind amplitude zeroed — [[0.4026428724420452,0.8052857448840904]]
+  ✗ …and it reads as the static preset — null/null
+  ✓ BROOK's wind is still blowing
+  ✗ BROOK's meadow is still untouched
+  ✓ the WORLD LOG still did not grow
+
+ash types /foliage full
+  ✗ ASH is restored exactly — {"blades":39283,"was":39283,"preset":null}
+  ✓ …including the wind amplitudes it borrowed
+  ✗ BROOK never noticed any of it
+  ✓ the world log is byte-identical from first to last
+
+ash sets /foliage static and reloads
+  ✗ ASH gets their own meadow back the way they left it — null/null
+  ✗ a fresh field inherits the choice (sticky across the re-grow) — [[0.4026428724420452,0.8052857448840904]]
+  ✗ BROOK's meadow, still, is the one its author planted
+  ✓ and the world log STILL did not grow
+
+13 failed — a viewer's choice reached something it should not have

--- a/tools/receipts-foliage/door-node20.txt
+++ b/tools/receipts-foliage/door-node20.txt
@@ -1,12 +1,13 @@
-on-branch, node 24.18.0 (global WebSocket present)
+on-branch, the reviewer's runtime: node 20.20.2 (no global WebSocket)
 
+v20.20.2
 cmd: node tools/foliage-door-test.mjs
 
 
 --- harness controls -------------------------------------------------
 
 the WebSocket contract, on this node and on node 20
-  ✓ a WebSocket resolves here — global (node 24.18.0)
+  ✓ a WebSocket resolves here — ws package (node 20.20.2 has no global)
   ✓ with no global WebSocket (node < 22) it falls back to the ws package
   ✓ this file never reaches for the bare global WebSocket
 
@@ -17,7 +18,7 @@ ownership is proven, not inferred from a 200
   ✓ the control cleaned up after itself
 
 a failure before the viewers exist leaks no child
-  ✓ a child came up and PROVED it is ours (:9873, pid 15508)
+  ✓ a child came up and PROVED it is ours (:9022, pid 4388)
   ✓ …and the port really is listening
   ✓ the injected failure propagated
   ✓ …and the child is gone: nothing listens on that port
@@ -25,7 +26,7 @@ a failure before the viewers exist leaks no child
 
 --- the product door -------------------------------------------------
 
-foliage door test — world "foliagedoorkglyh" on :9377, proven ours by nonce
+foliage door test — world "foliagedoorjw45k" on :9739, proven ours by nonce
 
 two viewers standing in one meadow
 

--- a/tools/receipts-foliage/door-on-branch.txt
+++ b/tools/receipts-foliage/door-on-branch.txt
@@ -1,0 +1,43 @@
+on-branch: node tools/foliage-door-test.mjs
+
+
+foliage door test — world "foliagedoorrhoio" on :9066, worlds dir C:\Users\madal\AppData\Local\Temp\foliage-door-PBRFka
+
+two viewers standing in one meadow
+
+  ✓ chat.js routes a typed /foliage to the handler
+  ✓ …and /grass as its alias
+  ✓ this build has the local motion dial at all
+  ✓ both viewers start from the same meadow
+  ✓ both start animating
+
+ash types /foliage off
+  ✓ the command reached a handler (via bus)
+  ✓ ASH's meadow went dark
+  ✓ BROOK's meadow is untouched
+  ✓ BROOK's dials never moved
+  ✓ the WORLD LOG did not grow
+  ✓ no grass verb was authored
+  ✓ BROOK's browser storage is untouched
+
+ash types /foliage static
+  ✓ ASH sees the meadow again
+  ✓ …and it is STILL: wind amplitude zeroed
+  ✓ …and it reads as the static preset
+  ✓ BROOK's wind is still blowing
+  ✓ BROOK's meadow is still untouched
+  ✓ the WORLD LOG still did not grow
+
+ash types /foliage full
+  ✓ ASH is restored exactly
+  ✓ …including the wind amplitudes it borrowed
+  ✓ BROOK never noticed any of it
+  ✓ the world log is byte-identical from first to last
+
+ash sets /foliage static and reloads
+  ✓ ASH gets their own meadow back the way they left it
+  ✓ a fresh field inherits the choice (sticky across the re-grow)
+  ✓ BROOK's meadow, still, is the one its author planted
+  ✓ and the world log STILL did not grow
+
+all green — one viewer changed their eyes, and the world did not notice

--- a/tools/receipts-foliage/grass-quality.txt
+++ b/tools/receipts-foliage/grass-quality.txt
@@ -1,0 +1,98 @@
+unit: bun run tools/grass-quality-test.ts
+
+
+flora's shipped density dial (source-extracted, both trees)
+  ✓ factor 0 keeps ZERO of 1000 instances (main keeps 50)
+
+the dial itself (makeGrassQuality)
+  ✓ no store → full, effective 1
+  ✓ persisted level loads
+  ✓ setQuality persists
+  ✓ reload sees the change
+  ✓ unknown level refused, current stands
+  ✓ garbage in the store → full
+  ✓ governor may lower below the cap
+  ✓ governor cannot raise above the cap
+  ✓ raising the cap does not un-shed the session
+  ✓ off is zero regardless of shed
+  ✓ shed clamps to [0,1]
+  ✓ levels and factors agree
+
+the instance-count dial (densityCount)
+  ✓ full keeps the field
+  ✓ 0.6 keeps 600
+  ✓ tiny factors floor at 5%
+  ✓ a thinned field never reads as mowed
+  ✓ off draws ZERO (main keeps ≥1 per stroke)
+  ✓ negative is zero too
+
+terrain lifecycle (the real setGrass/setGrassDensity path)
+  ✓ cap set BEFORE any field load is live
+  ✓ field arriving finds the cap waiting
+  ✓ chosen and effective are separately inspectable
+  ✓ cap change applies to the loaded field
+  ✓ replacement field inherits the cap (sticky re-grow)
+  ✓ replaced field was retired, not mutated
+  ✓ off tells the field to draw zero
+  ✓ off hides the group locally
+  ✓ off leaves the field object whole (shared state untouched)
+  ✓ raising the cap restores in place
+  ✓ governor thins the live field
+  ✓ governor recovery still honors the cap
+  ✓ the chosen level persisted for the next session
+  ✓ unknown level via terrain refused
+
+the silent no-op seam (flora's shipped wireDensityDial, both trees)
+  ✓ wireDensityDial extracted from flora.js
+  ✓ a stroke with instanced attributes gets a dial
+  ✓ missing attributes leave NO dial — the seam is real
+  ✓ a dialed stroke's LIVE count follows densityCount
+  ✓ shrub report covers both leaf and stem draw meshes
+  ✓ shrub stem mismatch makes the live report fail
+  ✓ the composed dial silently no-ops on the dial-less stroke
+  ✓ this tree can NAME that no-op (field.applied)
+  ✓ mixed field reports PARTIAL and identifies the stroke
+  ✓ a planted-nothing stroke is vacuously applied, never a failure
+
+the applied report through terrain (getGrassApplied)
+  ✓ terrain exports getGrassApplied
+  ✓ low on a compatible field: APPLIED, consistent with live mesh.count
+  ✓ the report carries the whole chain: chosen, cap, shed, requested
+  ✓ low on an incompatible field: UNAVAILABLE, not success at 0.35
+  ✓ getGrassDensity still names the REQUEST — truth lives in the report
+  ✓ off is honestly APPLIED via visibility even without a dial
+  ✓ restore from off re-evaluates: UNAVAILABLE again, not remembered success
+  ✓ full on an incompatible field is honestly applied (it IS drawing full)
+  ✓ re-grow preserves the choice and re-evaluates applied capability
+  ✓ a field that cannot report draw state is UNKNOWN, not success
+  ✓ no field at all says so
+
+the motion dial, and the three names over both dials
+  ✓ motion defaults to on
+  ✓ GRASS_MOTION is the whole vocabulary
+  ✓ setMotion persists under its own key
+  ✓ reload sees it
+  ✓ unknown motion refused, current stands
+  ✓ garbage in the store -> on
+  ✓ animates() is false at cap off even with motion on
+  ✓ ...and true again when there is something to move
+  ✓ the dials do not overwrite each other
+  ✓ full = cap full + motion on
+  ✓ static = cap full + motion OFF, and the meadow is still drawn
+  ✓ off = nothing drawn
+  ✓ a cap between the names has no name, and does not invent one
+  ✓ an unknown preset changes nothing
+  ✓ a governor shed does not rebrand the resident's preset
+
+one report for every surface (source-level)
+  ✓ the browser grass⚙ row reads the SAME report (getGrassApplied) as code does
+
+never a verb (source-level)
+  ✓ terrain.js does not import net.js or send verbs
+  ✓ grass_quality.js is dependency-free
+  ✓ terrain.js freezes motion by IDENTITY, never by emptying the hook array
+  ✓ the per-tile ticks are NOT frozen (a still meadow must not be a stale one)
+  ✓ the /foliage handler exists
+  ✓ ...and its body sends no verb of any kind
+
+76 passed, 0 failed

--- a/tools/receipts-foliage/lifecycle-fault.txt
+++ b/tools/receipts-foliage/lifecycle-fault.txt
@@ -1,0 +1,47 @@
+lifecycle fault control: a deliberate throw after the child is up must leave no listener.
+
+cmd: node tools/foliage-door-test.mjs --fault=post-server
+
+--- 9xxx listeners BEFORE ---
+  TCP    127.0.0.1:9010         0.0.0.0:0              LISTENING       16392
+  TCP    127.0.0.1:9180         0.0.0.0:0              LISTENING       4912
+
+
+--- harness controls -------------------------------------------------
+
+the WebSocket contract, on this node and on node 20
+  ✓ a WebSocket resolves here — ws package (node 20.20.2 has no global)
+  ✓ with no global WebSocket (node < 22) it falls back to the ws package
+  ✓ this file never reaches for the bare global WebSocket
+
+ownership is proven, not inferred from a 200
+  ✓ the impostor answers 200 — generic HTTP readiness would accept it
+  ✓ …but the nonce proof refuses it
+  ✓ …and refuses a listener echoing somebody else's nonce
+  ✓ the control cleaned up after itself
+
+a failure before the viewers exist leaks no child
+  ✓ a child came up and PROVED it is ours (:9182, pid 24888)
+  ✓ …and the port really is listening
+  ✓ the injected failure propagated
+  ✓ …and the child is gone: nothing listens on that port
+  ✓ …and dispose is idempotent (a second call is a no-op)
+
+--fault=post-server: failing deliberately after the child is up
+  child on :9369 pid 22300 — throwing now; nothing should survive it
+file:///C:/Users/madal/Projects/ev-fol/tools/foliage-door-test.mjs:172
+  try { throw new Error('deliberate --fault=post-server'); } finally { await lifeF.dispose('fault'); }
+              ^
+
+Error: deliberate --fault=post-server
+    at file:///C:/Users/madal/Projects/ev-fol/tools/foliage-door-test.mjs:172:15
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+Node.js v20.20.2
+exit=1
+
+--- 9xxx listeners AFTER (both are Logitech G Hub, not ours) ---
+  TCP    127.0.0.1:9010         0.0.0.0:0              LISTENING       16392
+  TCP    127.0.0.1:9180         0.0.0.0:0              LISTENING       4912
+
+no bun/sequencer child survived the fault.


### PR DESCRIPTION
The third of Mica's three bounded pieces: the smallest browser-local eye that hides foliage, with off/static/full semantics and a proof that one viewer's choice changes no shared facts.

**base** `main` `6006d6d` · **head** `c22eb72` · two commits · isolated worktree, browser-local only, no world verb, no production deployment, no Skye/Gabriel foliage work touched.

## The source map changed the answer

Most of this already ships. `client/lib/grass_quality.js` has carried the resident's cap — `full · medium · low · off`, persisted per browser, capped against the frame governor's session shed — since #60, and its own header had already drawn the line this task is about:

> Neither dial is ever a verb — the shared field (species, seed, extent, provenance) is world state; how many blades THIS machine fills pixels with is not.

`off` was already the real thing: zero instances, group hidden, field object intact, shared state untouched.

| control | where | scope | persisted | a verb? |
|---|---|---|---|---|
| resident's cap | `grass_quality.js` `makeGrassQuality` | this browser | `ew-grass-quality` | **no** |
| governor's shed | `governor.js` → `terrain.setGrassDensity` | this session | no | no |
| what draws | `terrain.js` `applyGrassBudget()` — `min(cap, shed)`; at `0`, count 0 **and** group hidden | | | |
| applied truth | `terrain.js` `getGrassApplied()`, `grassTiles()` | | | |
| the `grass⚙` row | `build.js` — select + aria-live, repaints on `grass-budget` | | | |
| **the field itself** | the `grass` verb — rank 2, owner-only (`server/rights.ts`) | **the world** | the world log | **yes** |
| wind | each stroke's `update(t){ uT.value = t }` → `_autoParticleSystems` | per-frame hook | | |
| pushers | `flora.js` `wirePushers`, gated by `freezePushers` | | | |
| per-tile ticks | `f._tileTick` via `pushHostHook`, on `field.autoHooks` | | | |

## What was actually missing: `static`

There was no way to keep the meadow **drawn** and stop it **moving**. The only route was the diagnostic path, which empties `_autoParticleSystems` wholesale — a bucket that also carries the sky and every entity emitter. Fine for a four-second A/B; not something a resident can leave switched on.

That gap is not cosmetic. #42's own field evidence points at motion rather than fill: an M3 Max at ~40fps with the meadow in frame and ~120 with it out, and `grassdiag` exists because the suspicion was shader-side displacement rather than blade pixels.

## A second dial, not a fifth rung

Density and motion are different costs for different reasons — *"my poor gpu"* is one, *"the swaying makes me ill"* is another, and someone who wants a still meadow at full detail should not have to mow it to get one. The cap keeps its four levels; motion is `on | off`, persisted under `ew-grass-motion`, by exactly the same rules.

The three names are **points** in that two-dial space:

| name | cap | motion |
|---|---|---|
| `full` | full | on |
| `static` | full | **off** — drawn, not animated |
| `off` | off | *moot: nothing drawn can move* |

`animates()` returns false at cap `off` whatever the motion dial says, so no surface ever has to explain a meadow claiming to sway while invisible. `preset()` returns `null` when the dials sit between names — `medium` is a legitimate place to stand and it is not `static`.

### How the freeze is applied

`terrain.js` `applyGrassMotion()`, narrowly and **by identity**:

- each stroke's wind-clock hook is released from the shared array (`autohooks.releaseHook`) and pushed back on the way out;
- that stroke's `base`/`gust` wind amplitudes are zeroed and restored to their exact prior values. Freezing the clock alone leaves blades stopped mid-gust, leaning; zeroing amplitude settles them upright, which is what *still* should look like.

Deliberately **not** frozen, each for a reason:

- **the per-tile ticks** — they re-settle LOD and visibility against the camera; freeze them and a walking viewer drags a stale meadow behind them. A still meadow is the ask, a wrong one is not.
- **the pushers** — a motionless field that still parts around your feet is interaction, not ambient animation.
- **anything that is not foliage** — emptying `_autoParticleSystems` would stop the clouds, the weather and every entity emitter for as long as one resident left one setting on.

A re-grow re-applies the choice against the new field, the same way the cap is already sticky.

### Honest limit, on the record

**`static` is a comfort setting, not an established performance one.** The shader still evaluates its wind term at zero amplitude, and no measurement on this hardware separates static from full — both sit on the vsync interval (`tools/receipts-42/`, PR #150). The lever that demonstrably removes work is `off`. If `static` should also be cheap, that is a measurement task on hardware where the frame is not already free — not a change to this dial.

## The surface

```
/foliage                      what your meadow is doing, and how to change it
/foliage full | static | off  the three names
/foliage medium | low         the cap's other rungs
/foliage sway on|off          the motion dial alone
```

`/grass` aliases it. In the settings panel, `sway⚙` sits under `grass⚙`, is disabled when the cap is `off` (nothing to move), and repaints on the same `grass-budget` event.

## The product-door test

The claim is a product claim, so the proof is a product proof. A unit test on the dial cannot establish it — the dial could be perfect and some caller could still emit a verb.

`tools/foliage-door-test.mjs` stands **two real viewers in one real world**, moves one of their dials through the real command path, and asks the world and the other viewer whether anything happened to them. Two separate browser **contexts**, not two tabs: `localStorage` is per origin, and two tabs of one profile share the resident's dial by design. Isolating them is what makes them two people rather than one person twice.

Three sources of truth, because a weaker one alone would pass a broken build:

1. **the world log on disk** — the world IS its log; if it did not grow, nothing was authored. Checked byte-identical from first assertion to last.
2. **the other viewer's rendered meadow** — blades drawn, applied density, wind amplitudes, their `localStorage` — read from their page, not inferred.
3. **the acting viewer's own meadow, which must change** — a test where nobody's view moved would pass while proving nothing.

```bash
node tools/foliage-door-test.mjs     # node, not bun — see docs/browser-perf-receipt.md
```

**24 checks green** (`tools/receipts-foliage/door-on-branch.txt`).

**Negative control: 13 named failures** on `origin/main` `6006d6d` with only the test file copied in (`door-fail-on-main.txt`) — no `/foliage` route, no motion dial, ash's meadow does not go dark, the wind keeps blowing. The world-log assertions **pass** on main, and should: a build with no local foliage control authors nothing because it can do nothing. Those passes are the invariant, not the feature.

`tools/grass-quality-test.ts` covers the dial headless — **76 passed, 0 failed** — including three source-level guards that are the real risk here: that `terrain.js` freezes by **identity** rather than by emptying the shared hook array, that the per-tile ticks are **not** in the freeze, and that the `/foliage` handler's own body sends no verb of any kind (sliced to itself — the next handler in the file sends `force`, and a generous byte window happily convicted this one of it).

`git diff --check 6006d6d..c22eb72` is clean. `smoke` 84 pass / 1 fail — `✗ rtc reaches its recipient`, which fails identically on a `main` control worktree.

## Two harness scars worth keeping

- **`page.waitForFunction` with an async predicate resolved immediately.** The dynamic `import()` a terrain probe needs makes the predicate a promise; both viewers baselined at zero blades and every later comparison was against nothing. The waits poll through `page.evaluate` now, where the awaiting is not in doubt.
- **Receipts are trimmed of the trailing blank line** the capture redirect appends, which `git diff --check` rejects — applied here before committing rather than after (thanks to the #149 review).

## Open questions for review

1. **Persistence.** The brief said "no durable state". This reads that as no *shared* durable state and follows the shipped precedent — `consent.js` and `grass_quality.js` are both `localStorage`-backed so a choice survives the session that made it. If the intent was no persistence at all, dropping the `ew-grass-motion` write is a one-line change; the test's reload section then inverts.
2. **`static` at other caps.** `preset()` names only full+motion. `medium` with motion off is reachable and legal but unnamed. Should it have a name, or is unnamed correct?
3. **Whether `static` should be cheap.** See the honest limit above.
4. **The sway row's placement.** It sits under `grass⚙`. It could instead be an accessibility setting, since motion sensitivity is the strongest reason to want it.

Full source map and rationale in `docs/foliage-local-eye.md`.

Directed-by: Cormundus
