### PR TITLE
fix: isolate optional sunflower generator loading

### DIFF
--- a/tools/vegetation-module-compat-test.ts
+++ b/tools/vegetation-module-compat-test.ts
@@ -1,0 +1,47 @@
+// A host can shadow vegetation.js while sourcing its generator modules from a
+// separately updated companion checkout. An optional species must not make the
+// entire vegetation module unloadable when that companion is one version old.
+
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${name}${ok ? "" : "  " + detail}`);
+  ok ? pass++ : fail++;
+};
+
+const scratch = mkdtempSync(join(tmpdir(), "ew-vegetation-compat-"));
+const source = new URL("../upstream-patched/eidoverse/vegetation.js", import.meta.url);
+const modulePath = join(scratch, "vegetation.js");
+
+try {
+  copyFileSync(source, modulePath);
+  writeFileSync(join(scratch, "vegetation_shrub_gen.js"),
+    "export const buildShrubGeometry = () => ({})\n");
+  writeFileSync(join(scratch, "vegetation_corn_gen.js"),
+    "export const buildCornGeometry = () => ({})\n");
+
+  const Stub = class {};
+  (globalThis as any).THREE = {
+    Matrix4: Stub,
+    Quaternion: Stub,
+    Vector3: Stub,
+    Euler: Stub,
+  };
+
+  console.log("\nvegetation module compatibility");
+  const mod = await import(`${pathToFileURL(modulePath).href}?run=${Date.now()}`);
+  check("ordinary flora loads without the optional sunflower generator",
+    typeof mod.createFlora === "function" && !!mod.FLORA_SPECIES.grass);
+} catch (error) {
+  check("ordinary flora loads without the optional sunflower generator", false,
+    error instanceof Error ? error.message : String(error));
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/upstream-patched/README.md
+++ b/upstream-patched/README.md
@@ -20,8 +20,12 @@ Current patches:
   grow (survivors of the host's distance thinning scale up to `cap`) and,
   with `lodGrow.exp`, the per-instance dither that moves the count-falloff
   curve into the shader (draw-order rank vs keep(d) — continuous density,
-  no tile seams). Without the opt: byte-identical to upstream. PR material
-  for Skye alongside docs/upstream-wrap-once.md.
+  no tile seams). It also loads the optional sunflower generator only when
+  sunflower is requested, so a separately updated companion checkout that
+  predates sunflower cannot disable every established flora species. A
+  missing generator still fails the sunflower request clearly. Without the
+  LOD opt, established-species rendering stays byte-identical to upstream.
+  PR material for Skye alongside docs/upstream-wrap-once.md.
 
 - `eidoverse/assets/animations/sitting_normal_chair.vrma` — hips translation
   track lowered by 0.409 (track units; 169 keyframes, Y lane only, X/Z and

--- a/upstream-patched/eidoverse/vegetation.js
+++ b/upstream-patched/eidoverse/vegetation.js
@@ -59,7 +59,6 @@ export const GRASS_COLORS = {
 
 import { buildShrubGeometry } from './vegetation_shrub_gen.js';
 import { buildCornGeometry } from './vegetation_corn_gen.js';
-import { buildSunflowerGeometry } from './vegetation_sunflower_gen.js';
 
 // ── species registry ─────────────────────────────────────────────────────────
 // card:    { w, h, curve, cup, segH } — one curved strip, full sheet per card
@@ -783,6 +782,7 @@ export async function createFlora(opts = {}) {
         console.log(`[grass2] corn plant: ${cornBuild.stats.verts} verts, ${cornBuild.stats.tris} tris`);
     }
     if (spec.archetype === 'sunflower') {
+        const { buildSunflowerGeometry } = await import('./vegetation_sunflower_gen.js');
         // fitted card envelopes measured from the delivered art (overdraw
         // pull-in); the gen has a stand-in fallback if the json is absent
         let sunFit = null;


### PR DESCRIPTION
This is a compatibility fix for independently updated `eidoverse-worlds` and `eidoverse-video` checkouts.

## The defect

`upstream-patched/eidoverse/vegetation.js` shadows the companion checkout's vegetation module, but its generator modules still come from the separately managed `EIDOVERSE_DIR` checkout. The top-level static import of `vegetation_sunflower_gen.js` therefore made sunflower support a load-time requirement for the entire vegetation module.

On a companion checkout from before sunflower support, that one missing optional generator prevents the module from evaluating at all. Grass, shrubs, corn, and every other established species become unavailable even though none of them needs the missing file.

## Upgrade context

"Before sunflower support" describes a legitimate rolling-upgrade or mixed-version window, not a recommended steady state. Operators should still update the companion checkout. Because the two repositories are versioned and deployed independently, the Worlds compatibility seam must remain safe while those updates land separately and while older deployments are still in service.

## The compatibility contract

- Established flora must remain loadable when the optional sunflower generator is absent.
- A sunflower request on that older companion must still fail clearly at the point of use; it must not silently substitute another species.
- A sunflower-capable companion keeps the same generator and rendering behavior.
- The companion checkout remains pristine; the compatibility seam stays in this repository's documented shadow file.

## What changes

- Load `vegetation_sunflower_gen.js` lazily inside the existing sunflower branch of `createFlora()`.
- Add an executable mixed-version regression test using a scratch companion that provides the established shrub and corn generators but deliberately omits sunflower.
- Document the shadow file's mixed-version behavior and failure boundary.

## Receipts

- `bun run tools/vegetation-module-compat-test.ts` — **1/1 passed**
- `bun run tools/flora.test.ts` — **67/67 passed**
- `git diff --check upstream/main...HEAD` — **clean**

## Scope

No world protocol, fold, persisted state, asset bytes, or established-species rendering changes. The only runtime difference is when the optional sunflower module is resolved.
