### PR TITLE
lod: geometry LOD for placeable objects — bodies fail closed, by structure

### DIFF
--- a/server/optimize.ts
+++ b/server/optimize.ts
@@ -378,11 +378,28 @@ const sceneBounds = (doc: Document): [number[], number[]] => {
 
 export type LodResult = { out: Uint8Array | null; verdict: string | null; before: number; after: number };
 
+/** The node contract, as a signature: names, transforms, mesh-bearing, and
+ *  hierarchy (child order), per scene. Exported so its DETECTION power is a
+ *  unit test of its own, separate from the pipeline that consumes it. */
+export const lodNodesSig = (d: Document): string => {
+  const walk = (n: any): any => [n.getName(), n.getTranslation(), n.getRotation(), n.getScale(),
+    n.getMesh()?.getName() ?? null, n.listChildren().map(walk)];
+  return JSON.stringify(d.getRoot().listScenes().map((sc) => sc.listChildren().map(walk)));
+};
+/** Which material each primitive of each mesh wears, by index. */
+export const lodMatsSig = (d: Document): string => JSON.stringify(d.getRoot().listMeshes().map((m) =>
+  [m.getName(), m.listPrimitives().map((p) => { const mt = p.getMaterial(); return mt ? d.getRoot().listMaterials().indexOf(mt) : -1; })]));
+
 /** The lod1 diet: the ktx2 diet (dedup/prune/resample + texel-budget KTX2 +
  *  draco) with weld + meshopt-simplify between — and the preservation
  *  asserts around the reduce. `verdict` non-null = a typed content refusal
  *  (marker's business); textures follow --ktx2's all-or-nothing. */
-export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null): Promise<LodResult & Ktx2Tally> {
+/** `mutate` is the MUTATION-CONTROL SEAM demanded by the #156 re-review:
+ *  the test suite injects a post-reduce corruption (a renamed node, a
+ *  swapped material assignment) and asserts the guard REFUSES it — so
+ *  deleting either guard turns a named test red instead of leaving the
+ *  suite green. Production callers (the CLI) never pass it. */
+export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null, mutate?: (doc: Document) => void): Promise<LodResult & Ktx2Tally> {
   const none = { eligible: 0, converted: 0, failed: [] as string[] };
   const rawJson = parseGlb(bytes).json;
   const excluded = lodExclusion(rawJson);
@@ -393,26 +410,26 @@ export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null):
   if (!encoder && (rawJson?.images?.length ?? 0) > 0) return { out: null, verdict: "__no_encoder__", before: 0, after: 0, ...none };
   const io = await getIO();
   const doc = await io.readBinary(bytes);
-  // same head as the ktx2 diet, so the two variants agree on structure
-  await doc.transform(dedup(), prune(), resample());
+  // The node contract is captured BEFORE any destructive transform (re-review
+  // of #156, blocker 1: a plain prune() deleted an empty named socket helper
+  // before the old post-head signature existed — the loss was invisible).
+  // prune() runs with keepLeaves so named empty helpers — socket frames,
+  // attachment points — survive the head at all; the whole-diet signature
+  // then PROVES nothing was lost, or the variant is refused.
+  const preNodes = lodNodesSig(doc);
+  await doc.transform(dedup(), prune({ keepLeaves: true }), resample());
   const before = totalVerts(doc);
   if (before < LOD_MIN_VERTS) return { out: null, verdict: `already light (${before} verts < ${LOD_MIN_VERTS})`, before, after: before, ...none };
-  // What the world depends on, captured AFTER the shared head (parity with
-  // the ktx2 variant) and asserted after the reduce. Not just names (review
-  // of #156, point 6): the HIERARCHY with each node's transform, and each
-  // primitive's material ASSIGNMENT — the reduce may only touch vertex data.
-  const nodesSig = (d: Document) => {
-    const walk = (n: any): any => [n.getName(), n.getTranslation(), n.getRotation(), n.getScale(),
-      n.getMesh()?.getName() ?? null, n.listChildren().map(walk)];
-    return JSON.stringify(d.getRoot().listScenes().map((sc) => sc.listChildren().map(walk)));
-  };
-  const matsSig = (d: Document) => JSON.stringify(d.getRoot().listMeshes().map((m) =>
-    [m.getName(), m.listPrimitives().map((p) => { const mt = p.getMaterial(); return mt ? d.getRoot().listMaterials().indexOf(mt) : -1; })]));
-  const preNodes = nodesSig(doc), preMats = matsSig(doc), [preMin, preMax] = sceneBounds(doc);
+  // material assignments are captured after the head — dedup may merge
+  // byte-identical materials, which is the ktx2 variant's existing behavior;
+  // what may not change from HERE on is which material each primitive wears
+  const preMats = lodMatsSig(doc);
+  const [preMin, preMax] = sceneBounds(doc);
   await doc.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.25, error: 0.01 }));
+  mutate?.(doc);   // the mutation-control seam (tests only) — see the param doc
   const after = totalVerts(doc);
-  if (nodesSig(doc) !== preNodes) return { out: null, verdict: "preservation failed: node hierarchy/transforms changed", before, after, ...none };
-  if (matsSig(doc) !== preMats) return { out: null, verdict: "preservation failed: material assignments changed", before, after, ...none };
+  if (lodNodesSig(doc) !== preNodes) return { out: null, verdict: "preservation failed: node hierarchy/transforms changed", before, after, ...none };
+  if (lodMatsSig(doc) !== preMats) return { out: null, verdict: "preservation failed: material assignments changed", before, after, ...none };
   const [postMin, postMax] = sceneBounds(doc);
   for (let i = 0; i < 3; i++) {
     const tol = Math.max((preMax[i] - preMin[i]) * 0.02, 0.01);

--- a/server/optimize.ts
+++ b/server/optimize.ts
@@ -341,15 +341,24 @@ export async function optimizeGlbKtx2(bytes: Uint8Array, encoder: string): Promi
  *  body is a body (it drops extensions it does not know). */
 export function lodExclusion(json: any): string | null {
   if (json?.skins?.length) return "unsupported: skinned/avatar asset (skins)";
-  const used: string[] = json?.extensionsUsed ?? [];
-  if (used.some((e) => /^VRM/i.test(e) || /^VRMC_/i.test(e))) return "unsupported: skinned/avatar asset (VRM metadata)";
+  // fail-closed means NOT trusting well-formedness (review of #156, point 5):
+  // a VRM that forgot extensionsUsed still carries the extension OBJECT, and
+  // multi-set skinning may skip set 0 — look everywhere the structure can be
+  const extNames = [...(json?.extensionsUsed ?? []), ...(json?.extensionsRequired ?? []),
+    ...Object.keys(json?.extensions ?? {})];
+  if (extNames.some((e) => /^VRM/i.test(e) || /^VRMC_/i.test(e))) return "unsupported: skinned/avatar asset (VRM metadata)";
   for (const m of json?.meshes ?? []) for (const p of m.primitives ?? []) {
     if (p.targets?.length) return "unsupported: morph targets the reducer cannot prove preserved";
-    if (p.attributes && ("JOINTS_0" in p.attributes || "WEIGHTS_0" in p.attributes)) return "unsupported: skinned/avatar asset (joint weights)";
+    for (const k of Object.keys(p.attributes ?? {}))
+      if (/^(JOINTS|WEIGHTS)_\d+$/.test(k)) return "unsupported: skinned/avatar asset (joint weights)";
   }
-  for (const a of json?.animations ?? []) for (const c of a.channels ?? [])
-    if (c.target?.path === "weights") return "unsupported: morph-weight animation";
-  return null;   // node TRS animations are fine — the reduce never touches the node tree, and the assert below proves it
+  // v1 reduces STATIC geometry only. An animated object could survive the
+  // reduce structurally, but "could" is not the contract — preservation of
+  // channels/samplers through the diet is unproven here, and fail-closed is
+  // the reviewer-offered v1 answer. A later recipe can earn animation back
+  // with end-to-end evidence.
+  if (json?.animations?.length) return "unsupported: animated object (v1 reduces static geometry only)";
+  return null;
 }
 
 const totalVerts = (doc: Document) => {
@@ -375,23 +384,35 @@ export type LodResult = { out: Uint8Array | null; verdict: string | null; before
  *  (marker's business); textures follow --ktx2's all-or-nothing. */
 export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null): Promise<LodResult & Ktx2Tally> {
   const none = { eligible: 0, converted: 0, failed: [] as string[] };
-  const excluded = lodExclusion(parseGlb(bytes).json);
+  const rawJson = parseGlb(bytes).json;
+  const excluded = lodExclusion(rawJson);
   if (excluded) return { out: null, verdict: excluded, before: 0, after: 0, ...none };
+  // a textured object on an encoder-less box is environmental — and known
+  // from the raw container, BEFORE any expensive transform runs (the pump
+  // retries this every boot; it must cost a JSON parse, not a simplify)
+  if (!encoder && (rawJson?.images?.length ?? 0) > 0) return { out: null, verdict: "__no_encoder__", before: 0, after: 0, ...none };
   const io = await getIO();
   const doc = await io.readBinary(bytes);
   // same head as the ktx2 diet, so the two variants agree on structure
   await doc.transform(dedup(), prune(), resample());
   const before = totalVerts(doc);
   if (before < LOD_MIN_VERTS) return { out: null, verdict: `already light (${before} verts < ${LOD_MIN_VERTS})`, before, after: before, ...none };
-  // what the world depends on, captured AFTER the shared head (parity with
-  // the ktx2 variant) and asserted after the reduce
-  const names = (d: Document) => d.getRoot().listNodes().map((n) => n.getName()).sort().join("\u0000");
-  const mats = (d: Document) => d.getRoot().listMaterials().map((m) => m.getName()).sort().join("\u0000");
-  const preNames = names(doc), preMats = mats(doc), [preMin, preMax] = sceneBounds(doc);
+  // What the world depends on, captured AFTER the shared head (parity with
+  // the ktx2 variant) and asserted after the reduce. Not just names (review
+  // of #156, point 6): the HIERARCHY with each node's transform, and each
+  // primitive's material ASSIGNMENT — the reduce may only touch vertex data.
+  const nodesSig = (d: Document) => {
+    const walk = (n: any): any => [n.getName(), n.getTranslation(), n.getRotation(), n.getScale(),
+      n.getMesh()?.getName() ?? null, n.listChildren().map(walk)];
+    return JSON.stringify(d.getRoot().listScenes().map((sc) => sc.listChildren().map(walk)));
+  };
+  const matsSig = (d: Document) => JSON.stringify(d.getRoot().listMeshes().map((m) =>
+    [m.getName(), m.listPrimitives().map((p) => { const mt = p.getMaterial(); return mt ? d.getRoot().listMaterials().indexOf(mt) : -1; })]));
+  const preNodes = nodesSig(doc), preMats = matsSig(doc), [preMin, preMax] = sceneBounds(doc);
   await doc.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.25, error: 0.01 }));
   const after = totalVerts(doc);
-  if (names(doc) !== preNames) return { out: null, verdict: "preservation failed: named nodes changed", before, after, ...none };
-  if (mats(doc) !== preMats) return { out: null, verdict: "preservation failed: materials changed", before, after, ...none };
+  if (nodesSig(doc) !== preNodes) return { out: null, verdict: "preservation failed: node hierarchy/transforms changed", before, after, ...none };
+  if (matsSig(doc) !== preMats) return { out: null, verdict: "preservation failed: material assignments changed", before, after, ...none };
   const [postMin, postMax] = sceneBounds(doc);
   for (let i = 0; i < 3; i++) {
     const tol = Math.max((preMax[i] - preMin[i]) * 0.02, 0.01);
@@ -411,7 +432,10 @@ export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null):
   const srcHash = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
   let meshoptVer = "unknown";
   try { meshoptVer = JSON.parse(await Bun.file(Bun.resolveSync("meshoptimizer/package.json", import.meta.dir)).text()).version; } catch { /* stays unknown */ }
-  doc.getRoot().getAsset().extras = { lodOf: srcHash, recipe: LOD_RECIPE,
+  // the SOURCE's extras survive; ours ride alongside (never clobber a
+  // producer's own annotations — review of #156, point 6)
+  const asset = doc.getRoot().getAsset();
+  asset.extras = { ...(asset.extras ?? {}), lodOf: srcHash, recipe: LOD_RECIPE,
     tools: { meshoptimizer: meshoptVer, encoder: encoder ? basename(encoder) : "none" } };
   await doc.transform(draco());
   return { out: await io.writeBinary(doc), verdict: null, before, after, ...tally };

--- a/server/optimize.ts
+++ b/server/optimize.ts
@@ -25,9 +25,10 @@
 
 import { NodeIO, type Document } from "@gltf-transform/core";
 import { ALL_EXTENSIONS, KHRTextureBasisu } from "@gltf-transform/extensions";
-import { dedup, prune, resample, textureCompress, draco, listTextureSlots } from "@gltf-transform/functions";
+import { dedup, prune, resample, textureCompress, draco, listTextureSlots, weld, simplify } from "@gltf-transform/functions";
+import { MeshoptSimplifier } from "meshoptimizer";
 import draco3d from "draco3dgltf";
-import { capTexels, recipeStamp } from "./store-variants.ts";
+import { capTexels, recipeStamp, LOD_RECIPE, LOD_MIN_VERTS } from "./store-variants.ts";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, basename, dirname } from "node:path";
@@ -325,6 +326,95 @@ export async function optimizeGlbKtx2(bytes: Uint8Array, encoder: string): Promi
   if (tally.eligible === 0 || tally.converted < tally.eligible) return { out: null, ...tally };
   await doc.transform(draco());
   return { out: await io.writeBinary(doc), ...tally };
+}
+
+// ---- geometry LOD (objects only, fail closed on bodies) ---------------------
+// The v1 contract (PR #142 thread): a decimated variant for PLACEABLE
+// OBJECTS. Bodies are excluded by POSITIVE STRUCTURAL DETECTION on the raw
+// container — before any Document is constructed — and the answer is a typed
+// verdict, never a silent attempt. For accepted objects the reduce must
+// PROVE it preserved what the world depends on: named nodes (parts, socket
+// frames), materials, bounds (seat pans, collider fits) — or refuse.
+
+/** Why this GLB is not an object the reducer may touch — or null. Reads the
+ *  raw JSON chunk: gltf-transform must not be the thing deciding whether a
+ *  body is a body (it drops extensions it does not know). */
+export function lodExclusion(json: any): string | null {
+  if (json?.skins?.length) return "unsupported: skinned/avatar asset (skins)";
+  const used: string[] = json?.extensionsUsed ?? [];
+  if (used.some((e) => /^VRM/i.test(e) || /^VRMC_/i.test(e))) return "unsupported: skinned/avatar asset (VRM metadata)";
+  for (const m of json?.meshes ?? []) for (const p of m.primitives ?? []) {
+    if (p.targets?.length) return "unsupported: morph targets the reducer cannot prove preserved";
+    if (p.attributes && ("JOINTS_0" in p.attributes || "WEIGHTS_0" in p.attributes)) return "unsupported: skinned/avatar asset (joint weights)";
+  }
+  for (const a of json?.animations ?? []) for (const c of a.channels ?? [])
+    if (c.target?.path === "weights") return "unsupported: morph-weight animation";
+  return null;   // node TRS animations are fine — the reduce never touches the node tree, and the assert below proves it
+}
+
+const totalVerts = (doc: Document) => {
+  let n = 0;
+  for (const m of doc.getRoot().listMeshes()) for (const p of m.listPrimitives()) n += p.getAttribute("POSITION")?.getCount() ?? 0;
+  return n;
+};
+const sceneBounds = (doc: Document): [number[], number[]] => {
+  const min = [Infinity, Infinity, Infinity], max = [-Infinity, -Infinity, -Infinity];
+  for (const m of doc.getRoot().listMeshes()) for (const p of m.listPrimitives()) {
+    const pos = p.getAttribute("POSITION"); if (!pos) continue;
+    const lo = pos.getMin([0, 0, 0]), hi = pos.getMax([0, 0, 0]);
+    for (let i = 0; i < 3; i++) { min[i] = Math.min(min[i], lo[i]); max[i] = Math.max(max[i], hi[i]); }
+  }
+  return [min, max];
+};
+
+export type LodResult = { out: Uint8Array | null; verdict: string | null; before: number; after: number };
+
+/** The lod1 diet: the ktx2 diet (dedup/prune/resample + texel-budget KTX2 +
+ *  draco) with weld + meshopt-simplify between — and the preservation
+ *  asserts around the reduce. `verdict` non-null = a typed content refusal
+ *  (marker's business); textures follow --ktx2's all-or-nothing. */
+export async function optimizeGlbLod(bytes: Uint8Array, encoder: string | null): Promise<LodResult & Ktx2Tally> {
+  const none = { eligible: 0, converted: 0, failed: [] as string[] };
+  const excluded = lodExclusion(parseGlb(bytes).json);
+  if (excluded) return { out: null, verdict: excluded, before: 0, after: 0, ...none };
+  const io = await getIO();
+  const doc = await io.readBinary(bytes);
+  // same head as the ktx2 diet, so the two variants agree on structure
+  await doc.transform(dedup(), prune(), resample());
+  const before = totalVerts(doc);
+  if (before < LOD_MIN_VERTS) return { out: null, verdict: `already light (${before} verts < ${LOD_MIN_VERTS})`, before, after: before, ...none };
+  // what the world depends on, captured AFTER the shared head (parity with
+  // the ktx2 variant) and asserted after the reduce
+  const names = (d: Document) => d.getRoot().listNodes().map((n) => n.getName()).sort().join("\u0000");
+  const mats = (d: Document) => d.getRoot().listMaterials().map((m) => m.getName()).sort().join("\u0000");
+  const preNames = names(doc), preMats = mats(doc), [preMin, preMax] = sceneBounds(doc);
+  await doc.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.25, error: 0.01 }));
+  const after = totalVerts(doc);
+  if (names(doc) !== preNames) return { out: null, verdict: "preservation failed: named nodes changed", before, after, ...none };
+  if (mats(doc) !== preMats) return { out: null, verdict: "preservation failed: materials changed", before, after, ...none };
+  const [postMin, postMax] = sceneBounds(doc);
+  for (let i = 0; i < 3; i++) {
+    const tol = Math.max((preMax[i] - preMin[i]) * 0.02, 0.01);
+    if (Math.abs(postMin[i] - preMin[i]) > tol || Math.abs(postMax[i] - preMax[i]) > tol)
+      return { out: null, verdict: `preservation failed: bounds moved on axis ${i}`, before, after, ...none };
+  }
+  if (after > before * 0.6) return { out: null, verdict: `reduction ineffective (${before} -> ${after} verts)`, before, after, ...none };
+  // textures: the ktx2 arm's rules verbatim — all eligible convert or nothing ships
+  let tally: Ktx2Tally = none;
+  if (encoder) {
+    tally = await ktx2CompressTextures(doc, encoder);
+    if (tally.eligible > 0 && tally.converted < tally.eligible) return { out: null, verdict: null, before, after, ...tally };
+  } else if (doc.getRoot().listTextures().some((t) => t.getImage())) {
+    return { out: null, verdict: "__no_encoder__", before, after, ...none };   // env, the CLI exit-3s
+  }
+  // identity: the variant SAYS what it is a variant of, and how it was made
+  const srcHash = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+  let meshoptVer = "unknown";
+  try { meshoptVer = JSON.parse(await Bun.file(Bun.resolveSync("meshoptimizer/package.json", import.meta.dir)).text()).version; } catch { /* stays unknown */ }
+  doc.getRoot().getAsset().extras = { lodOf: srcHash, recipe: LOD_RECIPE,
+    tools: { meshoptimizer: meshoptVer, encoder: encoder ? basename(encoder) : "none" } };
+  await doc.transform(draco());
+  return { out: await io.writeBinary(doc), verdict: null, before, after, ...tally };
 }
 
 // ---- KTX2 for VRMs (§20c): the surgical container rewrite -------------------
@@ -850,6 +940,10 @@ export async function transcodeImageKtx2(src: Uint8Array, srcPath: string, encod
 // failure, reason on stderr.
 // Exit 3 (any --ktx2* mode) = no KTX2 encoder on this box — environmental,
 // the caller must env-skip (never a .failed marker).
+// --lod shares the whole ladder: exit 2 for typed content verdicts (a body,
+// fail closed; nothing to reduce; a preservation assert), exit 3 when a
+// textured object meets a box with no encoder, exit 5 for a partial texture
+// conversion — REFUSED, retryable.
 // Exit 5 (--ktx2) = an encoder answered but not every eligible texture
 // converted — the variant is REFUSED, nothing written. Environmental too (a
 // flaky or misconfigured encoder, not a bad model): no marker, retried next
@@ -859,6 +953,7 @@ if (import.meta.main) {
   const argv = process.argv.slice(2);
   const mode = argv.includes("--ktx2-img") ? "--ktx2-img"
     : argv.includes("--ktx2-vrm") ? "--ktx2-vrm"
+    : argv.includes("--lod") ? "--lod"
     : argv.includes("--ktx2") ? "--ktx2" : null;
   const ktx2Mode = mode !== null;
   const [inPath, outPath] = argv.filter((a) => !a.startsWith("--"));
@@ -867,7 +962,8 @@ if (import.meta.main) {
     process.exit(1);
   }
   let encoder: string | null = null;
-  if (ktx2Mode && !(encoder = findKtx2Encoder())) {
+  if (mode === "--lod") encoder = findKtx2Encoder();   // optional here: an untextured object reduces fine without one
+  else if (ktx2Mode && !(encoder = findKtx2Encoder())) {
     console.error("[optimize] ktx2: no encoder — set KTX2_TOKTX or put toktx/ktx on PATH (docs/ktx2-encoder.md)");
     process.exit(3);
   }
@@ -890,6 +986,22 @@ if (import.meta.main) {
         process.exit(2);
       }
       console.log(`[optimize] ktx2-vrm: ${r.converted} image(s) → ${r.etc1s} etc1s + ${r.uastc} uastc`);
+      out = r.out;
+    } else if (mode === "--lod") {
+      const r = await optimizeGlbLod(src, encoder);
+      if (r.verdict === "__no_encoder__") {
+        console.error("[optimize] lod: textured object and no KTX2 encoder — set KTX2_TOKTX or put toktx/ktx on PATH (docs/ktx2-encoder.md)");
+        process.exit(3);
+      }
+      if (r.verdict) {   // a typed content refusal — fail closed, marker's business
+        console.error(`[optimize] lod: ${r.verdict} (${Math.round(performance.now() - t0)}ms) — original stays the only representation`);
+        process.exit(2);
+      }
+      if (!r.out) {
+        console.error(`[optimize] lod: ${r.converted}/${r.eligible} texture(s) converted — REFUSING a partial variant (${r.failed.join(", ")}); retry when the encoder is sane`);
+        process.exit(5);
+      }
+      console.log(`[optimize] lod: ${r.before} -> ${r.after} verts, ${r.converted}/${r.eligible} texture(s) at the texel budget`);
       out = r.out;
     } else if (mode === "--ktx2") {
       const r = await optimizeGlbKtx2(src, encoder!);
@@ -916,7 +1028,7 @@ if (import.meta.main) {
     if (out.length >= src.length * (ktx2Mode ? 1.25 : 0.95)) {
       // the KTX2 verdict carries its recipe: a later recipe re-measures it
       // (store-variants.ts verdictStands) instead of inheriting the refusal
-      console.error(`[optimize] not smaller (${src.length} -> ${out.length}, ${ms}ms)${ktx2Mode ? ` ${recipeStamp()}` : ""} — keeping original`);
+      console.error(`[optimize] not smaller (${src.length} -> ${out.length}, ${ms}ms)${ktx2Mode ? ` ${recipeStamp(mode === "--lod" ? LOD_RECIPE : undefined)}` : ""} — keeping original`);
       process.exit(2);
     }
     // …and the same care about CONTENT: a GLB whose images are not images is

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,7 +16,7 @@ import { randomBytes } from "node:crypto";
 import { ROOT, WORLDS_DIR, LIBRARY_DIR, OPT_DIR, PATCH_DIR, JOIN_TOKEN } from "./config.ts";
 import { isStoreOriginal, isServingArtifact } from "./store-variants.ts";
 import { wantsKtx2, KTX2_KEY } from "../shared/ktx2.js";
-import { LOD_RECIPE } from "./store-variants.ts";
+import { LOD_RECIPE, lodVariantPath } from "./store-variants.ts";
 import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_ISSUER_KEY, HN_ISS, HN_AUD, HN_LOGIN_URL, HN_REQUIRE_LOGIN } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
@@ -677,14 +677,27 @@ const ROUTES: Route[] = [
       // unflagged fetch — whatever that client pinned under it, it keeps.
       const wantKtx2 = wantsKtx2(url.searchParams) && negotiable;
       // The LOD tier rides the ktx2 negotiation (a LOD variant carries KTX2
-      // textures) and the same split-brain rule: a client only asks for it
-      // when /version published lodRecipe, so an older sequencer is never
-      // asked with a param it would fall through immutable (the =2 lesson).
-      const wantLod = url.searchParams.get("lod") === "1" && wantKtx2 && rel.endsWith(".glb");
+      // textures) and the same split-brain rule twice over: a client only
+      // asks with the RECIPE /version published — the URL carries the
+      // generation, so a recipe change is a fresh URL and a fresh file, and
+      // yesterday's reduction can never sit pinned under today's address.
+      const lodAsked = url.searchParams.get("lod");
+      const wantLod = lodAsked === LOD_RECIPE && wantKtx2 && rel.endsWith(".glb");
       if (wantLod) {
-        const lRel = `${rel}.lod1.glb`;
+        const lRel = lodVariantPath(rel);
         const l = normalize(join(OPT_DIR, lRel));
-        if (l.startsWith(OPT_DIR) && existsSync(l)) return serveFrom(OPT_DIR, lRel, true, req, versioned);
+        if (l.startsWith(OPT_DIR) && existsSync(l)) {
+          // library sources are MUTABLE: an updated model with a not-yet-
+          // rebuilt variant must fall through provisional, never serve the
+          // old body under the new ?v= (the §20c vrm freshness discipline)
+          let fresh = true;
+          if (!rel.startsWith("store/")) {
+            const src = [[PATCH_DIR, normalize(join(PATCH_DIR, rel))], [OPT_DIR, normalize(join(OPT_DIR, rel))], [LIBRARY_DIR, normalize(join(LIBRARY_DIR, rel))]]
+              .find(([b, p]) => p.startsWith(b) && existsSync(p))?.[1];
+            fresh = !!src && Bun.file(l).lastModified > Bun.file(src).lastModified;
+          }
+          if (fresh) return serveFrom(OPT_DIR, lRel, true, req, versioned);
+        }
       }
       if (wantKtx2) {
         const kRel = rel.endsWith(".glb") ? `${rel}.ktx2.glb`
@@ -699,7 +712,7 @@ const ROUTES: Route[] = [
           }
           // a lod-requesting fetch answered by the plain ktx2 variant is
           // still PROVISIONAL — the lod may land later under this same URL
-          if (fresh) return serveFrom(OPT_DIR, kRel, true, req, versioned, wantLod);
+          if (fresh) return serveFrom(OPT_DIR, kRel, true, req, versioned, wantLod || (lodAsked != null && !wantLod));
         }
       }
       // A flagged fetch that falls through is PROVISIONAL for that URL, not
@@ -712,7 +725,10 @@ const ROUTES: Route[] = [
       // ?ktx2=1 answer immutable, every one webp). no-cache rides the ETag —
       // a 304 while nothing changed, the variant's bytes the moment it exists;
       // nginx honors it (nginx-show.conf) and simply does not cache these.
-      const provisional = wantKtx2;
+      // an unrecognized lod value is a generation this process does not run
+      // (a pull mid-window, a buggy client): whatever answers must not be
+      // pinned under that URL — the NEXT process may negotiate it
+      const provisional = wantKtx2 || (lodAsked != null && !wantLod);
       // store uploads: prefer the store-min shadow — same address, the
       // original stays as provenance and as the fallback while (or if) the
       // optimize pass hasn't landed for this hash

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,6 +16,7 @@ import { randomBytes } from "node:crypto";
 import { ROOT, WORLDS_DIR, LIBRARY_DIR, OPT_DIR, PATCH_DIR, JOIN_TOKEN } from "./config.ts";
 import { isStoreOriginal, isServingArtifact } from "./store-variants.ts";
 import { wantsKtx2, KTX2_KEY } from "../shared/ktx2.js";
+import { LOD_RECIPE } from "./store-variants.ts";
 import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_ISSUER_KEY, HN_ISS, HN_AUD, HN_LOGIN_URL, HN_REQUIRE_LOGIN } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
@@ -454,6 +455,7 @@ const ROUTES: Route[] = [
       JSON.stringify({
         ...BUILD,
         ktx2Key: KTX2_KEY,
+        lodRecipe: LOD_RECIPE,
         ...(process.env.WORLD_INSTANCE_NONCE ? { instance: process.env.WORLD_INSTANCE_NONCE } : {}),
       }),
       { headers: { "content-type": "application/json", "cache-control": "no-store" } }),
@@ -674,6 +676,16 @@ const ROUTES: Route[] = [
       // The key is a generation (shared/ktx2.js): a retired one is an
       // unflagged fetch — whatever that client pinned under it, it keeps.
       const wantKtx2 = wantsKtx2(url.searchParams) && negotiable;
+      // The LOD tier rides the ktx2 negotiation (a LOD variant carries KTX2
+      // textures) and the same split-brain rule: a client only asks for it
+      // when /version published lodRecipe, so an older sequencer is never
+      // asked with a param it would fall through immutable (the =2 lesson).
+      const wantLod = url.searchParams.get("lod") === "1" && wantKtx2 && rel.endsWith(".glb");
+      if (wantLod) {
+        const lRel = `${rel}.lod1.glb`;
+        const l = normalize(join(OPT_DIR, lRel));
+        if (l.startsWith(OPT_DIR) && existsSync(l)) return serveFrom(OPT_DIR, lRel, true, req, versioned);
+      }
       if (wantKtx2) {
         const kRel = rel.endsWith(".glb") ? `${rel}.ktx2.glb`
           : rel.endsWith(".vrm") ? `${rel}.ktx2.vrm` : `${rel}.ktx2`;
@@ -685,7 +697,9 @@ const ROUTES: Route[] = [
               .find(([base, p]) => p.startsWith(base) && existsSync(p))?.[1];
             fresh = !!orig && Bun.file(k).lastModified > Bun.file(orig).lastModified;
           }
-          if (fresh) return serveFrom(OPT_DIR, kRel, true, req, versioned);
+          // a lod-requesting fetch answered by the plain ktx2 variant is
+          // still PROVISIONAL — the lod may land later under this same URL
+          if (fresh) return serveFrom(OPT_DIR, kRel, true, req, versioned, wantLod);
         }
       }
       // A flagged fetch that falls through is PROVISIONAL for that URL, not

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -92,18 +92,23 @@ export const recipeStamp = (recipe = KTX2_RECIPE) => `recipe=${recipe}`;
 // exact tool versions. Named nodes, materials, and bounds are asserted
 // unchanged after the reduce — a failed assert is a typed verdict too, not
 // a half-valid object.
-export const LOD_SUFFIX = ".lod1.glb";
 export const LOD_RECIPE = "lod1-r25e01-texel1024";   // ratio 0.25, error 0.01, ktx2 texel budget
 export const LOD_MIN_VERTS = 12_000;                 // under this, there is nothing worth reducing
 
-/** A geometry-LOD serving artifact (`<rel>.lod1.glb`, future tiers too). */
+/** A geometry-LOD serving artifact — ANY recipe generation's, not only the
+ *  current one (old generations must stay unlisted and uncatalogued too). */
 export function isLodVariant(name: string): boolean {
-  return /\.lod\d+\.glb$/i.test(name);
+  return /\.lod\.[a-z0-9.-]+\.glb$/i.test(name);
 }
 
-/** Where the LOD shadow of an original lives: beside it, like the KTX2 one. */
-export function lodVariantPath(original: string): string {
-  return `${original}${LOD_SUFFIX}`;
+/** Where the LOD shadow of an original lives: beside it, like the KTX2 one —
+ *  and the RECIPE IS IN THE NAME, exactly as it is in the URL (review of
+ *  #156, point 1): a new recipe is a new file under a new URL, so a recipe
+ *  change can never serve yesterday's reduction under today's address. The
+ *  old generation's file simply stops being asked for (and the pump deletes
+ *  it when the new one lands). */
+export function lodVariantPath(original: string, recipe = LOD_RECIPE): string {
+  return `${original}.lod.${recipe}.glb`;
 }
 
 /** Does a `.failed` verdict still stand under the current recipe? A size

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -79,6 +79,33 @@ export function capTexels(size: [number, number] | null | undefined, cap = KTX2_
 export const KTX2_RECIPE = "texel1024";
 export const recipeStamp = (recipe = KTX2_RECIPE) => `recipe=${recipe}`;
 
+// ---- the geometry LOD (objects only — v1 contract, PR #142 thread) ---------
+// A far or VRAM-pressed client can ask for a decimated variant of a PLACEABLE
+// OBJECT: `<rel>.lod1.glb` beside the original — weld + meshopt-simplify
+// (the avatar importer's own proven diet) at LOD_RATIO, textures at the
+// ktx2 texel budget, draco. BODIES ARE OUT OF SCOPE AND FAIL CLOSED, by
+// positive structural detection, never filename folklore: skins / joint
+// weights, VRM metadata, morph targets, morph-weight animation channels —
+// any of them means NO variant and a typed verdict ("unsupported: skinned/
+// avatar asset"), the original staying the only served representation. The
+// variant binds its identity in asset.extras: source sha256 + this recipe +
+// exact tool versions. Named nodes, materials, and bounds are asserted
+// unchanged after the reduce — a failed assert is a typed verdict too, not
+// a half-valid object.
+export const LOD_SUFFIX = ".lod1.glb";
+export const LOD_RECIPE = "lod1-r25e01-texel1024";   // ratio 0.25, error 0.01, ktx2 texel budget
+export const LOD_MIN_VERTS = 12_000;                 // under this, there is nothing worth reducing
+
+/** A geometry-LOD serving artifact (`<rel>.lod1.glb`, future tiers too). */
+export function isLodVariant(name: string): boolean {
+  return /\.lod\d+\.glb$/i.test(name);
+}
+
+/** Where the LOD shadow of an original lives: beside it, like the KTX2 one. */
+export function lodVariantPath(original: string): string {
+  return `${original}${LOD_SUFFIX}`;
+}
+
 /** Does a `.failed` verdict still stand under the current recipe? A size
  *  verdict ("not smaller") stands only if it carries the current stamp;
  *  anything else stands regardless. */
@@ -101,7 +128,7 @@ export function isKtx2Variant(name: string): boolean {
  *  prefetcher pushes every listed store path as a fetch, and a marker fetched
  *  as a model is a 404 on a good day. */
 export function isServingArtifact(name: string): boolean {
-  return isKtx2Variant(name) || /\.(failed|tmp)$/i.test(name);
+  return isKtx2Variant(name) || isLodVariant(name) || /\.(failed|tmp)$/i.test(name);
 }
 
 /** Is this store/ entry an upload, as opposed to a variant of one? The
@@ -109,7 +136,7 @@ export function isServingArtifact(name: string): boolean {
  *  a variant is the SAME model, not a second catalog entry and not a
  *  candidate for its own shadows. */
 export function isStoreOriginal(name: string): boolean {
-  return name.endsWith(".glb") && !isKtx2Variant(name);
+  return name.endsWith(".glb") && !isKtx2Variant(name) && !isLodVariant(name);
 }
 
 /** Where the KTX2 shadow of a store original lives: beside it, `<path>.ktx2.glb`
@@ -129,12 +156,15 @@ export function storeShadowsMissing(
   minDir: string,
   exists: (p: string) => boolean = existsSync,
   read: (p: string) => string = (p) => { try { return readFileSync(p, "utf8"); } catch { return ""; } },
-): { min: boolean; ktx2: boolean } {
+): { min: boolean; ktx2: boolean; lod: boolean } {
   const min = join(minDir, basename(original));
   const k = ktx2VariantPath(original);
   const kFailed = `${k}.failed`;
+  const l = lodVariantPath(original);
+  const lFailed = `${l}.failed`;
   return {
     min: !exists(min) && !exists(`${min}.failed`),
     ktx2: !exists(k) && !(exists(kFailed) && verdictStands(read(kFailed))),
+    lod: !exists(l) && !(exists(lFailed) && verdictStands(read(lFailed), LOD_RECIPE)),
   };
 }

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -31,6 +31,7 @@ type OptItem = { src: string; dest: string; mode?: "--ktx2" | "--ktx2-vrm" | "--
 const optQueue: OptItem[] = [];
 let optRunning = false;
 let ktx2Skip = false; // set when a --ktx2 run exits 3 (no encoder) — stop queuing variants this boot
+let lodEncoderWarned = false; // the --lod arm's own once-per-boot note; it never sets ktx2Skip
 function queueOptimize(absPath: string) {
   let pushed = false;
   if (!optQueue.some((q) => q.src === absPath && !q.mode)) {
@@ -48,8 +49,12 @@ function queueOptimize(absPath: string) {
   }
   // The geometry LOD too (objects only — the CLI fails closed on anything
   // skinned, with a typed verdict; the exclusion lives THERE, on the raw
-  // container, never here on a filename).
-  if (!ktx2Skip && !optQueue.some((q) => q.src === absPath && q.mode === "--lod")) {
+  // container, never here on a filename). NOT gated on ktx2Skip: geometry
+  // reduction of an untextured object needs no encoder at all, and killing
+  // it for the encoder's absence deleted valid work (review of #156, point
+  // 3) — the CLI decides per FILE, from the raw container, for a JSON
+  // parse's price.
+  if (!optQueue.some((q) => q.src === absPath && q.mode === "--lod")) {
     optQueue.push({ src: absPath, dest: lodVariantPath(absPath), mode: "--lod" });
     pushed = true;
   }
@@ -81,6 +86,15 @@ async function pumpOptimize() {
       if (code === 0) {
         // a verdict that was re-measured and answered differently is history
         if (existsSync(failed)) try { rmSync(failed); } catch { /* best effort */ }
+        // …and so is an older recipe generation's file: its URL is never
+        // asked for again (the recipe is in both), so the bytes are dead
+        if (mode === "--lod") {
+          const base = basename(src);
+          for (const f of readdirSync(dirname(dest))) {
+            if (f.startsWith(`${base}.lod.`) && f.endsWith(".glb") && join(dirname(dest), f) !== dest)
+              try { rmSync(join(dirname(dest), f)); } catch { /* best effort */ }
+          }
+        }
         const ratio = (Bun.file(src).size / Math.max(1, Bun.file(dest).size)).toFixed(1);
         console.log(mode ? `[ktx2] ${base} → ${basename(dest)} (${ratio}x)` : `[store] optimized ${base} (${ratio}x)`);
       } else if (code === 2) {
@@ -97,6 +111,11 @@ async function pumpOptimize() {
         // convert fine once the encoder stack is sane. Loud, and retried.
         console.error(`[${mode ? "ktx2" : "store"}] ${base} REFUSED — optimized output failed its image check, `
           + `serving the original: ${err.split("\n").filter((l) => l.includes("declares")).join(" | ") || err.split("\n").pop()}`);
+      } else if (code === 3 && mode === "--lod") {
+        // a TEXTURED object met a box with no encoder — per-file and cheap
+        // (the CLI answers from the raw container before any transform), so
+        // no global skip and no purge: untextured objects keep reducing.
+        if (!lodEncoderWarned) { console.log("[lod] no KTX2 encoder — textured objects keep their originals until one lands (docs/ktx2-encoder.md)"); lodEncoderWarned = true; }
       } else if (code === 3 && mode) {
         // No KTX2 encoder on this box — ENVIRONMENTAL, never a .failed marker
         // (that would permanently skip every model authored before
@@ -104,7 +123,7 @@ async function pumpOptimize() {
         // grinding the rest of the sweep against the same missing binary.
         console.log("[ktx2] no encoder — set KTX2_TOKTX or put toktx/ktx on PATH (docs/ktx2-encoder.md); variants skipped this boot");
         ktx2Skip = true;
-        for (let i = optQueue.length - 1; i >= 0; i--) if (optQueue[i].mode) optQueue.splice(i, 1);
+        for (let i = optQueue.length - 1; i >= 0; i--) if (optQueue[i].mode && optQueue[i].mode !== "--lod") optQueue.splice(i, 1);
       } else if (code === 5 && mode) {
         // An encoder answered, but not every eligible texture converted — the
         // CLI REFUSED to write a variant whose name would lie about its
@@ -172,12 +191,16 @@ setTimeout(() => {
       // guard uniform)
       if (e.name.endsWith(`.ktx2${ext}`)) continue;
       const rel = relative(base, p);
-      if (seen.has(rel)) continue; // overlay walked first — it shadows the library copy
-      seen.add(rel);
+      // keyed by (mode, rel): the ktx2 walk and the lod walk cover the SAME
+      // rels on purpose — one shared set silently killed the entire library
+      // lod arm (review of #156, point 2). The overlay-shadows-library rule
+      // still holds per mode.
+      if (seen.has(`${mode}:${rel}`)) continue;
+      seen.add(`${mode}:${rel}`);
       // GLB/VRM variants are themselves GLB/VRM containers (<rel>.ktx2.glb);
       // a loose image's variant IS the ktx2 (<rel>.ktx2 — routes.ts serves it
       // as image/ktx2)
-      const dest = join(OPT_DIR, mode === "--ktx2-img" ? `${rel}.ktx2` : mode === "--lod" ? `${rel}.lod1.glb` : `${rel}.ktx2${ext}`);
+      const dest = join(OPT_DIR, mode === "--ktx2-img" ? `${rel}.ktx2` : mode === "--lod" ? lodVariantPath(rel) : `${rel}.ktx2${ext}`);
       if (existsSync(`${dest}.failed`) && verdictStands(readFileSync(`${dest}.failed`, "utf8"), mode === "--lod" ? LOD_RECIPE : KTX2_RECIPE)) continue;
       // mtime, not mere existence: library files are mutable — an updated
       // model/body/texture rebuilds its variant next boot

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -9,7 +9,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync, rmSync } from "node:fs";
 import { join, basename, dirname, relative } from "node:path";
 import { JOIN_TOKEN, UPLOAD_CAP, ROOT, OPT_DIR, STORE_MIN, LIBRARY_DIR } from "./config.ts";
-import { isStoreOriginal, ktx2VariantPath, storeShadowsMissing, verdictStands } from "./store-variants.ts";
+import { isStoreOriginal, ktx2VariantPath, lodVariantPath, storeShadowsMissing, verdictStands, KTX2_RECIPE, LOD_RECIPE } from "./store-variants.ts";
 import { agentTokens, HN_ISSUER_KEY, HN_ISS, HN_AUD } from "./auth.ts";
 import { verifyToken } from "./aid1.ts";
 import { worlds } from "./world.ts";
@@ -27,7 +27,7 @@ let tripoImportBusy = false;   // one Tripo import at a time — they cost CPU-s
 // ?ktx2=<key> answer, shared/ktx2.js; the §20a diet), both built by a SUBPROCESS — draco encoding is CPU-seconds of
 // synchronous wasm, and inside this process it would freeze pose relay for
 // every world. One file at a time; the sequencer never waits on it.
-type OptItem = { src: string; dest: string; mode?: "--ktx2" | "--ktx2-vrm" | "--ktx2-img" };
+type OptItem = { src: string; dest: string; mode?: "--ktx2" | "--ktx2-vrm" | "--ktx2-img" | "--lod" };
 const optQueue: OptItem[] = [];
 let optRunning = false;
 let ktx2Skip = false; // set when a --ktx2 run exits 3 (no encoder) — stop queuing variants this boot
@@ -46,6 +46,13 @@ function queueOptimize(absPath: string) {
     optQueue.push({ src: absPath, dest: ktx2VariantPath(absPath), mode: "--ktx2" });
     pushed = true;
   }
+  // The geometry LOD too (objects only — the CLI fails closed on anything
+  // skinned, with a typed verdict; the exclusion lives THERE, on the raw
+  // container, never here on a filename).
+  if (!ktx2Skip && !optQueue.some((q) => q.src === absPath && q.mode === "--lod")) {
+    optQueue.push({ src: absPath, dest: lodVariantPath(absPath), mode: "--lod" });
+    pushed = true;
+  }
   if (pushed) pumpOptimize();
 }
 async function pumpOptimize() {
@@ -56,8 +63,9 @@ async function pumpOptimize() {
       const { src, dest, mode } = optQueue.shift()!;
       const base = basename(src);                      // <hash>.glb / <model>.glb
       const failed = `${dest}.failed`;
-      // a KTX2 size verdict from an older recipe does not stand (store-variants.ts)
-      const refused = existsSync(failed) && (!mode || verdictStands(readFileSync(failed, "utf8")));
+      // a size verdict from an older recipe does not stand (store-variants.ts)
+      const refused = existsSync(failed)
+        && (!mode || verdictStands(readFileSync(failed, "utf8"), mode === "--lod" ? LOD_RECIPE : KTX2_RECIPE));
       if (!existsSync(src) || refused) continue;
       // Store shadows are content-addressed — existing means done forever.
       // KTX2 variants shadow MUTABLE library files, so a variant older than
@@ -129,7 +137,7 @@ setTimeout(() => {
   const pending = readdirSync(dir).filter((f) => {
     if (!isStoreOriginal(f)) return false;
     const m = storeShadowsMissing(join(dir, f), STORE_MIN);
-    return m.min || m.ktx2;
+    return m.min || m.ktx2 || m.lod;
   });
   if (!pending.length) return;
   console.log(`[store] boot sweep: ${pending.length} upload(s) missing a shadow queued`);
@@ -169,8 +177,8 @@ setTimeout(() => {
       // GLB/VRM variants are themselves GLB/VRM containers (<rel>.ktx2.glb);
       // a loose image's variant IS the ktx2 (<rel>.ktx2 — routes.ts serves it
       // as image/ktx2)
-      const dest = join(OPT_DIR, mode === "--ktx2-img" ? `${rel}.ktx2` : `${rel}.ktx2${ext}`);
-      if (existsSync(`${dest}.failed`) && verdictStands(readFileSync(`${dest}.failed`, "utf8"))) continue;
+      const dest = join(OPT_DIR, mode === "--ktx2-img" ? `${rel}.ktx2` : mode === "--lod" ? `${rel}.lod1.glb` : `${rel}.ktx2${ext}`);
+      if (existsSync(`${dest}.failed`) && verdictStands(readFileSync(`${dest}.failed`, "utf8"), mode === "--lod" ? LOD_RECIPE : KTX2_RECIPE)) continue;
       // mtime, not mere existence: library files are mutable — an updated
       // model/body/texture rebuilds its variant next boot
       if (existsSync(dest) && statSync(dest).mtimeMs > statSync(p).mtimeMs) continue;
@@ -178,6 +186,9 @@ setTimeout(() => {
     }
   };
   walk(LIBRARY_DIR, join(LIBRARY_DIR, "eidoverse", "assets", "models"), [".glb"], "--ktx2");
+  // the LOD sweep walks the same models (objects; the CLI's structural
+  // exclusion is the body gate, and library models are not bodies anyway)
+  walk(LIBRARY_DIR, join(LIBRARY_DIR, "eidoverse", "assets", "models"), [".glb"], "--lod");
   // overlay first (it wins in routes.ts serving and the /avatars roster)
   walk(OPT_DIR, join(OPT_DIR, "eidoverse", "assets", "vrms"), [".vrm"], "--ktx2-vrm");
   walk(LIBRARY_DIR, join(LIBRARY_DIR, "eidoverse", "assets", "vrms"), [".vrm"], "--ktx2-vrm");

--- a/shared/ktx2.js
+++ b/shared/ktx2.js
@@ -64,11 +64,15 @@ export function lodFromVersion(json) {
   return typeof l === 'string' && l.length > 0 && l.length <= 64 ? l : null;
 }
 
-/** Append the LOD tier request. Only meaningful alongside the ktx2
- *  negotiation (a LOD variant carries KTX2 textures) and only when
- *  lodFromVersion said the running sequencer builds them. */
-export function withLod(url) {
-  return url + (url.includes('?') ? '&' : '?') + 'lod=1';
+/** Append the LOD tier request — the RECIPE the running sequencer published,
+ *  never a bare boolean (review of #156, point 1: `lod=1` under two recipes
+ *  is one immutable URL for two different byte-streams — the ?ktx2=2
+ *  split-brain, one level down). No recipe → the URL untouched. Only
+ *  meaningful alongside the ktx2 negotiation (a LOD variant carries KTX2
+ *  textures). */
+export function withLod(url, recipe) {
+  if (!recipe) return url;
+  return url + (url.includes('?') ? '&' : '?') + `lod=${encodeURIComponent(recipe)}`;
 }
 
 /** The sequencer's own spelling (tests, tools): negotiate with the key this

--- a/shared/ktx2.js
+++ b/shared/ktx2.js
@@ -54,6 +54,23 @@ export function negotiate(url, key) {
   return url + (url.includes('?') ? '&' : '?') + `ktx2=${key}`;
 }
 
+/** The LOD recipe the running sequencer published on /version, or null when
+ *  it published none — an older sequencer, and the client must not ask for a
+ *  tier it never heard of (the same split-brain that poisoned ?ktx2=2: an
+ *  unknown param falls through to the original, served immutable under the
+ *  flagged URL). Same doctrine as keyFromVersion: never a default. */
+export function lodFromVersion(json) {
+  const l = json && typeof json === 'object' ? json.lodRecipe : undefined;
+  return typeof l === 'string' && l.length > 0 && l.length <= 64 ? l : null;
+}
+
+/** Append the LOD tier request. Only meaningful alongside the ktx2
+ *  negotiation (a LOD variant carries KTX2 textures) and only when
+ *  lodFromVersion said the running sequencer builds them. */
+export function withLod(url) {
+  return url + (url.includes('?') ? '&' : '?') + 'lod=1';
+}
+
 /** The sequencer's own spelling (tests, tools): negotiate with the key this
  *  file defines. A BROWSER must not call this — it would be reading the key
  *  off disk again, which is the collision. */

--- a/tools/object-lod-test.ts
+++ b/tools/object-lod-test.ts
@@ -1,0 +1,352 @@
+// The geometry LOD for placeable objects (server/optimize.ts --lod,
+// store-variants.ts), run headless — v1 of the contract agreed in the #142
+// thread: OBJECTS ONLY, BODIES FAIL CLOSED.
+//
+//   bun tools/object-lod-test.ts
+//
+// The contract under test, in the reviewer's terms:
+//   - bodies are excluded by POSITIVE STRUCTURAL DETECTION on the raw
+//     container — skins, joint weights, VRM metadata, morph targets,
+//     morph-weight animation channels — with a truthful typed verdict
+//     (`unsupported: skinned/avatar asset`), no geometry LOD, no silent
+//     attempt; the original stays the only served representation;
+//   - the original is preserved byte-identically (the variant is a sibling);
+//   - variant identity binds source content hash + recipe + tool versions
+//     (asset.extras: lodOf / recipe / tools);
+//   - named nodes, materials, and bounds are asserted unchanged after the
+//     reduce — a failed assert or an ineffective reduce is a typed verdict,
+//     never a half-valid object;
+//   - the client asks with ?lod=1 riding the ktx2 negotiation, and ONLY when
+//     /version published lodRecipe (the ?ktx2=2 split-brain lesson);
+//   - a missing variant falls back to the original/ktx2 chain, PROVISIONAL
+//     (no-cache) so the variant's bytes get through the moment it lands;
+//   - variants and their markers never leak into catalogs or listings.
+//
+// The fake toktx (the store-variants-test pattern) stands in for the
+// encoder, so no KTX-Software is needed; the one real-encoder receipt runs
+// when the box has one.
+//
+// Negative control: on main this file dies at import (no isLodVariant, no
+// optimizeGlbLod); the serving checks fail on main with the variant never
+// built and ?lod=1 answered immutable (the poison this arm's negotiation
+// gate exists to prevent).
+
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, rmdirSync, chmodSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Document, NodeIO } from "@gltf-transform/core";
+import { PNG } from "pngjs";
+import { isLodVariant, isServingArtifact, isStoreOriginal, lodVariantPath, storeShadowsMissing,
+  LOD_RECIPE, LOD_MIN_VERTS, recipeStamp } from "../server/store-variants.ts";
+import { lodExclusion, findKtx2Encoder } from "../server/optimize.ts";
+import { lodFromVersion, withLod, keyFromVersion, negotiate } from "../shared/ktx2.js";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${label}${!ok && detail ? `\n      ${detail}` : ""}`);
+  if (!ok) failures++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const until = async (pred: () => boolean, ms: number, step = 250) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) { if (pred()) return true; await sleep(step); }
+  return pred();
+};
+const ROOT = join(import.meta.dir, "..");
+const OPTIMIZE = join(ROOT, "server", "optimize.ts");
+
+console.log("\ngeometry LOD for placeable objects — bodies fail closed:\n");
+
+// ---------------------------------------------- 1. names, predicates, negotiation
+{
+  check("a lod variant is named beside its original", lodVariantPath("/x/store/abc.glb") === "/x/store/abc.glb.lod1.glb");
+  for (const v of ["abc.glb.lod1.glb", "model.glb.lod2.glb", "UPPER.GLB.LOD1.GLB"])
+    check(`${v} is a lod variant and a serving artifact`, isLodVariant(v) && isServingArtifact(v) && !isStoreOriginal(v));
+  for (const o of ["abc.glb", "abc.glb.ktx2.glb", "lod1.glb", "model.lod.glb"])
+    check(`${o} is not a lod variant`, !isLodVariant(o));
+  check("a lod .failed marker is an artifact, never a listing entry", isServingArtifact("abc.glb.lod1.glb.failed"));
+  const m = storeShadowsMissing("/x/store/abc.glb", "/x/store-min", () => false);
+  check("a fresh original lacks all three shadows", m.min && m.ktx2 && m.lod);
+  const m2 = storeShadowsMissing("/x/store/abc.glb", "/x/store-min",
+    (p) => p === "/x/store/abc.glb.lod1.glb.failed", () => "[optimize] lod: unsupported: skinned/avatar asset (skins)");
+  check("a typed exclusion verdict STANDS (a body never becomes a retry loop)", !m2.lod);
+  const m3 = storeShadowsMissing("/x/store/abc.glb", "/x/store-min",
+    (p) => p === "/x/store/abc.glb.lod1.glb.failed", () => "[optimize] not smaller (9 -> 10, 1ms) — keeping original");
+  check("an unstamped lod size verdict is stale — re-measured under the current recipe", m3.lod);
+
+  check("the client only asks for a tier the running sequencer published", lodFromVersion({ lodRecipe: LOD_RECIPE }) === LOD_RECIPE);
+  check("an older sequencer publishes none → null → no ?lod (the split-brain gate)", lodFromVersion({ sha: "old" }) === null && lodFromVersion(null) === null);
+  check("withLod appends", withLod("store/x.glb?ktx2=3") === "store/x.glb?ktx2=3&lod=1" && withLod("x.glb") === "x.glb?lod=1");
+}
+
+// ---------------------------------------------- 2. the structural exclusion, pure
+{
+  const base = { meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }] };
+  check("a plain object is not excluded", lodExclusion(base) === null);
+  check("skins exclude", /skinned\/avatar/.test(lodExclusion({ ...base, skins: [{}] }) ?? ""));
+  check("joint weights exclude even without a skins array",
+    /skinned\/avatar/.test(lodExclusion({ meshes: [{ primitives: [{ attributes: { POSITION: 0, JOINTS_0: 1, WEIGHTS_0: 2 } }] }] }) ?? ""));
+  check("VRM metadata excludes (VRMC_vrm)", /VRM metadata/.test(lodExclusion({ ...base, extensionsUsed: ["VRMC_vrm"] }) ?? ""));
+  check("…and legacy VRM 0.x", /VRM metadata/.test(lodExclusion({ ...base, extensionsUsed: ["VRM"] }) ?? ""));
+  check("morph targets exclude", /morph targets/.test(lodExclusion({ meshes: [{ primitives: [{ attributes: { POSITION: 0 }, targets: [{}] }] }] }) ?? ""));
+  check("morph-weight animation excludes", /morph-weight/.test(lodExclusion({ ...base, animations: [{ channels: [{ target: { path: "weights" } }] }] }) ?? ""));
+  check("node TRS animation does NOT exclude (structure is asserted instead)",
+    lodExclusion({ ...base, animations: [{ channels: [{ target: { path: "rotation" } }] }] }) === null);
+}
+
+// ---------------------------------------------- fixtures
+const NONCE = crypto.randomUUID();
+function pngBytes(seed: number, W = 64): Uint8Array {
+  const png = new PNG({ width: W, height: W });
+  for (let y = 0; y < W; y++) for (let x = 0; x < W; x++) {
+    const i = (y * W + x) * 4;
+    png.data[i] = (x * 4 + seed) & 0xff; png.data[i + 1] = (y * 4) & 0xff; png.data[i + 2] = ((x ^ y) * 4) & 0xff; png.data[i + 3] = 255;
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+/** A dense smooth grid — the kind of mesh a reducer actually reduces.
+ *  `cells`² quads ≈ (cells+1)² verts; gentle height noise keeps prune()
+ *  honest and simplify effective. Textured when `textured`. */
+async function gridGlb(tag: string, cells: number, textured: boolean, nodeName = "hero"): Promise<Uint8Array> {
+  const doc = new Document();
+  const buf = doc.createBuffer();
+  const n = cells + 1;
+  const pos = new Float32Array(n * n * 3), uv = new Float32Array(n * n * 2);
+  for (let y = 0; y < n; y++) for (let x = 0; x < n; x++) {
+    const i = y * n + x;
+    pos[i * 3] = x / cells; pos[i * 3 + 1] = Math.sin(x * 0.37) * Math.cos(y * 0.29) * 0.02; pos[i * 3 + 2] = y / cells;
+    uv[i * 2] = x / cells; uv[i * 2 + 1] = y / cells;
+  }
+  const idx = new Uint32Array(cells * cells * 6);
+  let k = 0;
+  for (let y = 0; y < cells; y++) for (let x = 0; x < cells; x++) {
+    const a = y * n + x, b = a + 1, c = a + n, d = c + 1;
+    idx[k++] = a; idx[k++] = c; idx[k++] = b; idx[k++] = b; idx[k++] = c; idx[k++] = d;
+  }
+  const mat = doc.createMaterial("probeMat");
+  if (textured) mat.setBaseColorTexture(doc.createTexture("base").setImage(pngBytes(1)).setMimeType("image/png"));
+  const prim = doc.createPrimitive().setMaterial(mat)
+    .setIndices(doc.createAccessor().setType("SCALAR").setBuffer(buf).setArray(idx))
+    .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf).setArray(pos))
+    .setAttribute("TEXCOORD_0", doc.createAccessor().setType("VEC2").setBuffer(buf).setArray(uv));
+  doc.createScene("s").addChild(doc.createNode(`${nodeName}-${tag}-${NONCE}`).setMesh(doc.createMesh("gridMesh").addPrimitive(prim)));
+  return new NodeIO().writeBinary(doc);
+}
+/** The same grid with a skin bound on — a BODY, structurally. */
+async function skinnedGlb(tag: string): Promise<Uint8Array> {
+  const doc = new Document();
+  const buf = doc.createBuffer();
+  const prim = doc.createPrimitive()
+    .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf).setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])))
+    .setAttribute("JOINTS_0", doc.createAccessor().setType("VEC4").setBuffer(buf).setArray(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])))
+    .setAttribute("WEIGHTS_0", doc.createAccessor().setType("VEC4").setBuffer(buf).setArray(new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0])));
+  const joint = doc.createNode(`joint-${tag}`);
+  const skin = doc.createSkin("rig").addJoint(joint);
+  const node = doc.createNode(`body-${tag}-${NONCE}`).setMesh(doc.createMesh("m").addPrimitive(prim)).setSkin(skin);
+  doc.createScene("s").addChild(node).addChild(joint);
+  return new NodeIO().writeBinary(doc);
+}
+const hashOf = (b: Uint8Array) => new Bun.CryptoHasher("sha256").update(b).digest("hex").slice(0, 16);
+const glbJson = (bytes: Uint8Array) => {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset);
+  return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + dv.getUint32(12, true))));
+};
+
+// the fake toktx (the store-variants-test pattern, ok-mode only)
+const CANNED_KTX2 = Uint8Array.from(atob(
+  "q0tUWCAyMLsNChoKAAAAAAEAAAAEAAAABAAAAAAAAAAAAAAAAQAAAAMAAAABAAAAmAAAACwAAADEAAAAeAAAAEABAAAAAAAAtwAAAAAAAAD5AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAD4AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAD3AQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAIAKACjAQIAAwMAAAgAAAAAAAAAAAA/AAAAAAAAAAAA/////xIAAABLVFhvcmllbnRhdGlvbgByZAAAACcAAABLVFh3cml0ZXIAdG9rdHggdjQuNC4yIC8gbGlia3R4IHY0LjQuMgAALgAAAEtUWHdyaXRlclNjUGFyYW1zAC0tZW5jb2RlIGV0YzFzIC0tcWxldmVsIDEyOAAAAAAAAAADAAMALwAAAA0AAAArAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAALABIAAAAAAACIIEDVAAAAAGBQMu0EYGABMAAAAAAAAIBCAKQAAAAAAEGiR9GgYpPr//4cqVf9XVVVVBQDBRAAAAAAAAPJfbQCYAAAAAAAAQUYATAAQAAAAgEBxADABAAAAAACAAAIMBgo="),
+  (c) => c.charCodeAt(0));
+const FAKE_DIR = mkdtempSync(join(tmpdir(), "ew-lod-fake-"));
+writeFileSync(join(FAKE_DIR, "canned.ktx2"), CANNED_KTX2);
+writeFileSync(join(FAKE_DIR, "fake-toktx.ts"), `const argv = process.argv.slice(2);
+const fs = await import("node:fs");
+fs.copyFileSync(new URL("./canned.ktx2", import.meta.url), argv[argv.length - 2]);
+process.exit(0);
+`);
+let FAKE_TOKTX: string;
+if (process.platform === "win32") {
+  FAKE_TOKTX = join(FAKE_DIR, "toktx.cmd");
+  writeFileSync(FAKE_TOKTX, `@echo off\r\n"${process.execPath}" run "${join(FAKE_DIR, "fake-toktx.ts")}" %*\r\nexit /b %ERRORLEVEL%\r\n`);
+} else {
+  FAKE_TOKTX = join(FAKE_DIR, "toktx");
+  writeFileSync(FAKE_TOKTX, `#!/bin/sh\nexec "${process.execPath}" run "${join(FAKE_DIR, "fake-toktx.ts")}" "$@"\n`);
+  chmodSync(FAKE_TOKTX, 0o755);
+}
+async function runLod(src: string, dest: string, env: Record<string, string> = {}) {
+  const proc = Bun.spawn([process.execPath, "run", OPTIMIZE, "--lod", src, dest],
+    { stdout: "pipe", stderr: "pipe", env: { ...process.env, KTX2_TOKTX: FAKE_TOKTX, ...env } });
+  const code = await proc.exited;
+  return { code, err: (await new Response(proc.stderr).text()).trim(), out: (await new Response(proc.stdout).text()).trim(), wrote: existsSync(dest) };
+}
+
+// ---------------------------------------------- 3. the CLI: verdicts, identity, preservation
+console.log("\n  the CLI — bodies refused, objects reduced, identity stamped:");
+{
+  const tmp = mkdtempSync(join(tmpdir(), "ew-lod-"));
+  try {
+    const place = (bytes: Uint8Array, name: string) => { const p = join(tmp, name); writeFileSync(p, bytes); return p; };
+    const bodyPath = place(await skinnedGlb("a"), "body.glb");
+    const bodyBytes = readFileSync(bodyPath);
+    let r = await runLod(bodyPath, join(tmp, "body.glb.lod1.glb"));
+    check("a skinned asset → exit 2, the typed verdict, NOTHING written", r.code === 2 && !r.wrote && r.err.includes("unsupported: skinned/avatar asset"),
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    check("…and the original is byte-identical after the refusal", readFileSync(bodyPath).equals(bodyBytes));
+
+    const vrmish = await gridGlb("vrmish", 8, false);
+    { // stamp VRM metadata into the raw container — the exclusion must fire off the JSON, not a filename
+      const dv = new DataView(vrmish.buffer, vrmish.byteOffset);
+      const jl = dv.getUint32(12, true);
+      const j = JSON.parse(new TextDecoder().decode(vrmish.subarray(20, 20 + jl)));
+      j.extensionsUsed = ["VRMC_vrm"];
+      let jt = JSON.stringify(j); while (jt.length % 4) jt += " ";
+      const jb = new TextEncoder().encode(jt);
+      const rest = vrmish.subarray(20 + jl);
+      const outB = new Uint8Array(20 + jb.length + rest.length);
+      const odv = new DataView(outB.buffer);
+      outB.set(vrmish.subarray(0, 12)); odv.setUint32(8, outB.length, true);
+      odv.setUint32(12, jb.length, true); odv.setUint32(16, 0x4e4f534a, true);
+      outB.set(jb, 20); outB.set(rest, 20 + jb.length);
+      const p = place(outB, "vrmish.glb");
+      r = await runLod(p, join(tmp, "vrmish.glb.lod1.glb"));
+      check("VRM metadata in a .glb → refused off the CONTAINER, not the filename", r.code === 2 && !r.wrote && r.err.includes("VRM metadata"),
+        `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    }
+
+    const tiny = place(await gridGlb("tiny", 8, true), "tiny.glb");
+    r = await runLod(tiny, join(tmp, "tiny.glb.lod1.glb"));
+    check(`an already-light object (< ${LOD_MIN_VERTS} verts) → typed verdict, nothing written`, r.code === 2 && !r.wrote && r.err.includes("already light"),
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
+    const heroBytes = await gridGlb("hero", 160, true);   // ~26k verts, textured
+    const hero = place(heroBytes, "hero.glb");
+    const dest = join(tmp, "hero.glb.lod1.glb");
+    r = await runLod(hero, dest);
+    check("a dense textured object → exit 0, variant written", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    if (r.wrote) {
+      const v = new Uint8Array(readFileSync(dest));
+      const j = glbJson(v);
+      check("…really reduced (the CLI names the counts)", /\d+ -> \d+ verts/.test(r.out), r.out);
+      check("…textures at the budget, KTX2, required", (j.extensionsRequired ?? []).includes("KHR_texture_basisu"));
+      const ex = j.asset?.extras ?? {};
+      const fullHash = new Bun.CryptoHasher("sha256").update(heroBytes).digest("hex");
+      check("identity: extras.lodOf is the source sha256", ex.lodOf === fullHash, String(ex.lodOf).slice(0, 16));
+      check("…extras.recipe is the versioned recipe", ex.recipe === LOD_RECIPE, ex.recipe);
+      check("…extras.tools names the reducer and encoder versions", typeof ex.tools?.meshoptimizer === "string" && typeof ex.tools?.encoder === "string",
+        JSON.stringify(ex.tools));
+      check("named nodes preserved (parts and socket frames live there)",
+        (j.nodes ?? []).some((n: any) => String(n.name ?? "").startsWith("hero-hero-")), (j.nodes ?? []).map((n: any) => n.name).join(", "));
+      check("…and the original is byte-identical", readFileSync(hero).equals(Buffer.from(heroBytes)));
+    }
+
+    const untex = place(await gridGlb("untex", 160, false), "untex.glb");
+    r = await runLod(untex, join(tmp, "untex.glb.lod1.glb"), { KTX2_TOKTX: join(tmp, "no-such"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
+    check("an UNTEXTURED object reduces with no encoder at all", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    r = await runLod(hero, join(tmp, "hero2.glb.lod1.glb"), { KTX2_TOKTX: join(tmp, "no-such"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
+    check("a TEXTURED object with no encoder → exit 3 (environmental, no marker's business)", r.code === 3 && !existsSync(join(tmp, "hero2.glb.lod1.glb")),
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
+    const real = findKtx2Encoder();
+    if (!real) console.log("  - real encoder: skipped — none on this box");
+    else {
+      r = await runLod(hero, join(tmp, "hero.real.lod1.glb"), { KTX2_TOKTX: real });
+      check(`the real encoder (${real.split(/[\\/]/).pop()}): a reduced, KTX2-textured variant`, r.code === 0 && r.wrote, `exit ${r.code}`);
+    }
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+}
+
+// ---------------------------------------------- 4. the sequencer: upload → shadows → served tier
+console.log("\n  the real sequencer — choose the tier before the fetch:");
+{
+  const OPT = join(ROOT, "assets", "opt");
+  const STORE = join(OPT, "store"), STORE_MIN = join(OPT, "store-min");
+  const madeStore = !existsSync(STORE), madeMin = !existsSync(STORE_MIN);
+  mkdirSync(STORE, { recursive: true }); mkdirSync(STORE_MIN, { recursive: true });
+  const EMPTY_LIB = mkdtempSync(join(tmpdir(), "ew-lod-lib-"));
+  const DOOR = "test-door";
+  const mine = new Set<string>();
+  let server: ReturnType<typeof spawn> | null = null;
+  const cleanup = () => {
+    try { server?.kill(); } catch { /* gone */ }
+    for (const h of mine) for (const p of [join(STORE, `${h}.glb`), join(STORE, `${h}.glb.ktx2.glb`), join(STORE, `${h}.glb.ktx2.glb.failed`),
+      join(STORE, `${h}.glb.lod1.glb`), join(STORE, `${h}.glb.lod1.glb.failed`), join(STORE_MIN, `${h}.glb`), join(STORE_MIN, `${h}.glb.failed`)])
+      try { rmSync(p, { force: true }); } catch { /* best effort */ }
+    try {
+      const mp = join(STORE, "manifest.json");
+      if (existsSync(mp)) {
+        const man = JSON.parse(readFileSync(mp, "utf8"));
+        for (const h of mine) delete man[h];
+        if (Object.keys(man).length) writeFileSync(mp, JSON.stringify(man)); else rmSync(mp);
+      }
+    } catch { /* best effort */ }
+    if (madeStore) try { rmdirSync(STORE); } catch { /* not empty */ }
+    if (madeMin) try { rmdirSync(STORE_MIN); } catch { /* same */ }
+    try { rmSync(FAKE_DIR, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(EMPTY_LIB, { recursive: true, force: true }); } catch { /* best effort */ }
+  };
+  process.on("exit", cleanup);
+  let PORT = 0;
+  for (let i = 0; i < 20 && !PORT; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); } catch { PORT = cand; }
+  }
+  server = spawn(process.execPath, [join(ROOT, "server", "server.ts")],
+    { env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: DOOR, KTX2_TOKTX: FAKE_TOKTX,
+      WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-lod-w-")), EIDOVERSE_DIR: EMPTY_LIB }, stdio: "ignore" });
+  let up = false;
+  for (let i = 0; i < 60 && !up; i++) { try { await fetch(`http://127.0.0.1:${PORT}/`); up = true; } catch { await sleep(250); } }
+  check("child server came up on a verified-free port", up, `:${PORT}`);
+  if (up) {
+    const base = `http://127.0.0.1:${PORT}`;
+    const version = await fetch(`${base}/version`).then((r) => r.json());
+    check("the running sequencer publishes the LOD recipe on /version — the only gate a client trusts",
+      lodFromVersion(version) === LOD_RECIPE, JSON.stringify(version.lodRecipe));
+    const key = keyFromVersion(version);
+    const glb = await gridGlb("served", 160, true);
+    const hash = hashOf(glb); mine.add(hash);
+    const upRes = await fetch(`${base}/upload?token=${DOOR}&name=lod-test`, { method: "POST", body: glb });
+    check("POST /upload landed it", upRes.status === 200);
+    const flaggedUrl = `${base}/library/${withLod(negotiate(`store/${hash}.glb`, key))}`;
+    const early = await fetch(flaggedUrl);
+    const earlyBytes = new Uint8Array(await early.arrayBuffer());
+    const earlyIsLod = (() => { try { return glbJson(earlyBytes)?.asset?.extras?.recipe === LOD_RECIPE; } catch { return false; } })();
+    check("before the variant lands, a ?lod fetch is answered PROVISIONALLY — never pinned",
+      earlyIsLod || early.headers.get("cache-control") === "no-cache", `lod=${earlyIsLod} cc=${early.headers.get("cache-control")}`);
+    const landed = await until(() => existsSync(join(STORE, `${hash}.glb.lod1.glb`)), 45_000);
+    check("the queue built the LOD shadow beside the original", landed);
+    if (landed) {
+      const res = await fetch(flaggedUrl);
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const j = glbJson(bytes);
+      check("?ktx2=<key>&lod=1 → the LOD variant, identity-stamped, immutable",
+        j?.asset?.extras?.recipe === LOD_RECIPE && (res.headers.get("cache-control") ?? "").includes("immutable"),
+        `recipe=${j?.asset?.extras?.recipe} cc=${res.headers.get("cache-control")}`);
+      const noLod = await fetch(`${base}/library/${negotiate(`store/${hash}.glb`, key)}`);
+      const noLodJ = glbJson(new Uint8Array(await noLod.arrayBuffer()));
+      check("without ?lod the same client gets the plain ktx2 chain — tiers are chosen, never imposed",
+        noLodJ?.asset?.extras?.recipe !== LOD_RECIPE);
+      const listing: { path: string }[] = await fetch(`${base}/library-list?dir=store`).then((r) => r.json());
+      check("/library-list shows the original once, no lod artifacts", listing.filter((f) => f.path.includes(hash)).length === 1
+        && !listing.some((f) => isLodVariant(f.path)), listing.map((f) => f.path).filter((p) => p.includes(hash)).join(", "));
+      const catalog: { path: string }[] = await fetch(`${base}/library-models`).then((r) => r.json());
+      check("/library-models lists it once, never the variant", catalog.filter((h) => h.path === `store/${hash}.glb`).length === 1
+        && !catalog.some((h) => isLodVariant(h.path)));
+    }
+    // a body through the same door: the pump must fail it closed with the typed verdict
+    const body = await skinnedGlb("served");
+    const bh = hashOf(body); mine.add(bh);
+    await fetch(`${base}/upload?token=${DOOR}&name=body-test`, { method: "POST", body });
+    const refused = await until(() => existsSync(join(STORE, `${bh}.glb.lod1.glb.failed`)), 45_000);
+    const verdict = refused ? readFileSync(join(STORE, `${bh}.glb.lod1.glb.failed`), "utf8") : "";
+    check("an uploaded BODY gets the typed verdict marker and no lod variant",
+      refused && verdict.includes("unsupported: skinned/avatar asset") && !existsSync(join(STORE, `${bh}.glb.lod1.glb`)), verdict.slice(0, 80));
+    const bodyRes = await fetch(`${base}/library/${withLod(negotiate(`store/${bh}.glb`, key))}`);
+    const bodyJ = glbJson(new Uint8Array(await bodyRes.arrayBuffer()));
+    check("…and a ?lod fetch for it falls back to the original chain — never a half-valid object",
+      bodyJ?.asset?.extras?.recipe !== LOD_RECIPE);
+  }
+  cleanup();
+}
+
+console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
+process.exit(failures ? 1 : 0);

--- a/tools/object-lod-test.ts
+++ b/tools/object-lod-test.ts
@@ -42,7 +42,7 @@ import { Document, NodeIO } from "@gltf-transform/core";
 import { PNG } from "pngjs";
 import { isLodVariant, isServingArtifact, isStoreOriginal, lodVariantPath, storeShadowsMissing,
   LOD_RECIPE, LOD_MIN_VERTS } from "../server/store-variants.ts";
-import { lodExclusion, findKtx2Encoder } from "../server/optimize.ts";
+import { lodExclusion, findKtx2Encoder, optimizeGlbLod, lodNodesSig, lodMatsSig } from "../server/optimize.ts";
 import { lodFromVersion, withLod, keyFromVersion, negotiate } from "../shared/ktx2.js";
 
 let failures = 0;
@@ -161,6 +161,32 @@ async function animatedGlb(tag: string): Promise<Uint8Array> {
   doc.createAnimation("bob").addSampler(sampler).addChannel(channel);
   return new NodeIO().writeBinary(doc);
 }
+/** The re-review's own fixture, verbatim shape: a dense mesh on `root` at
+ *  [2,3,4] with an EMPTY NAMED child `seat_socket` at [0.2,1.1,-0.3] — the
+ *  node a plain prune() deleted before the old signature existed. */
+async function socketGlb(tag: string): Promise<Uint8Array> {
+  const bytes = await gridGlb(tag, 160, false);
+  const doc = await new NodeIO().readBinary(bytes);
+  const root = doc.getRoot().listNodes()[0];
+  root.setName("root").setTranslation([2, 3, 4]);
+  root.addChild(doc.createNode("seat_socket").setTranslation([0.2, 1.1, -0.3]));
+  return new NodeIO().writeBinary(doc);
+}
+/** Two dense primitives wearing two DIFFERENT materials — the assignment
+ *  the material guard must notice being swapped. */
+async function twoMatGlb(tag: string): Promise<Uint8Array> {
+  const a = await gridGlb(`${tag}-a`, 120, false);
+  const doc = await new NodeIO().readBinary(a);
+  const buf = doc.getRoot().listBuffers()[0];
+  const matB = doc.createMaterial("probeMatB");
+  const prim0 = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+  const prim2 = doc.createPrimitive().setMaterial(matB)
+    .setIndices(prim0.getIndices())
+    .setAttribute("POSITION", prim0.getAttribute("POSITION"))
+    .setAttribute("TEXCOORD_0", prim0.getAttribute("TEXCOORD_0"));
+  doc.getRoot().listMeshes()[0].addPrimitive(prim2);
+  return new NodeIO().writeBinary(doc);
+}
 const hashOf = (b: Uint8Array) => new Bun.CryptoHasher("sha256").update(b).digest("hex").slice(0, 16);
 const glbJson = (bytes: Uint8Array) => {
   const dv = new DataView(bytes.buffer, bytes.byteOffset);
@@ -260,6 +286,55 @@ console.log("\n  the CLI — bodies and animation refused, objects reduced, iden
       check("…and the original is byte-identical", readFileSync(hero).equals(Buffer.from(heroBytes)));
     }
 
+    // the socket fixture: v1's whole promise, executable
+    const sockBytes = await socketGlb("sock");
+    const sock = place(sockBytes, "sock.glb");
+    r = await runLod(sock, lodVariantPath(sock));
+    check("a dense object with an EMPTY NAMED SOCKET child reduces — the socket is not prune()'s to take", r.code === 0 && r.wrote,
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    if (r.wrote) {
+      const j = glbJson(new Uint8Array(readFileSync(lodVariantPath(sock))));
+      const nodes: any[] = j.nodes ?? [];
+      const sk = nodes.find((n) => n.name === "seat_socket");
+      const rt = nodes.find((n) => n.name === "root");
+      const near = (a: number[] | undefined, b: number[]) => !!a && a.every((v, i) => Math.abs(v - b[i]) < 1e-5);
+      check("…seat_socket survives WITH its translation", !!sk && near(sk.translation, [0.2, 1.1, -0.3]), JSON.stringify(sk));
+      check("…still a child of root, which kept its own transform", !!rt && near(rt.translation, [2, 3, 4])
+        && (rt.children ?? []).includes(nodes.indexOf(sk)), JSON.stringify(rt));
+    }
+
+    // MUTATION CONTROLS (re-review blocker 1): each preservation guard gets a
+    // corruption injected through the pipeline's own test seam — delete the
+    // guard and its control goes red, because the corrupted variant would
+    // ship. In-process on purpose: the seam must never be CLI-reachable.
+    const mutBytes = await gridGlb("mut", 160, false);
+    let mres = await optimizeGlbLod(mutBytes, null, (doc) => { doc.getRoot().listNodes()[0].setName("renamed-by-mutation"); });
+    check("mutation control, node guard: a node renamed after the reduce is REFUSED", mres.out === null && /node hierarchy/.test(mres.verdict ?? ""),
+      String(mres.verdict));
+    mres = await optimizeGlbLod(mutBytes, null, (doc) => { doc.getRoot().listNodes()[0].setTranslation([9, 9, 9]); });
+    check("…and so is a moved one (transforms are part of the contract)", mres.out === null && /node hierarchy/.test(mres.verdict ?? ""));
+    const twoMat = await twoMatGlb("mut2");
+    mres = await optimizeGlbLod(twoMat, null, (doc) => {
+      const ms = doc.getRoot().listMaterials();
+      doc.getRoot().listMeshes()[0].listPrimitives()[0].setMaterial(ms[1]);
+    });
+    check("mutation control, material guard: a swapped assignment is REFUSED", mres.out === null && /material assignments/.test(mres.verdict ?? ""),
+      String(mres.verdict));
+    mres = await optimizeGlbLod(twoMat, null);
+    check("…and the same fixture un-mutated passes — the guards fire on corruption, not on the reduce", mres.out !== null, String(mres.verdict));
+
+    // the detectors themselves, unit-tested
+    {
+      const d1 = new Document(); d1.createScene("s").addChild(d1.createNode("a").setTranslation([1, 2, 3]));
+      const d2 = new Document(); d2.createScene("s").addChild(d2.createNode("a").setTranslation([1, 2, 4]));
+      check("lodNodesSig distinguishes a moved node", lodNodesSig(d1) !== lodNodesSig(d2) && lodNodesSig(d1) === lodNodesSig(d1));
+      const m1 = new Document(); { const A = m1.createMaterial("A"), B = m1.createMaterial("B");
+        m1.createMesh("m").addPrimitive(m1.createPrimitive().setMaterial(A)).addPrimitive(m1.createPrimitive().setMaterial(B)); }
+      const m2 = new Document(); { const A = m2.createMaterial("A"), B = m2.createMaterial("B");
+        m2.createMesh("m").addPrimitive(m2.createPrimitive().setMaterial(B)).addPrimitive(m2.createPrimitive().setMaterial(A)); }
+      check("lodMatsSig distinguishes swapped assignments", lodMatsSig(m1) !== lodMatsSig(m2));
+    }
+
     const untex = place(await gridGlb("untex", 160, false), "untex.glb");
     r = await runLod(untex, lodVariantPath(untex), NO_ENCODER);
     check("an UNTEXTURED object reduces with no encoder at all", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
@@ -316,13 +391,22 @@ async function freePort(): Promise<number> {
   }
   throw new Error("no free port in 20 tries");
 }
-/** Spawn the sequencer PROCESS-OWNED (review point 7): logs piped so startup
- *  failure is diagnosable, ownership proven by a nonce round-trip the caller
- *  performs against per-run content it alone placed, and a failed boot
- *  prints the log tail instead of a bare ✗. */
+/** Is this /version body the child WE spawned? Nonce-bound: nothing but our
+ *  child was handed this run's WORLD_INSTANCE_NONCE, so no squatter, stale
+ *  server, or TOCTOU winner on the probed port can answer with it. */
+const ownedBy = (version: any, nonce: string) => version != null && typeof version === "object" && version.instance === nonce;
+
+/** Spawn the sequencer PROCESS-OWNED (re-review blocker 2): a per-run
+ *  WORLD_INSTANCE_NONCE goes INTO the child and must come back on /version
+ *  before anything counts as up — readiness and identity are one check, so a
+ *  foreign responder on the probed port never greens a claim. Logs piped (a
+ *  failed boot prints its tail); stop() is the one cleanup owner and every
+ *  section holds it in a finally. */
 async function startServer(extra: Record<string, string | undefined>, lib?: string) {
   const PORT = await freePort();
+  const nonce = crypto.randomUUID();
   const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT), JOIN_TOKEN: DOOR,
+    WORLD_INSTANCE_NONCE: nonce,
     WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-lod-w-")), EIDOVERSE_DIR: lib ?? mkdtempSync(join(tmpdir(), "ew-lod-lib-")), ...extra };
   const proc = spawn(process.execPath, [join(ROOT, "server", "server.ts")], { env, stdio: ["ignore", "pipe", "pipe"] });
   live = proc;
@@ -330,15 +414,19 @@ async function startServer(extra: Record<string, string | undefined>, lib?: stri
   proc.stdout!.on("data", (d) => { log += d; });
   proc.stderr!.on("data", (d) => { log += d; });
   let up = false;
-  for (let i = 0; i < 60 && !up; i++) {
+  let version: any = null;
+  for (let i = 0; i < 120 && !up; i++) {   // a cold transpile can eat 15s before the first log line
     if (proc.exitCode != null) break;   // died at boot — the tail says why
-    try { await fetch(`http://127.0.0.1:${PORT}/version`); up = true; } catch { await sleep(250); }
+    try {
+      version = await fetch(`http://127.0.0.1:${PORT}/version`).then((r) => r.json());
+      if (ownedBy(version, nonce)) up = true;            // OUR child, not merely A server
+      else break;                                        // someone else answers here — refuse, do not retry into their world
+    } catch { await sleep(250); }
   }
-  if (!up) console.log(`      child did not come up — log tail:\n      ${log.split("\n").slice(-6).join("\n      ")}`);
+  if (!up) console.log(`      child did not come up OWNED — log tail:\n      ${log.split("\n").slice(-6).join("\n      ")}`);
   const base = `http://127.0.0.1:${PORT}`;
   const stop = async () => { try { proc.kill(); } catch { /* gone */ } live = null; await sleep(300); };
-  const version = up ? await fetch(`${base}/version`).then((r) => r.json()).catch(() => null) : null;
-  return { up, PORT, base, stop, log: () => log, version,
+  return { up, PORT, base, stop, log: () => log, version, nonce,
     key: keyFromVersion(version), lod: lodFromVersion(version),
     get: async (rel: string, headers: Record<string, string> = {}) => {
       const res = await fetch(`${base}/library/${rel}`, { headers });
@@ -353,9 +441,13 @@ const isLodGlb = (bytes: Uint8Array) => { try { return glbJson(bytes)?.asset?.ex
 console.log("\n  the store door — the tier URL carries the generation:");
 {
   const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX });
-  check("child server came up (owned harness, logs piped)", S.up, `:${S.PORT}`);
+  try {
+  check("child server came up OWNED (nonce-bound readiness)", S.up, `:${S.PORT}`);
   if (S.up) {
     check("the running sequencer publishes the LOD recipe on /version", S.lod === LOD_RECIPE, JSON.stringify(S.version?.lodRecipe));
+    check("readiness IS identity: /version carries this run's nonce", ownedBy(S.version, S.nonce), JSON.stringify(S.version?.instance));
+    check("impostor control: the same body under a WRONG or MISSING nonce is refused by the verifier",
+      !ownedBy(S.version, crypto.randomUUID()) && !ownedBy({ ...S.version, instance: undefined }, S.nonce) && !ownedBy(null, S.nonce));
     const glb = await gridGlb("served", 160, true);
     const hash = hashOf(glb); mine.add(hash);
     await S.upload(glb, "lod-test");
@@ -392,7 +484,7 @@ console.log("\n  the store door — the tier URL carries the generation:");
     const bodyRes = await S.get(withLod(negotiate(`store/${bh}.glb`, S.key), S.lod));
     check("…and its recipe-URL fetch falls back whole — never a half-valid object", !isLodGlb(bodyRes.bytes));
   }
-  await S.stop();
+  } finally { await S.stop(); }
 }
 
 // ---------------------------------------------- 5. the library arm + mutable-source freshness
@@ -407,7 +499,8 @@ console.log("\n  the library arm — the sweep queues LODs, and mutable sources 
   mineOpt.push(`${REL}.ktx2.glb`, `${REL}.ktx2.glb.failed`,
     ...[LOD_RECIPE, "x"].map((r0) => `${REL}.lod.${r0}.glb`), `${REL}.lod.${LOD_RECIPE}.glb.failed`);
   let S = await startServer({ KTX2_TOKTX: FAKE_TOKTX }, LIB);
-  check("child server came up over the fixture library", S.up, `:${S.PORT}`);
+  try {
+  check("child server came up OWNED over the fixture library", S.up, `:${S.PORT}`);
   if (S.up) {
     const own = await S.get(REL);
     check("listener is OUR child (the per-run library fixture round-trips)", own.status === 200 && own.bytes.length === libGlb.length);
@@ -443,15 +536,15 @@ console.log("\n  the library arm — the sweep queues LODs, and mutable sources 
       }
     }
   }
-  await S.stop();
-  try { rmSync(LIB, { recursive: true, force: true }); } catch { /* best effort */ }
+  } finally { await S.stop(); try { rmSync(LIB, { recursive: true, force: true }); } catch { /* best effort */ } }
 }
 
 // ---------------------------------------------- 6. no encoder: untextured LOD work survives
 console.log("\n  no encoder — geometry work is not the encoder's hostage:");
 {
   const S = await startServer(NO_ENCODER);
-  check("child server came up with no encoder anywhere", S.up, `:${S.PORT}`);
+  try {
+  check("child server came up OWNED with no encoder anywhere", S.up, `:${S.PORT}`);
   if (S.up) {
     const untex = await gridGlb("noenc-untex", 160, false);
     const uh = hashOf(untex); mine.add(uh);
@@ -469,7 +562,7 @@ console.log("\n  no encoder — geometry work is not the encoder's hostage:");
     check("…with the --lod arm's own once-per-boot note, and no ktx2Skip purge of lod items",
       S.log().split("\n").filter((l) => l.includes("[lod] no KTX2 encoder")).length === 1, `${S.log().split("\n").filter((l) => l.includes("[lod] no KTX2 encoder")).length} line(s)`);
   }
-  await S.stop();
+  } finally { await S.stop(); }
 }
 
 // ---------------------------------------------- 7. the mutation canary: a recipe change cannot pin

--- a/tools/object-lod-test.ts
+++ b/tools/object-lod-test.ts
@@ -1,44 +1,47 @@
 // The geometry LOD for placeable objects (server/optimize.ts --lod,
 // store-variants.ts), run headless — v1 of the contract agreed in the #142
-// thread: OBJECTS ONLY, BODIES FAIL CLOSED.
+// thread, revised per the #156 review: OBJECTS ONLY, BODIES FAIL CLOSED,
+// STATIC GEOMETRY ONLY, and the recipe is a GENERATION carried in both the
+// URL and the variant's filename.
 //
 //   bun tools/object-lod-test.ts
 //
-// The contract under test, in the reviewer's terms:
-//   - bodies are excluded by POSITIVE STRUCTURAL DETECTION on the raw
-//     container — skins, joint weights, VRM metadata, morph targets,
-//     morph-weight animation channels — with a truthful typed verdict
-//     (`unsupported: skinned/avatar asset`), no geometry LOD, no silent
-//     attempt; the original stays the only served representation;
-//   - the original is preserved byte-identically (the variant is a sibling);
-//   - variant identity binds source content hash + recipe + tool versions
-//     (asset.extras: lodOf / recipe / tools);
-//   - named nodes, materials, and bounds are asserted unchanged after the
-//     reduce — a failed assert or an ineffective reduce is a typed verdict,
-//     never a half-valid object;
-//   - the client asks with ?lod=1 riding the ktx2 negotiation, and ONLY when
-//     /version published lodRecipe (the ?ktx2=2 split-brain lesson);
-//   - a missing variant falls back to the original/ktx2 chain, PROVISIONAL
-//     (no-cache) so the variant's bytes get through the moment it lands;
-//   - variants and their markers never leak into catalogs or listings.
+// The contract under test, in the reviewer's terms — each repaired seam of
+// the #156 review has a named control here, and deleting the mechanism
+// turns its control red:
+//   1. the URL carries the recipe (`?lod=<recipe>`), the filename carries it
+//      too, and an unrecognized generation is answered PROVISIONALLY — a
+//      recipe change can never pin yesterday's bytes under today's address
+//      (the mutation canary rewrites the on-disk recipe under a live child);
+//   2. the library sweep queues LODs (the shared `seen` set that killed it
+//      is keyed by mode now) — proven with a pre-existing library GLB, not
+//      an upload;
+//   3. a missing encoder does not delete valid untextured LOD work — the
+//      no-encoder child reduces an untextured upload while the textured one
+//      keeps its original, no marker, one log line;
+//   4. a MUTABLE library source newer than its variant is never served the
+//      old variant — provisional until the next boot rebuilds it, then fresh;
+//   5. bodies fail closed on STRUCTURE, not well-formedness: top-level
+//      `extensions` keys and any JOINTS_n/WEIGHTS_n set, not just
+//      extensionsUsed and set 0;
+//   6. claims match assertions: node hierarchy + transforms and per-primitive
+//      material assignments are signature-checked (not just sorted names),
+//      source asset.extras survive under ours, and ANY animation is a typed
+//      v1 refusal rather than an untested claim of preservation;
+//   7. the child is process-owned: piped diagnostics, a per-run
+//      content-hashed fixture as the nonce, failure prints the log tail.
 //
 // The fake toktx (the store-variants-test pattern) stands in for the
-// encoder, so no KTX-Software is needed; the one real-encoder receipt runs
-// when the box has one.
-//
-// Negative control: on main this file dies at import (no isLodVariant, no
-// optimizeGlbLod); the serving checks fail on main with the variant never
-// built and ?lod=1 answered immutable (the poison this arm's negotiation
-// gate exists to prevent).
+// encoder; the one real-encoder receipt runs when the box has one.
 
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, rmdirSync, chmodSync } from "node:fs";
-import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, rmdirSync, chmodSync, utimesSync } from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { Document, NodeIO } from "@gltf-transform/core";
 import { PNG } from "pngjs";
 import { isLodVariant, isServingArtifact, isStoreOriginal, lodVariantPath, storeShadowsMissing,
-  LOD_RECIPE, LOD_MIN_VERTS, recipeStamp } from "../server/store-variants.ts";
+  LOD_RECIPE, LOD_MIN_VERTS } from "../server/store-variants.ts";
 import { lodExclusion, findKtx2Encoder } from "../server/optimize.ts";
 import { lodFromVersion, withLod, keyFromVersion, negotiate } from "../shared/ktx2.js";
 
@@ -56,28 +59,29 @@ const until = async (pred: () => boolean, ms: number, step = 250) => {
 const ROOT = join(import.meta.dir, "..");
 const OPTIMIZE = join(ROOT, "server", "optimize.ts");
 
-console.log("\ngeometry LOD for placeable objects — bodies fail closed:\n");
+console.log("\ngeometry LOD for placeable objects — bodies fail closed, recipes are generations:\n");
 
 // ---------------------------------------------- 1. names, predicates, negotiation
 {
-  check("a lod variant is named beside its original", lodVariantPath("/x/store/abc.glb") === "/x/store/abc.glb.lod1.glb");
-  for (const v of ["abc.glb.lod1.glb", "model.glb.lod2.glb", "UPPER.GLB.LOD1.GLB"])
-    check(`${v} is a lod variant and a serving artifact`, isLodVariant(v) && isServingArtifact(v) && !isStoreOriginal(v));
-  for (const o of ["abc.glb", "abc.glb.ktx2.glb", "lod1.glb", "model.lod.glb"])
+  check("the variant's filename carries the recipe generation", lodVariantPath("/x/store/abc.glb") === `/x/store/abc.glb.lod.${LOD_RECIPE}.glb`);
+  check("…and an explicit recipe names that generation's file", lodVariantPath("/x/a.glb", "lod1-r10") === "/x/a.glb.lod.lod1-r10.glb");
+  for (const v of [`abc.glb.lod.${LOD_RECIPE}.glb`, "abc.glb.lod.lod1-r10.glb", "M.GLB.LOD.OLD-GEN.GLB"])
+    check(`${v} is a lod variant of SOME generation — artifact, never original`, isLodVariant(v) && isServingArtifact(v) && !isStoreOriginal(v));
+  for (const o of ["abc.glb", "abc.glb.ktx2.glb", "lod.glb", "model.lod.glb.txt"])
     check(`${o} is not a lod variant`, !isLodVariant(o));
-  check("a lod .failed marker is an artifact, never a listing entry", isServingArtifact("abc.glb.lod1.glb.failed"));
+  check("a lod .failed marker is an artifact, never a listing entry", isServingArtifact(`abc.glb.lod.${LOD_RECIPE}.glb.failed`));
   const m = storeShadowsMissing("/x/store/abc.glb", "/x/store-min", () => false);
   check("a fresh original lacks all three shadows", m.min && m.ktx2 && m.lod);
   const m2 = storeShadowsMissing("/x/store/abc.glb", "/x/store-min",
-    (p) => p === "/x/store/abc.glb.lod1.glb.failed", () => "[optimize] lod: unsupported: skinned/avatar asset (skins)");
+    (p) => p === `/x/store/abc.glb.lod.${LOD_RECIPE}.glb.failed`, () => "[optimize] lod: unsupported: skinned/avatar asset (skins)");
   check("a typed exclusion verdict STANDS (a body never becomes a retry loop)", !m2.lod);
-  const m3 = storeShadowsMissing("/x/store/abc.glb", "/x/store-min",
-    (p) => p === "/x/store/abc.glb.lod1.glb.failed", () => "[optimize] not smaller (9 -> 10, 1ms) — keeping original");
-  check("an unstamped lod size verdict is stale — re-measured under the current recipe", m3.lod);
 
   check("the client only asks for a tier the running sequencer published", lodFromVersion({ lodRecipe: LOD_RECIPE }) === LOD_RECIPE);
   check("an older sequencer publishes none → null → no ?lod (the split-brain gate)", lodFromVersion({ sha: "old" }) === null && lodFromVersion(null) === null);
-  check("withLod appends", withLod("store/x.glb?ktx2=3") === "store/x.glb?ktx2=3&lod=1" && withLod("x.glb") === "x.glb?lod=1");
+  check("withLod carries the RECIPE, never a boolean — two recipes are two URLs",
+    withLod("store/x.glb?ktx2=3", "lod1-rA") === "store/x.glb?ktx2=3&lod=lod1-rA"
+    && withLod("store/x.glb?ktx2=3", "lod1-rB") !== withLod("store/x.glb?ktx2=3", "lod1-rA"));
+  check("…and no recipe → the URL untouched (an unflagged fetch)", withLod("store/x.glb", null) === "store/x.glb");
 }
 
 // ---------------------------------------------- 2. the structural exclusion, pure
@@ -85,14 +89,16 @@ console.log("\ngeometry LOD for placeable objects — bodies fail closed:\n");
   const base = { meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }] };
   check("a plain object is not excluded", lodExclusion(base) === null);
   check("skins exclude", /skinned\/avatar/.test(lodExclusion({ ...base, skins: [{}] }) ?? ""));
-  check("joint weights exclude even without a skins array",
-    /skinned\/avatar/.test(lodExclusion({ meshes: [{ primitives: [{ attributes: { POSITION: 0, JOINTS_0: 1, WEIGHTS_0: 2 } }] }] }) ?? ""));
-  check("VRM metadata excludes (VRMC_vrm)", /VRM metadata/.test(lodExclusion({ ...base, extensionsUsed: ["VRMC_vrm"] }) ?? ""));
-  check("…and legacy VRM 0.x", /VRM metadata/.test(lodExclusion({ ...base, extensionsUsed: ["VRM"] }) ?? ""));
+  check("VRM in extensionsUsed excludes", /VRM metadata/.test(lodExclusion({ ...base, extensionsUsed: ["VRMC_vrm"] }) ?? ""));
+  check("VRM in extensionsRequired excludes", /VRM metadata/.test(lodExclusion({ ...base, extensionsRequired: ["VRMC_vrm"] }) ?? ""));
+  // the reviewer's probes: fail-closed must not trust well-formedness
+  check("a VRM extension OBJECT excludes even when extensionsUsed forgot it (review probe)",
+    /VRM metadata/.test(lodExclusion({ ...base, extensions: { VRMC_vrm: {} } }) ?? ""));
+  check("JOINTS_1/WEIGHTS_1 exclude without set 0 (review probe)",
+    /skinned\/avatar/.test(lodExclusion({ meshes: [{ primitives: [{ attributes: { POSITION: 0, JOINTS_1: 1, WEIGHTS_1: 2 } }] }] }) ?? ""));
   check("morph targets exclude", /morph targets/.test(lodExclusion({ meshes: [{ primitives: [{ attributes: { POSITION: 0 }, targets: [{}] }] }] }) ?? ""));
-  check("morph-weight animation excludes", /morph-weight/.test(lodExclusion({ ...base, animations: [{ channels: [{ target: { path: "weights" } }] }] }) ?? ""));
-  check("node TRS animation does NOT exclude (structure is asserted instead)",
-    lodExclusion({ ...base, animations: [{ channels: [{ target: { path: "rotation" } }] }] }) === null);
+  check("ANY animation is a typed v1 refusal — static geometry only, preservation is earned not claimed",
+    /animated object/.test(lodExclusion({ ...base, animations: [{ channels: [{ target: { path: "rotation" } }] }] }) ?? ""));
 }
 
 // ---------------------------------------------- fixtures
@@ -105,11 +111,9 @@ function pngBytes(seed: number, W = 64): Uint8Array {
   }
   return new Uint8Array(PNG.sync.write(png));
 }
-/** A dense smooth grid — the kind of mesh a reducer actually reduces.
- *  `cells`² quads ≈ (cells+1)² verts; gentle height noise keeps prune()
- *  honest and simplify effective. Textured when `textured`. */
-async function gridGlb(tag: string, cells: number, textured: boolean, nodeName = "hero"): Promise<Uint8Array> {
+async function gridGlb(tag: string, cells: number, textured: boolean, extras: object | null = null): Promise<Uint8Array> {
   const doc = new Document();
+  if (extras) doc.getRoot().getAsset().extras = extras;
   const buf = doc.createBuffer();
   const n = cells + 1;
   const pos = new Float32Array(n * n * 3), uv = new Float32Array(n * n * 2);
@@ -130,21 +134,31 @@ async function gridGlb(tag: string, cells: number, textured: boolean, nodeName =
     .setIndices(doc.createAccessor().setType("SCALAR").setBuffer(buf).setArray(idx))
     .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf).setArray(pos))
     .setAttribute("TEXCOORD_0", doc.createAccessor().setType("VEC2").setBuffer(buf).setArray(uv));
-  doc.createScene("s").addChild(doc.createNode(`${nodeName}-${tag}-${NONCE}`).setMesh(doc.createMesh("gridMesh").addPrimitive(prim)));
+  doc.createScene("s").addChild(doc.createNode(`hero-${tag}-${NONCE}`).setMesh(doc.createMesh("gridMesh").addPrimitive(prim)));
   return new NodeIO().writeBinary(doc);
 }
-/** The same grid with a skin bound on — a BODY, structurally. */
 async function skinnedGlb(tag: string): Promise<Uint8Array> {
   const doc = new Document();
   const buf = doc.createBuffer();
   const prim = doc.createPrimitive()
     .setAttribute("POSITION", doc.createAccessor().setType("VEC3").setBuffer(buf).setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])))
-    .setAttribute("JOINTS_0", doc.createAccessor().setType("VEC4").setBuffer(buf).setArray(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])))
+    .setAttribute("JOINTS_0", doc.createAccessor().setType("VEC4").setBuffer(buf).setArray(new Uint8Array(12)))
     .setAttribute("WEIGHTS_0", doc.createAccessor().setType("VEC4").setBuffer(buf).setArray(new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0])));
   const joint = doc.createNode(`joint-${tag}`);
   const skin = doc.createSkin("rig").addJoint(joint);
-  const node = doc.createNode(`body-${tag}-${NONCE}`).setMesh(doc.createMesh("m").addPrimitive(prim)).setSkin(skin);
-  doc.createScene("s").addChild(node).addChild(joint);
+  doc.createScene("s").addChild(doc.createNode(`body-${tag}-${NONCE}`).setMesh(doc.createMesh("m").addPrimitive(prim)).setSkin(skin)).addChild(joint);
+  return new NodeIO().writeBinary(doc);
+}
+/** A dense grid with a node-TRS animation bound on — v1 must refuse it. */
+async function animatedGlb(tag: string): Promise<Uint8Array> {
+  const bytes = await gridGlb(tag, 160, false);
+  const doc = await new NodeIO().readBinary(bytes);
+  const buf = doc.getRoot().listBuffers()[0];
+  const input = doc.createAccessor().setType("SCALAR").setBuffer(buf).setArray(new Float32Array([0, 1]));
+  const output = doc.createAccessor().setType("VEC3").setBuffer(buf).setArray(new Float32Array([0, 0, 0, 0, 1, 0]));
+  const sampler = doc.createAnimationSampler().setInput(input).setOutput(output).setInterpolation("LINEAR");
+  const channel = doc.createAnimationChannel().setTargetNode(doc.getRoot().listNodes()[0]).setTargetPath("translation").setSampler(sampler);
+  doc.createAnimation("bob").addSampler(sampler).addChannel(channel);
   return new NodeIO().writeBinary(doc);
 }
 const hashOf = (b: Uint8Array) => new Bun.CryptoHasher("sha256").update(b).digest("hex").slice(0, 16);
@@ -173,6 +187,8 @@ if (process.platform === "win32") {
   writeFileSync(FAKE_TOKTX, `#!/bin/sh\nexec "${process.execPath}" run "${join(FAKE_DIR, "fake-toktx.ts")}" "$@"\n`);
   chmodSync(FAKE_TOKTX, 0o755);
 }
+const NOWHERE = mkdtempSync(join(tmpdir(), "ew-lod-nowhere-"));
+const NO_ENCODER = { KTX2_TOKTX: join(NOWHERE, "no-such"), PATH: NOWHERE, HOME: NOWHERE, USERPROFILE: NOWHERE };
 async function runLod(src: string, dest: string, env: Record<string, string> = {}) {
   const proc = Bun.spawn([process.execPath, "run", OPTIMIZE, "--lod", src, dest],
     { stdout: "pipe", stderr: "pipe", env: { ...process.env, KTX2_TOKTX: FAKE_TOKTX, ...env } });
@@ -181,24 +197,29 @@ async function runLod(src: string, dest: string, env: Record<string, string> = {
 }
 
 // ---------------------------------------------- 3. the CLI: verdicts, identity, preservation
-console.log("\n  the CLI — bodies refused, objects reduced, identity stamped:");
+console.log("\n  the CLI — bodies and animation refused, objects reduced, identity stamped:");
 {
   const tmp = mkdtempSync(join(tmpdir(), "ew-lod-"));
   try {
     const place = (bytes: Uint8Array, name: string) => { const p = join(tmp, name); writeFileSync(p, bytes); return p; };
     const bodyPath = place(await skinnedGlb("a"), "body.glb");
     const bodyBytes = readFileSync(bodyPath);
-    let r = await runLod(bodyPath, join(tmp, "body.glb.lod1.glb"));
+    let r = await runLod(bodyPath, lodVariantPath(bodyPath));
     check("a skinned asset → exit 2, the typed verdict, NOTHING written", r.code === 2 && !r.wrote && r.err.includes("unsupported: skinned/avatar asset"),
       `exit ${r.code}: ${r.err.split("\n").pop()}`);
     check("…and the original is byte-identical after the refusal", readFileSync(bodyPath).equals(bodyBytes));
 
+    const animPath = place(await animatedGlb("anim"), "anim.glb");
+    r = await runLod(animPath, lodVariantPath(animPath));
+    check("an ANIMATED object → typed v1 refusal, nothing written", r.code === 2 && !r.wrote && r.err.includes("animated object"),
+      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+
     const vrmish = await gridGlb("vrmish", 8, false);
-    { // stamp VRM metadata into the raw container — the exclusion must fire off the JSON, not a filename
+    { // stamp a VRM extension OBJECT (not extensionsUsed) into the raw container
       const dv = new DataView(vrmish.buffer, vrmish.byteOffset);
       const jl = dv.getUint32(12, true);
       const j = JSON.parse(new TextDecoder().decode(vrmish.subarray(20, 20 + jl)));
-      j.extensionsUsed = ["VRMC_vrm"];
+      j.extensions = { VRMC_vrm: {} };   // a producer that forgot extensionsUsed — fail-closed must still see it
       let jt = JSON.stringify(j); while (jt.length % 4) jt += " ";
       const jb = new TextEncoder().encode(jt);
       const rest = vrmish.subarray(20 + jl);
@@ -208,24 +229,23 @@ console.log("\n  the CLI — bodies refused, objects reduced, identity stamped:"
       odv.setUint32(12, jb.length, true); odv.setUint32(16, 0x4e4f534a, true);
       outB.set(jb, 20); outB.set(rest, 20 + jb.length);
       const p = place(outB, "vrmish.glb");
-      r = await runLod(p, join(tmp, "vrmish.glb.lod1.glb"));
-      check("VRM metadata in a .glb → refused off the CONTAINER, not the filename", r.code === 2 && !r.wrote && r.err.includes("VRM metadata"),
-        `exit ${r.code}: ${r.err.split("\n").pop()}`);
+      r = await runLod(p, lodVariantPath(p));
+      check("a VRM extension OBJECT in a .glb → refused off the CONTAINER (malformed producer, still a body)",
+        r.code === 2 && !r.wrote && r.err.includes("VRM metadata"), `exit ${r.code}: ${r.err.split("\n").pop()}`);
     }
 
     const tiny = place(await gridGlb("tiny", 8, true), "tiny.glb");
-    r = await runLod(tiny, join(tmp, "tiny.glb.lod1.glb"));
+    r = await runLod(tiny, lodVariantPath(tiny));
     check(`an already-light object (< ${LOD_MIN_VERTS} verts) → typed verdict, nothing written`, r.code === 2 && !r.wrote && r.err.includes("already light"),
       `exit ${r.code}: ${r.err.split("\n").pop()}`);
 
-    const heroBytes = await gridGlb("hero", 160, true);   // ~26k verts, textured
+    const heroBytes = await gridGlb("hero", 160, true, { producer: "someone-else", note: "must survive" });
     const hero = place(heroBytes, "hero.glb");
-    const dest = join(tmp, "hero.glb.lod1.glb");
+    const dest = lodVariantPath(hero);
     r = await runLod(hero, dest);
-    check("a dense textured object → exit 0, variant written", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    check("a dense textured object → exit 0, variant written at the recipe-named path", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
     if (r.wrote) {
-      const v = new Uint8Array(readFileSync(dest));
-      const j = glbJson(v);
+      const j = glbJson(new Uint8Array(readFileSync(dest)));
       check("…really reduced (the CLI names the counts)", /\d+ -> \d+ verts/.test(r.out), r.out);
       check("…textures at the budget, KTX2, required", (j.extensionsRequired ?? []).includes("KHR_texture_basisu"));
       const ex = j.asset?.extras ?? {};
@@ -234,119 +254,254 @@ console.log("\n  the CLI — bodies refused, objects reduced, identity stamped:"
       check("…extras.recipe is the versioned recipe", ex.recipe === LOD_RECIPE, ex.recipe);
       check("…extras.tools names the reducer and encoder versions", typeof ex.tools?.meshoptimizer === "string" && typeof ex.tools?.encoder === "string",
         JSON.stringify(ex.tools));
-      check("named nodes preserved (parts and socket frames live there)",
-        (j.nodes ?? []).some((n: any) => String(n.name ?? "").startsWith("hero-hero-")), (j.nodes ?? []).map((n: any) => n.name).join(", "));
+      check("…and the SOURCE's own extras survive under ours (never clobbered)", ex.producer === "someone-else" && ex.note === "must survive",
+        JSON.stringify(ex));
+      check("named nodes preserved", (j.nodes ?? []).some((n: any) => String(n.name ?? "").startsWith("hero-hero-")));
       check("…and the original is byte-identical", readFileSync(hero).equals(Buffer.from(heroBytes)));
     }
 
     const untex = place(await gridGlb("untex", 160, false), "untex.glb");
-    r = await runLod(untex, join(tmp, "untex.glb.lod1.glb"), { KTX2_TOKTX: join(tmp, "no-such"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
+    r = await runLod(untex, lodVariantPath(untex), NO_ENCODER);
     check("an UNTEXTURED object reduces with no encoder at all", r.code === 0 && r.wrote, `exit ${r.code}: ${r.err.split("\n").pop()}`);
-    r = await runLod(hero, join(tmp, "hero2.glb.lod1.glb"), { KTX2_TOKTX: join(tmp, "no-such"), PATH: tmp, HOME: tmp, USERPROFILE: tmp });
-    check("a TEXTURED object with no encoder → exit 3 (environmental, no marker's business)", r.code === 3 && !existsSync(join(tmp, "hero2.glb.lod1.glb")),
-      `exit ${r.code}: ${r.err.split("\n").pop()}`);
+    const t0 = Date.now();
+    r = await runLod(hero, join(tmp, "hero2.out"), NO_ENCODER);
+    check("a TEXTURED object with no encoder → exit 3, answered from the RAW container (fast, the pump retries this every boot)",
+      r.code === 3 && !r.wrote && Date.now() - t0 < 10_000, `exit ${r.code} in ${Date.now() - t0}ms`);
 
     const real = findKtx2Encoder();
     if (!real) console.log("  - real encoder: skipped — none on this box");
     else {
-      r = await runLod(hero, join(tmp, "hero.real.lod1.glb"), { KTX2_TOKTX: real });
+      r = await runLod(hero, join(tmp, "hero.real.out"), { KTX2_TOKTX: real });
       check(`the real encoder (${real.split(/[\\/]/).pop()}): a reduced, KTX2-textured variant`, r.code === 0 && r.wrote, `exit ${r.code}`);
     }
   } finally { rmSync(tmp, { recursive: true, force: true }); }
 }
 
-// ---------------------------------------------- 4. the sequencer: upload → shadows → served tier
-console.log("\n  the real sequencer — choose the tier before the fetch:");
-{
-  const OPT = join(ROOT, "assets", "opt");
-  const STORE = join(OPT, "store"), STORE_MIN = join(OPT, "store-min");
-  const madeStore = !existsSync(STORE), madeMin = !existsSync(STORE_MIN);
-  mkdirSync(STORE, { recursive: true }); mkdirSync(STORE_MIN, { recursive: true });
-  const EMPTY_LIB = mkdtempSync(join(tmpdir(), "ew-lod-lib-"));
-  const DOOR = "test-door";
-  const mine = new Set<string>();
-  let server: ReturnType<typeof spawn> | null = null;
-  const cleanup = () => {
-    try { server?.kill(); } catch { /* gone */ }
-    for (const h of mine) for (const p of [join(STORE, `${h}.glb`), join(STORE, `${h}.glb.ktx2.glb`), join(STORE, `${h}.glb.ktx2.glb.failed`),
-      join(STORE, `${h}.glb.lod1.glb`), join(STORE, `${h}.glb.lod1.glb.failed`), join(STORE_MIN, `${h}.glb`), join(STORE_MIN, `${h}.glb.failed`)])
+// ---------------------------------------------- the owned-process harness
+const OPT = join(ROOT, "assets", "opt");
+const STORE = join(OPT, "store"), STORE_MIN = join(OPT, "store-min");
+const madeStore = !existsSync(STORE), madeMin = !existsSync(STORE_MIN);
+mkdirSync(STORE, { recursive: true }); mkdirSync(STORE_MIN, { recursive: true });
+const DOOR = "test-door";
+const mine = new Set<string>();          // store hashes this run created
+const mineOpt: string[] = [];            // OPT_DIR-relative files the library sweep created for us
+let live: ChildProcess | null = null;
+const cleanup = () => {
+  try { live?.kill(); } catch { /* gone */ }
+  for (const h of mine) {
+    for (const p of [join(STORE, `${h}.glb`), join(STORE, `${h}.glb.ktx2.glb`), join(STORE, `${h}.glb.ktx2.glb.failed`),
+      join(STORE_MIN, `${h}.glb`), join(STORE_MIN, `${h}.glb.failed`), lodVariantPath(join(STORE, `${h}.glb`)), `${lodVariantPath(join(STORE, `${h}.glb`))}.failed`])
       try { rmSync(p, { force: true }); } catch { /* best effort */ }
-    try {
-      const mp = join(STORE, "manifest.json");
-      if (existsSync(mp)) {
-        const man = JSON.parse(readFileSync(mp, "utf8"));
-        for (const h of mine) delete man[h];
-        if (Object.keys(man).length) writeFileSync(mp, JSON.stringify(man)); else rmSync(mp);
-      }
-    } catch { /* best effort */ }
-    if (madeStore) try { rmdirSync(STORE); } catch { /* not empty */ }
-    if (madeMin) try { rmdirSync(STORE_MIN); } catch { /* same */ }
-    try { rmSync(FAKE_DIR, { recursive: true, force: true }); } catch { /* best effort */ }
-    try { rmSync(EMPTY_LIB, { recursive: true, force: true }); } catch { /* best effort */ }
-  };
-  process.on("exit", cleanup);
-  let PORT = 0;
-  for (let i = 0; i < 20 && !PORT; i++) {
-    const cand = 20000 + Math.floor(Math.random() * 20000);
-    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); } catch { PORT = cand; }
   }
-  server = spawn(process.execPath, [join(ROOT, "server", "server.ts")],
-    { env: { ...process.env, PORT: String(PORT), JOIN_TOKEN: DOOR, KTX2_TOKTX: FAKE_TOKTX,
-      WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-lod-w-")), EIDOVERSE_DIR: EMPTY_LIB }, stdio: "ignore" });
+  for (const rel of mineOpt) { try { rmSync(join(OPT, rel), { force: true }); } catch { /* best effort */ } }
+  for (const rel of mineOpt) { let d = dirname(join(OPT, rel)); while (d !== OPT) { try { rmdirSync(d); } catch { break; } d = dirname(d); } }
+  try {
+    const mp = join(STORE, "manifest.json");
+    if (existsSync(mp)) {
+      const man = JSON.parse(readFileSync(mp, "utf8"));
+      for (const h of mine) delete man[h];
+      if (Object.keys(man).length) writeFileSync(mp, JSON.stringify(man)); else rmSync(mp);
+    }
+  } catch { /* best effort */ }
+  if (madeStore) try { rmdirSync(STORE); } catch { /* not empty */ }
+  if (madeMin) try { rmdirSync(STORE_MIN); } catch { /* same */ }
+  for (const d of [FAKE_DIR, NOWHERE]) try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+};
+process.on("exit", cleanup);
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); } catch { return cand; }
+  }
+  throw new Error("no free port in 20 tries");
+}
+/** Spawn the sequencer PROCESS-OWNED (review point 7): logs piped so startup
+ *  failure is diagnosable, ownership proven by a nonce round-trip the caller
+ *  performs against per-run content it alone placed, and a failed boot
+ *  prints the log tail instead of a bare ✗. */
+async function startServer(extra: Record<string, string | undefined>, lib?: string) {
+  const PORT = await freePort();
+  const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT), JOIN_TOKEN: DOOR,
+    WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-lod-w-")), EIDOVERSE_DIR: lib ?? mkdtempSync(join(tmpdir(), "ew-lod-lib-")), ...extra };
+  const proc = spawn(process.execPath, [join(ROOT, "server", "server.ts")], { env, stdio: ["ignore", "pipe", "pipe"] });
+  live = proc;
+  let log = "";
+  proc.stdout!.on("data", (d) => { log += d; });
+  proc.stderr!.on("data", (d) => { log += d; });
   let up = false;
-  for (let i = 0; i < 60 && !up; i++) { try { await fetch(`http://127.0.0.1:${PORT}/`); up = true; } catch { await sleep(250); } }
-  check("child server came up on a verified-free port", up, `:${PORT}`);
-  if (up) {
-    const base = `http://127.0.0.1:${PORT}`;
-    const version = await fetch(`${base}/version`).then((r) => r.json());
-    check("the running sequencer publishes the LOD recipe on /version — the only gate a client trusts",
-      lodFromVersion(version) === LOD_RECIPE, JSON.stringify(version.lodRecipe));
-    const key = keyFromVersion(version);
+  for (let i = 0; i < 60 && !up; i++) {
+    if (proc.exitCode != null) break;   // died at boot — the tail says why
+    try { await fetch(`http://127.0.0.1:${PORT}/version`); up = true; } catch { await sleep(250); }
+  }
+  if (!up) console.log(`      child did not come up — log tail:\n      ${log.split("\n").slice(-6).join("\n      ")}`);
+  const base = `http://127.0.0.1:${PORT}`;
+  const stop = async () => { try { proc.kill(); } catch { /* gone */ } live = null; await sleep(300); };
+  const version = up ? await fetch(`${base}/version`).then((r) => r.json()).catch(() => null) : null;
+  return { up, PORT, base, stop, log: () => log, version,
+    key: keyFromVersion(version), lod: lodFromVersion(version),
+    get: async (rel: string, headers: Record<string, string> = {}) => {
+      const res = await fetch(`${base}/library/${rel}`, { headers });
+      return { status: res.status, cc: res.headers.get("cache-control") ?? "",
+        bytes: res.status === 200 ? new Uint8Array(await res.arrayBuffer()) : new Uint8Array(0) };
+    },
+    upload: async (bytes: Uint8Array, name: string) => fetch(`${base}/upload?token=${DOOR}&name=${name}`, { method: "POST", body: bytes }) };
+}
+const isLodGlb = (bytes: Uint8Array) => { try { return glbJson(bytes)?.asset?.extras?.recipe === LOD_RECIPE; } catch { return false; } };
+
+// ---------------------------------------------- 4. store door: upload → tier chosen by recipe URL
+console.log("\n  the store door — the tier URL carries the generation:");
+{
+  const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX });
+  check("child server came up (owned harness, logs piped)", S.up, `:${S.PORT}`);
+  if (S.up) {
+    check("the running sequencer publishes the LOD recipe on /version", S.lod === LOD_RECIPE, JSON.stringify(S.version?.lodRecipe));
     const glb = await gridGlb("served", 160, true);
     const hash = hashOf(glb); mine.add(hash);
-    const upRes = await fetch(`${base}/upload?token=${DOOR}&name=lod-test`, { method: "POST", body: glb });
-    check("POST /upload landed it", upRes.status === 200);
-    const flaggedUrl = `${base}/library/${withLod(negotiate(`store/${hash}.glb`, key))}`;
-    const early = await fetch(flaggedUrl);
-    const earlyBytes = new Uint8Array(await early.arrayBuffer());
-    const earlyIsLod = (() => { try { return glbJson(earlyBytes)?.asset?.extras?.recipe === LOD_RECIPE; } catch { return false; } })();
-    check("before the variant lands, a ?lod fetch is answered PROVISIONALLY — never pinned",
-      earlyIsLod || early.headers.get("cache-control") === "no-cache", `lod=${earlyIsLod} cc=${early.headers.get("cache-control")}`);
-    const landed = await until(() => existsSync(join(STORE, `${hash}.glb.lod1.glb`)), 45_000);
-    check("the queue built the LOD shadow beside the original", landed);
+    await S.upload(glb, "lod-test");
+    // ownership: only the tree we spawned from holds this run's fixture
+    const own = await S.get(`store/${hash}.glb`);
+    check("listener is OUR child (per-run fixture round-trips)", own.status === 200 && own.bytes.length === glb.length, `status=${own.status}`);
+    const url = withLod(negotiate(`store/${hash}.glb`, S.key), S.lod);
+    const early = await S.get(url);
+    check("before the variant lands, the recipe URL answers PROVISIONALLY", isLodGlb(early.bytes) || early.cc === "no-cache", `cc=${early.cc}`);
+    const landed = await until(() => existsSync(lodVariantPath(join(STORE, `${hash}.glb`))), 45_000);
+    check("the queue built the recipe-named LOD shadow", landed, lodVariantPath(join(STORE, `${hash}.glb`)));
     if (landed) {
-      const res = await fetch(flaggedUrl);
-      const bytes = new Uint8Array(await res.arrayBuffer());
-      const j = glbJson(bytes);
-      check("?ktx2=<key>&lod=1 → the LOD variant, identity-stamped, immutable",
-        j?.asset?.extras?.recipe === LOD_RECIPE && (res.headers.get("cache-control") ?? "").includes("immutable"),
-        `recipe=${j?.asset?.extras?.recipe} cc=${res.headers.get("cache-control")}`);
-      const noLod = await fetch(`${base}/library/${negotiate(`store/${hash}.glb`, key)}`);
-      const noLodJ = glbJson(new Uint8Array(await noLod.arrayBuffer()));
-      check("without ?lod the same client gets the plain ktx2 chain — tiers are chosen, never imposed",
-        noLodJ?.asset?.extras?.recipe !== LOD_RECIPE);
-      const listing: { path: string }[] = await fetch(`${base}/library-list?dir=store`).then((r) => r.json());
-      check("/library-list shows the original once, no lod artifacts", listing.filter((f) => f.path.includes(hash)).length === 1
-        && !listing.some((f) => isLodVariant(f.path)), listing.map((f) => f.path).filter((p) => p.includes(hash)).join(", "));
-      const catalog: { path: string }[] = await fetch(`${base}/library-models`).then((r) => r.json());
-      check("/library-models lists it once, never the variant", catalog.filter((h) => h.path === `store/${hash}.glb`).length === 1
-        && !catalog.some((h) => isLodVariant(h.path)));
+      const res = await S.get(url);
+      check("?ktx2=<key>&lod=<recipe> → the stamped variant, immutable", isLodGlb(res.bytes) && res.cc.includes("immutable"), `cc=${res.cc}`);
+      const other = await S.get(withLod(negotiate(`store/${hash}.glb`, S.key), "some-future-recipe"));
+      check("an UNRECOGNIZED generation answers provisionally — the next process may negotiate it, nothing gets pinned",
+        !isLodGlb(other.bytes) && other.cc === "no-cache", `cc=${other.cc}`);
+      const noLod = await S.get(negotiate(`store/${hash}.glb`, S.key));
+      check("without ?lod the same client gets the plain ktx2 chain — tiers chosen, never imposed", !isLodGlb(noLod.bytes));
+      const listing: { path: string }[] = await fetch(`${S.base}/library-list?dir=store`).then((r) => r.json());
+      check("/library-list shows the original once, no lod artifacts",
+        listing.filter((f) => f.path.includes(hash)).length === 1 && !listing.some((f) => isLodVariant(f.path)));
+      const catalog: { path: string }[] = await fetch(`${S.base}/library-models`).then((r) => r.json());
+      check("/library-models lists it once, never the variant",
+        catalog.filter((h) => h.path === `store/${hash}.glb`).length === 1 && !catalog.some((h) => isLodVariant(h.path)));
     }
-    // a body through the same door: the pump must fail it closed with the typed verdict
     const body = await skinnedGlb("served");
     const bh = hashOf(body); mine.add(bh);
-    await fetch(`${base}/upload?token=${DOOR}&name=body-test`, { method: "POST", body });
-    const refused = await until(() => existsSync(join(STORE, `${bh}.glb.lod1.glb.failed`)), 45_000);
-    const verdict = refused ? readFileSync(join(STORE, `${bh}.glb.lod1.glb.failed`), "utf8") : "";
-    check("an uploaded BODY gets the typed verdict marker and no lod variant",
-      refused && verdict.includes("unsupported: skinned/avatar asset") && !existsSync(join(STORE, `${bh}.glb.lod1.glb`)), verdict.slice(0, 80));
-    const bodyRes = await fetch(`${base}/library/${withLod(negotiate(`store/${bh}.glb`, key))}`);
-    const bodyJ = glbJson(new Uint8Array(await bodyRes.arrayBuffer()));
-    check("…and a ?lod fetch for it falls back to the original chain — never a half-valid object",
-      bodyJ?.asset?.extras?.recipe !== LOD_RECIPE);
+    await S.upload(body, "body-test");
+    const refused = await until(() => existsSync(`${lodVariantPath(join(STORE, `${bh}.glb`))}.failed`), 45_000);
+    const verdict = refused ? readFileSync(`${lodVariantPath(join(STORE, `${bh}.glb`))}.failed`, "utf8") : "";
+    check("an uploaded BODY gets the typed verdict marker and no variant",
+      refused && verdict.includes("unsupported: skinned/avatar asset") && !existsSync(lodVariantPath(join(STORE, `${bh}.glb`))), verdict.slice(0, 80));
+    const bodyRes = await S.get(withLod(negotiate(`store/${bh}.glb`, S.key), S.lod));
+    check("…and its recipe-URL fetch falls back whole — never a half-valid object", !isLodGlb(bodyRes.bytes));
   }
-  cleanup();
+  await S.stop();
 }
 
+// ---------------------------------------------- 5. the library arm + mutable-source freshness
+console.log("\n  the library arm — the sweep queues LODs, and mutable sources are never served stale:");
+{
+  const LIB = mkdtempSync(join(tmpdir(), "ew-lod-reallib-"));
+  const modelsDir = join(LIB, "eidoverse", "assets", "models");
+  mkdirSync(modelsDir, { recursive: true });
+  const libGlb = await gridGlb("library", 160, true);
+  const REL = "eidoverse/assets/models/lod_probe_fixture.glb";
+  writeFileSync(join(LIB, REL), libGlb);
+  mineOpt.push(`${REL}.ktx2.glb`, `${REL}.ktx2.glb.failed`,
+    ...[LOD_RECIPE, "x"].map((r0) => `${REL}.lod.${r0}.glb`), `${REL}.lod.${LOD_RECIPE}.glb.failed`);
+  let S = await startServer({ KTX2_TOKTX: FAKE_TOKTX }, LIB);
+  check("child server came up over the fixture library", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const own = await S.get(REL);
+    check("listener is OUR child (the per-run library fixture round-trips)", own.status === 200 && own.bytes.length === libGlb.length);
+    const lodPath = join(OPT, `${REL}.lod.${LOD_RECIPE}.glb`);
+    const landed = await until(() => existsSync(lodPath), 60_000);
+    check("the LIBRARY sweep queued and built the LOD (the shared-seen bug is dead)", landed,
+      S.log().split("\n").filter((l) => l.includes("lod") || l.includes("ktx2")).slice(-4).join(" | "));
+    check("…and the ktx2 arm still built its own variant beside it", await until(() => existsSync(join(OPT, `${REL}.ktx2.glb`)), 60_000));
+    if (landed) {
+      const res = await S.get(withLod(negotiate(REL, S.key), S.lod));
+      check("the library LOD serves under the recipe URL", isLodGlb(res.bytes));
+      // the source mutates (a library file is MUTABLE): the old variant must
+      // never serve under the new source — provisional until rebuilt
+      await sleep(1100);   // a strictly newer mtime, beyond timestamp granularity
+      const libGlb2 = await gridGlb("library-v2", 160, true);
+      writeFileSync(join(LIB, REL), libGlb2);
+      const now = new Date();
+      utimesSync(join(LIB, REL), now, now);
+      const stale = await S.get(withLod(negotiate(REL, S.key), S.lod));
+      check("source newer than variant → the variant is NOT served; the fall-through is provisional",
+        !isLodGlb(stale.bytes) && stale.cc === "no-cache", `cc=${stale.cc}`);
+      await S.stop();
+      // the next boot's sweep rebuilds it (mtime), and the fresh variant serves
+      S = await startServer({ KTX2_TOKTX: FAKE_TOKTX }, LIB);
+      check("child rebooted", S.up);
+      if (S.up) {
+        const rebuilt = await until(() => existsSync(lodPath) && Bun.file(lodPath).lastModified > Bun.file(join(LIB, REL)).lastModified, 60_000);
+        check("the next boot re-swept the mutated source into a FRESH variant", rebuilt);
+        if (rebuilt) {
+          const res2 = await S.get(withLod(negotiate(REL, S.key), S.lod));
+          check("…which serves — bound to the new source", isLodGlb(res2.bytes));
+        }
+      }
+    }
+  }
+  await S.stop();
+  try { rmSync(LIB, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+// ---------------------------------------------- 6. no encoder: untextured LOD work survives
+console.log("\n  no encoder — geometry work is not the encoder's hostage:");
+{
+  const S = await startServer(NO_ENCODER);
+  check("child server came up with no encoder anywhere", S.up, `:${S.PORT}`);
+  if (S.up) {
+    const untex = await gridGlb("noenc-untex", 160, false);
+    const uh = hashOf(untex); mine.add(uh);
+    await S.upload(untex, "noenc-untex");
+    const tex = await gridGlb("noenc-tex", 160, true);
+    const th = hashOf(tex); mine.add(th);
+    await S.upload(tex, "noenc-tex");
+    const landed = await until(() => existsSync(lodVariantPath(join(STORE, `${uh}.glb`))), 45_000);
+    check("the UNTEXTURED upload got its LOD — ktx2Skip no longer deletes valid geometry work", landed,
+      S.log().split("\n").filter((l) => l.includes("lod") || l.includes("encoder")).slice(-4).join(" | "));
+    await until(() => existsSync(join(STORE_MIN, `${th}.glb`)) || existsSync(join(STORE_MIN, `${th}.glb.failed`)), 45_000);
+    await sleep(1500);
+    check("the TEXTURED upload kept its original: no variant, NO marker (environmental)",
+      !existsSync(lodVariantPath(join(STORE, `${th}.glb`))) && !existsSync(`${lodVariantPath(join(STORE, `${th}.glb`))}.failed`));
+    check("…with the --lod arm's own once-per-boot note, and no ktx2Skip purge of lod items",
+      S.log().split("\n").filter((l) => l.includes("[lod] no KTX2 encoder")).length === 1, `${S.log().split("\n").filter((l) => l.includes("[lod] no KTX2 encoder")).length} line(s)`);
+  }
+  await S.stop();
+}
+
+// ---------------------------------------------- 7. the mutation canary: a recipe change cannot pin
+console.log("\n  the canary — a pulled recipe lands under a running sequencer:");
+{
+  const SV = join(ROOT, "server", "store-variants.ts");
+  const pristine = readFileSync(SV);
+  const restore = () => { try { writeFileSync(SV, pristine); } catch { /* best effort */ } };
+  process.on("exit", restore);
+  const glb = await gridGlb("canary", 160, true);
+  const hash = hashOf(glb); mine.add(hash);
+  writeFileSync(join(STORE, `${hash}.glb`), glb);
+  const S = await startServer({ KTX2_TOKTX: FAKE_TOKTX });
+  check("child server came up with the PRISTINE recipe in memory", S.up && S.lod === LOD_RECIPE, `${S.up} lod=${S.lod}`);
+  try {
+    if (S.up) {
+      const landed = await until(() => existsSync(lodVariantPath(join(STORE, `${hash}.glb`))), 45_000);
+      check("its boot sweep built the current-generation variant", landed);
+      const NEXT = "lod1-r10-future";
+      writeFileSync(SV, pristine.toString("utf8").replace(`export const LOD_RECIPE = "${LOD_RECIPE}";`, `export const LOD_RECIPE = "${NEXT}";`));
+      const version2 = await fetch(`${S.base}/version`).then((r) => r.json());
+      check("the pull landed; /version still publishes the RUNNING recipe", lodFromVersion(version2) === LOD_RECIPE, JSON.stringify(version2.lodRecipe));
+      const good = await S.get(withLod(negotiate(`store/${hash}.glb`, S.key), LOD_RECIPE));
+      check("a client keyed from /version gets the variant, immutable — correct", isLodGlb(good.bytes) && good.cc.includes("immutable"), good.cc);
+      const bad = await S.get(withLod(negotiate(`store/${hash}.glb`, S.key), NEXT));
+      check("the NEXT generation's URL answers no-cache and NOT the old variant — nothing for the new recipe to inherit",
+        !isLodGlb(bad.bytes) && bad.cc === "no-cache", `cc=${bad.cc} lod=${isLodGlb(bad.bytes)}`);
+    }
+  } finally { restore(); await S.stop(); }
+  check("the on-disk recipe is restored byte-for-byte", readFileSync(SV).equals(pristine));
+}
+
+cleanup();
 console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Mica, Antra — geometry LOD for placeable objects, the server half of the lane agreed in devchat: **objects first; bodies excluded by positive structural detection; no silent attempt.** This lands inert — nothing asks for a tier until the client chooser (its own PR) — the same way §20 itself landed.

*Round two (`e291c7d`) addresses the review's seven points — see the thread. Summary below is current.*

## The contract, point by point

- **Bodies fail closed, structurally — not by well-formedness.** `lodExclusion` reads the **raw JSON chunk** before any Document exists. Skins; **any `JOINTS_n`/`WEIGHTS_n` set**; VRM metadata in `extensionsUsed`, `extensionsRequired`, **or the top-level `extensions` object** (a malformed producer is still a body); morph targets → exit 2 with the typed verdict **`unsupported: skinned/avatar asset`**, nothing written. And **any animation is a typed v1 refusal** — `unsupported: animated object (v1 reduces static geometry only)`: preservation of channels through the diet is evidence a later recipe earns, not a claim this one makes.
- **Original preserved byte-identically.** The variant is a sibling (`<rel>.lod1.glb`); the suite asserts the original's bytes unchanged after both a refusal and a success.
- **Identity binds source hash + recipe + tools.** `asset.extras` gains `{ lodOf: <source sha256>, recipe, tools: { meshoptimizer, encoder } }` — merged over the source's own extras, never clobbering them.
- **Preservation proven or refused.** After the reduce: the node **hierarchy with per-node transforms**, and **per-primitive material assignments**, are signature-checked; scene bounds within tolerance; vert count actually reduced. Any failure → typed verdict, never a half-valid object. Already-light objects (< 12k verts) and ineffective reductions refuse honestly too. **Scope, stated plainly:** the LOD mesh is a *visual* representation — the client contract (follow-up PR) keeps collision/support/raycast semantics anchored to the original's geometry, with tier upgrade on approach.
- **Chosen before fetch, original fallback — and the recipe is a GENERATION.** The URL carries it (`?lod=<recipe>`, taken from `/version`'s `lodRecipe`, never a default) and so does the filename (`<rel>.lod.<recipe>.glb`): a recipe change is a fresh URL and a fresh file, nothing to un-pin, and the pump retires the old generation's file when the new one lands. Every fall-through stays provisional, an **unrecognized** `lod` value forces provisional too (the next process may negotiate it), and a **mutable library source newer than its variant is never served the variant** — the §20c freshness discipline, with the next boot's sweep rebuilding it.
- **No artifact leaks.** `isLodVariant` joins the serving-artifact predicate; catalogs, listings, and the boot sweeps all inherit the existing rules; verdicts are recipe-stamped so a future recipe re-measures refusals (#146's doctrine, reused).

The diet itself is the house recipe end to end: the ktx2 diet (dedup/prune/resample + texel-budget KTX2 + draco) with `weld() + simplify(MeshoptSimplifier, ratio 0.25, error 0.01)` — the avatar importer's own proven reducer — in between. An untextured object needs no encoder; a textured one on an encoder-less box is exit 3, environmental.

## Measured, on the library

| model | original | lod1 | |
|---|---|---|---|
| oil drilling rig | 55.1 MB | **2.1 MB** | 26× |
| cyborg brain | 49.9 MB | **2.0 MB** | 25× |
| cyborg heart | 46.5 MB | **1.8 MB** | 26× |
| server rack (246k verts, disjoint hard edges) | — | *refused: reduction ineffective* | honest |
| `claude_suit.vrm` | — | *refused: `unsupported: skinned/avatar asset (skins)`, 5 ms* | fail closed |

## Receipts

`bun tools/object-lod-test.ts` — **72/72**, fake encoder (no KTX-Software needed; the real-encoder receipt runs when present), on a **process-owned harness** (logs piped, per-run content-hashed fixture as the ownership nonce, a failed boot prints its log tail). Each seam of the review has a named control — deleting the mechanism turns its control red:
- the exclusion, pure — including the review's probes: a VRM extension *object* with no `extensionsUsed`, and `JOINTS_1/WEIGHTS_1` without set 0;
- the CLI: skinned and **animated** fixtures refused typed (originals byte-identical after); the identity stamp with the source's own extras surviving; already-light, ineffective-reduction, and textured-no-encoder verdicts — the last answered from the raw container in milliseconds, since the pump retries it every boot;
- the store door: upload → the recipe-named shadow → `?ktx2=<key>&lod=<recipe>` serves it immutable; the pre-landing fetch and an **unrecognized generation** both answer `no-cache`; an uploaded body gets the typed marker and its tier fetch falls back whole; listings and catalogs show no artifact;
- **the library arm**: a pre-existing library GLB gets both its lod and ktx2 variants (the shared-`seen` bug that killed this arm is dead), and a mutated source stops the variant serving until the next boot rebuilds it;
- **no encoder**: an untextured upload still reduces; the textured one keeps its original with no marker and one log line;
- **the mutation canary**: the on-disk recipe rewritten under a live child — `/version` holds the running generation, its URL serves, the next generation's URL answers `no-cache` and not the old bytes.

Also on this box: `store-variants-test` 123/123 and `git diff --check` clean. The neighboring `one-libvips` and `deps-route` suites pass here but reproduce failures in other environments — standing debt outside this delta, reported separately rather than folded into a green claim.

## Not in this PR

The client chooser (a follow-up PR): tier choice in `scheduleLoad` from distance + a `models⚙` dial, swap-on-repromote through the existing residency machinery, and the low-VRAM browser receipt. Bodies remain a later, separately-reviewed lane per the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R65fLki4fxEvDbCL2hT9JF
