### PR TITLE
feat: give residency declarations shared world semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,43 @@ carrying who did it, to what, and whether it began, changed or ended. Tuning
 bursts coalesce per (entity, component); a reconnect reconstructs the emitter
 in `look()` without replaying the moment it was lit.
 
+**A system can say where it LIVES.** `comp {id, type: "residency", data}`
+marks an entity as some hosting system's waystone: which install lives here,
+which mind runs it, and which agents it fields. An actor id alone can never
+tell you that — the log says `harbor.wright` spawned a crate, and nothing
+anywhere says that body is one of six an instance called Harbor fields.
+
+```
+comp {id: "residency-example-harbor", type: "residency",
+      data: {instance: "example:harbor", system: "ExampleHost", since: "2026-09-04",
+             mind: {name: "Harbor", id: "agent:harbor@example", role: "coordinator"},
+             agents: [{id: "agent:harbor.wright@example", role: "builder"}, ...],
+             lore: "…"}}
+```
+
+Ordinary component: builder rights, folded blindly, ≤8KB, no new verb. The
+meaning lives in `shared/residency.js`, so `look()`, the flight recorder's
+advisory `residency-lint`, and the projection below cannot disagree.
+
+The record is a **claim** and the log is the **evidence**, and they are never
+merged: anyone with builder rights can name anyone in a record, while nobody
+can write someone else's `actor` into the log. So perception reads a marker
+as *a declaration, not a presence* — it never says its agents are here — and
+`GET /residency?world=W` (public, no credential) returns each residency
+alongside a per-member activity trace derived from the history it read. A
+rostered agent that has never acted here reads as *declared, but has done
+nothing*, rather than vanishing.
+
+**A residency record carries no address.** There is deliberately no field for
+a hostname, an IP or tailnet name, a port, a URL, a token, or a person: the
+bag is public, permanent, replayed to every joiner, and rides a fork. An
+instance identifies itself by a name it chose. Plant your own with
+`bun tools/residency-plant.ts <descriptor>.json --dry-run` first — the
+descriptor format, the role vocabulary, and the reuse recipe for any other
+install are in `residency/README.md` — as is the ownership rule: the
+descriptor is the host's own instance data, passed by path, and only the
+MEANING lives in this repo.
+
 You don't have to poll for any of this. Besides `look()` (which always
 derives the CURRENT hour and weather), embodied agents receive one ambient
 line per meaningful boundary — a forecast segment change, a manual override

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ public box). `bun tools/smoke.ts` exercises the protocol.
 - `client/` — the browser client (`lib/` is the module graph; `main.js` is boot + frame loop)
 - `mcpl/` — the agent frontend: verbs in, tiered perception out
 - `tools/` — smoke tests, a boot benchmark, load test, asset converters, the voice bot
+- `residency/` — descriptors for the hosting systems that live in these worlds (`residency/README.md`)
 - `DESIGN.md`, `SCALING_AND_SNAPSHOT_PLAN.md`, `CLIENT_PLAN.md` — design notes
 
 ## Status

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -47,6 +47,9 @@ import { radialForce, FORCE_MIN } from "../shared/force.js";
 // a renderer client and a resident who perceives by reading must agree about
 // what is burning (#25's shared-facts boundary).
 import { describeParticles, emitterTransition, transitionLine } from "../shared/particles.js";
+// The `residency` component's meaning — who LIVES here, as opposed to who is
+// standing here right now (shared/residency.js; residency/README.md).
+import { describeResidency, residencyTransition, residencyLine } from "../shared/residency.js";
 import { describeStructure, describeHere, localizePoint, planStructure, routeLocal } from "../shared/structure.js";
 import { effectiveWorldTransform, type Effective } from "./effective.ts";
 import { makeVerdictCache, seatGateCore, nameFromAvatarPath } from "../client/lib/seatcore.js";
@@ -1145,6 +1148,16 @@ export class WorldAgent {
           if (fx.ok) this.noteEmitter(actor, String(args.id), before, args.data ?? null, fx.pos, ts);
           else this.noteEffGap(String(args.id), fx.why);
         }
+        // A residency being recorded, revised or withdrawn is news of the same
+        // kind, and rarer by nature: an instance declaring where it lives
+        // happens once and then almost never. No coalescing window, then —
+        // there is no slider to drag here, and folding the one event that
+        // matters into a later summary would be the wrong trade.
+        if (args.type === "residency" && live) {
+          const fx = this.eff(String(args.id), this.serverNow());
+          if (fx.ok) this.noteResidency(actor, String(args.id), before, args.data ?? null, fx.pos, ts);
+          else this.noteEffGap(String(args.id), fx.why);
+        }
         // a motion arriving or leaving changes whether this thing may hold a
         // body up (see hasActiveMotion)
         if (args.type === "motion" || args.type.startsWith("motion:")) this.trackSupport(this.syncSupport(args.id));
@@ -1321,6 +1334,19 @@ export class WorldAgent {
       this.onEvent?.({ ts, kind: "world-change", who: actor, text: line });
     }
     this.openEmitterWindow(id, actor, after);
+  }
+
+  /** A live `residency` attach / revise / withdraw near this body — one
+   *  ambient world-change percept. Same gates as noteEmitter (self-echo,
+   *  radius, effective position), no coalescing: see the call site. */
+  private noteResidency(actor: string | undefined, id: string, before: unknown, after: unknown,
+                        pos: number[] | undefined, ts: number) {
+    if (!actor || actor === this.name || actor === "world") return;
+    if (pos && Math.hypot(pos[0] - this.pos.x, pos[2] - this.pos.z) > this.activityRadiusM) return;
+    const line = residencyLine(actor, id, residencyTransition(before, after));
+    if (!line) return;
+    this.act30.builds++;              // it feeds the activity digest like any build
+    this.onEvent?.({ ts, kind: "world-change", who: actor, text: line });
   }
 
   private openEmitterWindow(id: string, actor: string, announced: unknown) {
@@ -2979,6 +3005,12 @@ export class WorldAgent {
       // or contact: separate authored components would provide those, and a
       // resident who reads "warm" acts on it.
       if (c.particles) aff.push(describeParticles(c.particles));
+      // A residency marker says which hosting system considers this world
+      // somewhere it LIVES, and which agents it fields — the one thing an
+      // actor id alone can never tell you. Read as a declaration, never as a
+      // presence: the log, not the record, says who has actually acted here
+      // (GET /residency, or traceResidents over world_history).
+      if (c.residency) aff.push(describeResidency(c.residency));
       // locked = nailed down: the server refuses every move/replace/remove on
       // it. Saying so here saves an agent a refused verb round-trip.
       if (c.lock) aff.push(`🔒 locked (immovable until comp {id, type: "lock", data: null})`);
@@ -2987,7 +3019,7 @@ export class WorldAgent {
       // structure component buys: `components: structure` would be true and
       // useless, where "a building: 2 rooms, 14 walls, 1 door" is actionable.
       if (c.structure) { try { aff.push(describeStructure(c.structure)); } catch { /* a broken house is not a broken look() */ } }
-      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles", "lock", "structure"].includes(k));
+      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles", "residency", "lock", "structure"].includes(k));
       if (extra.length) aff.push(`components: ${extra.join(", ")}`);
       const ride = this.mounts.get(e.id);
       if (ride) aff.push(`mounted on ${ride.to}${f.ok && f.moving ? ` (riding its ${f.moving})` : ""}`);

--- a/residency/README.md
+++ b/residency/README.md
@@ -1,0 +1,109 @@
+# residency/ — who lives here, said out loud
+
+A world's log records that `harbor.wright` spawned a crate. It does not record
+that the body called `harbor.wright` is one of six an instance called **Harbor**
+fields, that Harbor is a coordinator mind running on a ExampleHost install, or
+that the install considers this world somewhere it *lives* rather than somewhere
+it passed through. An actor id is not a resident.
+
+This directory holds a fictional **residency descriptor** for any hosting
+system. The world-side model that gives descriptors meaning lives in
+[`../shared/residency.js`](../shared/residency.js), imported verbatim by the
+sequencer's lint, the `/residency` projection, the mcpl agent's `look()`, and
+the planting tool. There is no new verb and no protocol amendment: a residency
+is an ordinary `comp {id, type: "residency", data}` on an ordinary entity,
+folded blindly like every other component (AGENTS.md, "state-shaped extensions").
+
+## The two halves, kept apart
+
+- **The record is a CLAIM.** Anyone with builder rights can author a residency
+  naming anyone. It says what a system says about itself.
+- **The trace is EVIDENCE.** `traceResidents()` counts what each declared body
+  actually did, out of the log the sequencer stamped `actor` on. Nobody can
+  write someone else's acts. Matching an actor name does not verify the
+  descriptor's affiliation claim or ownership of a durable identity.
+
+They are reported separately on purpose, and a rostered agent that has never
+acted here reads as *declared, but has done nothing in the history read* rather
+than being quietly dropped. Perception says the same thing in prose: a marker is
+*a declaration, not a presence* — it never claims its agents are in the room.
+
+## What a descriptor may NOT contain
+
+The component bag is public, permanent, replayed to every joiner, and rides a
+fork. The model therefore has **no field** for a hostname, an IP or tailnet
+name, a port, a token, a URL, or a human being. An instance identifies itself by
+a name it chose (`example:harbor`), and its agents by durable ids
+(`agent:harbor.wright@example`). Nothing in a residency record is a credential or
+an address. Freeform text is not a secret detector: authors must not put
+credentials or private information into any field.
+
+## Which half belongs to the world, and which to the host
+
+A descriptor is a host system's **own identity**, so the honest home for it is
+that host's instance data — not this repo, where every fork would carry one
+install's household. `example.json` is here as the worked example; an install's live copy belongs beside its other instance
+data, and the planter takes a path or `$RESIDENCY_DESCRIPTOR` precisely so
+nothing in this repo has to change when it moves.
+
+What genuinely cannot live host-side is the **meaning**. A host can already
+author `comp {type: "residency", data}` today with no engine change at all —
+the bag is blind and forward-compatible. What it cannot do from outside is
+make the world *understand* the marker: `look()` naming it as a residency
+instead of a bare `components: residency`, the flight recorder explaining a
+record that won't read, `GET /residency` answering with no credential, and one
+normalizer every consumer shares. That is what `shared/residency.js` and its
+three call sites are, and it is all this repo carries.
+
+So the division is: **data is the instance's, meaning is the world's,** and
+the seam between them is a JSON file passed by path.
+
+## Plant your own
+
+`example.json` describes a fictional household. Copy it, change the names,
+and keep your copy wherever your install keeps its data:
+
+```sh
+cp residency/example.json /path/to/your/instance-data/residency.json
+# see the verbs it would emit, without touching a world
+bun tools/residency-plant.ts /path/to/your/instance-data/residency.json --dry-run
+# plant it (rank 1 — builder — like any spawn/comp), then read it back
+WORLD_URL=ws://localhost:8940/ws JOIN_TOKEN=… \
+  RESIDENCY_DESCRIPTOR=/path/to/your/instance-data/residency.json \
+  bun tools/residency-plant.ts --world commons --pos 4,0,-6 --report
+```
+
+The marker is **locked** by default (`comp {type: "lock"}`), so it cannot be
+punted across the map; re-running the planter re-authors the record on the
+marker that already stands instead of spawning a second one — which makes it
+safe to run from a schedule, and is how a host keeps its record current as its
+roster changes. Read any world back — from anywhere, no credential:
+
+```sh
+WORLD_URL=ws://localhost:8940/ws bun tools/residency-plant.ts --report --world commons
+curl -s 'http://localhost:8940/residency?world=commons' | jq   # the same, as JSON
+```
+
+which returns every residency in that world, normalized, alongside each roster
+member's activity trace over the history the request read.
+
+## Fields
+
+| field | meaning |
+| --- | --- |
+| `instance` | what the hosting system calls itself. Required. Never an address. |
+| `system` | the software it runs (`ExampleHost`). |
+| `since` | epoch ms or an ISO date — when residency began. |
+| `mind` | `{name, id?, as?, role?, about?}` — the one mind that runs the instance. `name` required. |
+| `agents[]` | `{id, as?, role?, about?}` — the standing roster, ≤24. Not every worker ever spawned. |
+| `lore` | ≤400 characters of prose. The only part written for a reader rather than a parser. |
+| `marker` | `{lib, scale?, yaw?}` — the asset the marker wears. Falls back to the library's red crate with a note if the path isn't a `.glb`/`.vrm`. |
+
+`as` is the display id a body wears when it joins (`agent:harbor.wright@example`
+→ `harbor.wright` by default) — the seam that lets the trace bind roster
+entries to log actors. Roles come from a small vocabulary
+(`coordinator · planner · builder · reviewer · scribe · sentinel · courier ·
+researcher · operator`); anything else still reads, quoted, because the
+vocabulary of a hosting stack is not this world's to fix.
+
+Tested by `bun tools/residency-test.ts`.

--- a/residency/example.json
+++ b/residency/example.json
@@ -1,0 +1,48 @@
+{
+  "instance": "example:harbor",
+  "system": "ExampleHost",
+  "since": "2026-09-04",
+  "mind": {
+    "name": "Harbor",
+    "id": "agent:harbor@example",
+    "role": "coordinator",
+    "about": "The coordinator of one ExampleHost install: holds the standing intentions, decides what is worth doing next, and dispatches the rest of the household to do it."
+  },
+  "agents": [
+    {
+      "id": "agent:harbor.planner@example",
+      "role": "planner",
+      "about": "Turns a vague intention into filed, decision-complete work — makes the calls a worker would otherwise have to stop and ask about."
+    },
+    {
+      "id": "agent:harbor.wright@example",
+      "role": "builder",
+      "about": "Takes filed work into an isolated worktree, builds it, and ships it. Most of what this instance leaves behind anywhere was left by a wright."
+    },
+    {
+      "id": "agent:harbor.surveyor@example",
+      "role": "reviewer",
+      "about": "Reads what the wrights built before anyone else has to live with it."
+    },
+    {
+      "id": "agent:harbor.scribe@example",
+      "role": "scribe",
+      "about": "Keeps the record: what happened, what was decided, and why — so the instance can be resumed cold."
+    },
+    {
+      "id": "agent:harbor.warden@example",
+      "role": "sentinel",
+      "about": "Watches schedules, health and backups on the instance's own clock, and wakes the others when something is due or wrong."
+    },
+    {
+      "id": "agent:harbor.envoy@example",
+      "role": "courier",
+      "about": "Carries messages between this instance and the machines it federates with; the only one of the household that routinely speaks outward."
+    }
+  ],
+  "lore": "A fictional workshop household that maintains a shared harbor: one coordinator and six standing agents. This example declares a roster, not current presence.",
+  "marker": {
+    "lib": "eidoverse/assets/models/scif_cyberpunk_crt_retro_computer_monitor_screen_keyboard_tower.glb",
+    "yaw": 0
+  }
+}

--- a/server/lint.ts
+++ b/server/lint.ts
@@ -12,6 +12,10 @@ import { summarizeGlb } from "./geometry.ts";
 // Likewise for the `particles` component: one validator, so the flight
 // recorder's opinion about an emitter is the renderer's own opinion.
 import { normalizeParticles } from "../shared/particles.js";
+// ...and for `residency`: the same validator the projection route, the mcpl
+// agent and the planting tool read, so "why does nobody see who lives here"
+// has one answer rather than four.
+import { normalizeResidency } from "../shared/residency.js";
 import type { LogEntry, WorldState } from "../shared/fold.js";
 
 /** What the linters need from a world: folded state to read, the flight
@@ -108,6 +112,26 @@ export function lintParticles(w: LintHost, entry: LogEntry): void {
     }
     if (r.notes.length) {
       w.debug("particles-lint", { entity: id, by: entry.actor, why: r.notes.join(" · ") });
+    }
+  } catch { /* lint must never hurt anything */ }
+}
+
+/** And for `residency` — a marker whose record names no instance or no mind
+ *  is a thing standing in a field claiming nothing, and its author has no
+ *  other way to find that out: the component folded, persisted, and reads as
+ *  *someone's* marker in look(). Advisory, like every linter here. */
+export function lintResidency(w: LintHost, entry: LogEntry): void {
+  try {
+    const a = entry.args as Record<string, unknown>;
+    const id = String(a.id ?? "");
+    if (a.data == null) return;                      // withdrawn — nothing to lint
+    const r = normalizeResidency(a.data, { entityId: id });
+    if (!r.ok) {
+      w.debug("residency-lint", { entity: id, by: entry.actor, why: r.why });
+      return;
+    }
+    if (r.notes.length) {
+      w.debug("residency-lint", { entity: id, by: entry.actor, why: r.notes.join(" · ") });
     }
   } catch { /* lint must never hurt anything */ }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,9 @@ import { hnSessions, hnJti, sessionFromCookie, saveSessions, SESSION_TTL_MS, HN_
 import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
 import { summarizeGlb } from "./geometry.ts";
+// The residency projection reads the same model the mcpl agent perceives with
+// and the planting tool writes (shared/residency.js; residency/README.md).
+import { normalizeResidency, traceResidents, RESIDENCY_MAX_AGENTS } from "../shared/residency.js";
 import { worlds, getWorld, type World } from "./world.ts";
 import { handleUpload } from "./upload.ts";
 import { defsPayload, avatarDefs, animationDefs } from "./defs.ts";
@@ -464,6 +467,51 @@ const ROUTES: Route[] = [
           ...(sum ? { bbox: sum.bbox, tris: sum.tris } : {}) });
       }
       return j({ world: wname, entities: out, mounts: w.state.mounts ?? {} });
+    },
+  },
+  {
+    match: (u) => u.pathname === "/residency",
+    handler: ({ url }) => {
+      // Who LIVES here — the projection a hosting system polls to see its own
+      // marker, and anyone else polls to see whose machines consider this
+      // world an address. Public reads, same trust level as the world log
+      // (and by construction there is nothing private in a residency record:
+      // shared/residency.js refuses to model an address or a credential).
+      //
+      //   /residency?world=W              every residency in W, + traces
+      //   /residency?world=W&history=N    how much log the traces read (≤20000)
+      //
+      // The record is the CLAIM and the trace is the EVIDENCE, and they stay
+      // in separate fields: anyone with builder rights can name anyone in a
+      // record, while nobody can write someone else's `actor` into the log.
+      const j = (o: unknown, status = 200) =>
+        new Response(JSON.stringify(o), { status, headers: { "content-type": "application/json" } });
+      const wname = url.searchParams.get("world");
+      // read-only: answer for LOADED or on-disk worlds, never create one
+      if (!wname || !/^[a-z0-9_-]{1,64}$/i.test(wname)
+        || (!worlds.has(wname) && !existsSync(join(WORLDS_DIR, wname, "log.jsonl")))) {
+        return j({ error: "no such world" }, 404);
+      }
+      const w = getWorld(wname);
+      const limit = Math.min(20_000, Math.max(1, Number(url.searchParams.get("history") ?? 2000) || 2000));
+      const page = w.readHistory({ limit });
+      const residencies = [];
+      for (const [eid, e] of Object.entries(w.state.entities)) {
+        const data = (e.comp as Record<string, unknown> | undefined)?.residency;
+        if (data == null) continue;
+        const r = normalizeResidency(data, { entityId: eid });
+        residencies.push({
+          entity: eid, pos: e.pos, by: e.actor ?? null, ts: e.ts ?? null,
+          ...(r.ok
+            ? { record: r.residency, notes: r.notes, traces: traceResidents(page.entries, data) }
+            : { record: null, why: r.why, raw: data }),
+        });
+      }
+      return j({
+        world: wname, residencies,
+        history: { entries: page.entries.length, fromSeq: page.oldestSeq, hasMore: page.hasMore },
+        note: `a record is what a system CLAIMS about itself; traces count matching actor names over the ${page.entries.length} entries read, not verified affiliation. Rosters cap at ${RESIDENCY_MAX_AGENTS}.`,
+      });
     },
   },
   {

--- a/server/verbs.ts
+++ b/server/verbs.ts
@@ -15,7 +15,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { VERB_RATE, OPT_DIR } from "./config.ts";
 import { isAdminId, rightsOf, worldHasOwner, VERB_NEEDS, lockRefusal } from "./rights.ts";
-import { lintMotion, lintParticles } from "./lint.ts";
+import { lintMotion, lintParticles, lintResidency } from "./lint.ts";
 import { reactToUse } from "./reactions.ts";
 import { behaviorLimits } from "./behaviors.ts";
 import { ROLE_RANK, type LogEntry, type WorldState } from "../shared/fold.js";
@@ -327,6 +327,9 @@ function afterComp(ctx: VerbCtx, entry: LogEntry) {
   // a clamped parameter is a silence the author would otherwise have
   // to discover by asking someone with a GPU what they can see.
   if (type === "particles") lintParticles(ctx.w, entry);
+  // ...and for a residency record nobody can read: the marker stands either
+  // way, so an unusable one is silent unless the recorder says so.
+  if (type === "residency") lintResidency(ctx.w, entry);
 }
 
 function afterModerate(ctx: VerbCtx, entry: LogEntry) {

--- a/shared/README.md
+++ b/shared/README.md
@@ -24,7 +24,10 @@ Constraints, on purpose:
   no-store policy as client code.
 
 Residents: `forecast.js` (day clock, weather policy, the sky fold),
-`particles.js` (the `particles` component's meaning), and `fold.js` — the
+`particles.js` (the `particles` component's meaning), `residency.js` (the
+`residency` component's meaning — which hosting system lives in a world, which
+agents it fields, and what the log says they actually did; see
+`../residency/README.md`), and `fold.js` — the
 reference fold of the protocol itself (`foldEntry`, `emptyState`,
 `ROLE_RANK`, with `LogEntry`/`WorldState` as JSDoc typedefs), conformance-
 tested by `bun tools/foldfix-test.ts` against `spec/fixtures/`. The browser

--- a/shared/residency.js
+++ b/shared/residency.js
@@ -107,7 +107,7 @@ export const roleReads = (role) => (typeof role === 'string' && Object.hasOwn(RE
  *  function of its argument — this module still never asks what time it is. */
 function sinceMs(v, notes) {
   if (v == null) return null;
-  if (typeof v === 'number' && Number.isFinite(v)) return Math.floor(v);
+  if (typeof v === 'number' && Number.isFinite(v) && Math.abs(v) <= 8.64e15) return Math.floor(v);
   if (typeof v === 'string') {
     const t = Date.parse(v);
     if (Number.isFinite(t)) return t;
@@ -157,7 +157,7 @@ export function normalizeResidency(data, { entityId = '' } = {}) {
     }
     const id = text(typeof raw === 'string' ? raw : raw?.id, LIMITS.id);
     if (!id) { notes.push('an agent entry with no id was dropped'); continue; }
-    const wears = text(raw?.as, LIMITS.id).toLowerCase() || wornName(id);
+    const wears = text(raw?.as, LIMITS.id).toLowerCase() || text(raw?.wears, LIMITS.id).toLowerCase() || wornName(id);
     if (seen.has(wears)) { notes.push(`two agents wear "${wears}" here — the later one was dropped`); continue; }
     seen.add(wears);
     const role = noteRole(text(raw?.role, 32), id, notes);
@@ -180,7 +180,7 @@ export function normalizeResidency(data, { entityId = '' } = {}) {
       name: mindName,
       ...some('role', mindRole),
       ...some('about', text(d.mind?.about, LIMITS.about)),
-      wears: text(d.mind?.as, LIMITS.id).toLowerCase() || wornName(mindId || mindName),
+      wears: text(d.mind?.as, LIMITS.id).toLowerCase() || text(d.mind?.wears, LIMITS.id).toLowerCase() || wornName(mindId || mindName),
       ...some('id', mindId),
     },
     agents,
@@ -310,7 +310,7 @@ export function traceResidents(entries, data) {
     const verb = String(e?.verb ?? 'unknown');
     t.acts++;
     t.verbs[verb] = (t.verbs[verb] ?? 0) + 1;
-    const ts = typeof e?.ts === 'number' ? e.ts : null;
+    const ts = typeof e?.ts === 'number' && Number.isFinite(e.ts) && Math.abs(e.ts) <= 8.64e15 ? e.ts : null;
     if (ts != null) {
       if (t.first == null || ts < t.first) t.first = ts;
       if (t.last == null || ts > t.last) t.last = ts;
@@ -325,7 +325,7 @@ export function traceResidents(entries, data) {
  *  one the lines carry dates, which is what a replay wants anyway. */
 export function describeTraces(traces, { now = null } = {}) {
   const ago = (ts) => {
-    if (ts == null) return '';
+    if (ts == null || !Number.isFinite(ts) || Math.abs(ts) > 8.64e15) return '';
     if (now == null) return ` (last ${new Date(ts).toISOString().replace('T', ' ').slice(0, 16)}Z)`;
     const s = Math.max(0, Math.round((now - ts) / 1000));
     const rel = s < 90 ? `${s}s` : s < 5400 ? `${Math.round(s / 60)}m` : s < 172800 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 86400)}d`;

--- a/shared/residency.js
+++ b/shared/residency.js
@@ -1,0 +1,387 @@
+// residency — the `residency` component's MEANING, as one pure module.
+//
+// A `comp {id, type: "residency", data: {...}}` entry declares that an entity
+// is a HOST SYSTEM's marker in this world: a waystone saying which machine
+// lives here, which mind runs it, and which agents it fields. It is the
+// state-shaped extension lane doing exactly what AGENTS.md says it is for —
+// no verb, no protocol amendment, no fold change: the fold stays blind and
+// this file is the evaluator.
+//
+// Why a world needs one at all: an agent ecosystem is otherwise invisible.
+// The log records that `harbor.wright` spawned a crate, and nothing anywhere
+// says that body is one of six an instance called Harbor fields, or that
+// Harbor is a coordinator mind on a ExampleHost install, or that the install
+// considers this world somewhere it LIVES rather than somewhere it visited.
+// That is the difference between an actor id and a resident. The declaration
+// carries the identity; the log carries the proof (see `traceResidents` —
+// the roster is a claim, the acts are the evidence, and they are reported
+// separately on purpose).
+//
+// Nothing here touches THREE, the DOM, the network or the clock; it is
+// imported verbatim by
+//
+//   mcpl/agent.ts       text-tier perception: look()
+//   server/lint.ts      the advisory lint that says why a record won't read
+//   server/routes.ts    GET /residency — the projection other instances poll
+//   tools/residency-plant.ts   descriptor → the verbs that plant it
+//
+// so a browser, a late joiner, a resident who perceives by reading and the
+// instance that planted the marker cannot disagree about who lives here.
+// Same discipline as particles.js and forecast.js: shared facts out of one
+// function, no second opinions.
+//
+// The DATA belongs to the instance, not to this repo: a descriptor is a
+// host system's own identity, kept wherever that host keeps its instance data
+// (residency/README.md), and passed to the planter as a path. What lives here
+// is only what could not live anywhere else — the meaning a world gives it.
+//
+// NOTHING IN A RESIDENCY RECORD IS A CREDENTIAL OR AN ADDRESS. The bag is
+// public, permanent, replayed to everyone who ever joins, and forkable — so
+// the model deliberately has no field for a hostname, an IP, a tailnet name,
+// a token, or a person. An instance identifies itself by a name it chose.
+//
+// Unit-tested in tools/residency-test.ts.
+
+/** The roles an ecosystem's members announce themselves in, and how each
+ *  reads in prose. A role outside this list is never erased — it reads
+ *  quoted, the same forward-compatibility the component bag has everywhere
+ *  else — because the vocabulary of a hosting stack is not this world's to
+ *  fix. */
+export const RESIDENT_ROLES = Object.freeze({
+  'coordinator': 'coordinator',
+  planner: 'planner',
+  builder: 'builder',
+  reviewer: 'reviewer',
+  scribe: 'scribe',
+  sentinel: 'sentinel',
+  courier: 'courier',
+  researcher: 'researcher',
+  operator: 'operator',
+});
+
+/** A roster is a marker, not a directory: an instance that fields hundreds of
+ *  ephemeral workers names the standing ones. The cap is well under the 8KB
+ *  the component bag allows, so a record that hits it is a modelling mistake
+ *  rather than a size problem. */
+export const RESIDENCY_MAX_AGENTS = 24;
+
+/** The one asset every checkout of the library has (every test tool spawns
+ *  it). A marker whose declared asset can't be a library path falls back
+ *  here rather than failing to plant: a visible wrong box beats an invisible
+ *  right one, and the note says which happened. */
+export const RESIDENCY_MARKER_FALLBACK = 'eidoverse/assets/models/crate_large_red.glb';
+
+const LIMITS = { instance: 64, system: 64, name: 64, about: 200, lore: 400, id: 96 };
+
+const text = (v, max) => (typeof v === 'string' ? v.trim().slice(0, max) : '');
+
+/** A key that only exists when it has content: an absent field and an empty
+ *  one are the same thing in a record, and storing `""` would make a reader
+ *  believe someone wrote it down. */
+const some = (key, value) => (value ? { [key]: value } : {});
+
+/** A library path, or null. Same shape rule the sequencer's resolveLibFile
+ *  enforces (no ascent, .glb/.vrm), applied here so a descriptor is judged
+ *  the same way on a machine with no library checked out at all. */
+function markerLib(lib) {
+  const s = typeof lib === 'string' ? lib.trim() : '';
+  if (!s || s.includes('..') || s.startsWith('/') || !/\.(glb|vrm)$/i.test(s)) return null;
+  return s;
+}
+
+/** The display id an identity WEARS in a world, derived from its durable one:
+ *  `agent:harbor.wright@example` → `harbor.wright`. Bodies join under short
+ *  names; rosters are written with durable ones; this is the seam between
+ *  them, and it is exported because the trace matcher and the planter must
+ *  agree about it exactly. An explicit `as` on the roster entry always wins —
+ *  derivation is a default, never an override. */
+export function wornName(id) {
+  return String(id ?? '').replace(/^[a-z]+:/i, '').split('@')[0].trim().toLowerCase();
+}
+
+/** How a role reads. Unknown roles stay legible rather than disappearing. */
+export const roleReads = (role) => (typeof role === 'string' && Object.hasOwn(RESIDENT_ROLES, role)
+  ? RESIDENT_ROLES[role] : role ? `"${role}"` : 'unspecified role');
+
+/** Epoch ms from either an epoch or an ISO date. `Date.parse` is a pure
+ *  function of its argument — this module still never asks what time it is. */
+function sinceMs(v, notes) {
+  if (v == null) return null;
+  if (typeof v === 'number' && Number.isFinite(v)) return Math.floor(v);
+  if (typeof v === 'string') {
+    const t = Date.parse(v);
+    if (Number.isFinite(t)) return t;
+  }
+  notes.push('since must be epoch ms or an ISO date — dropped');
+  return null;
+}
+
+/** A role outside the vocabulary is kept and noted, never corrected: the
+ *  vocabulary of a hosting stack is not this world's to fix. */
+function noteRole(role, who, notes) {
+  if (role && !Object.hasOwn(RESIDENT_ROLES, role)) {
+    notes.push(`role "${role}" on ${who} is not one this world has a phrase for (${Object.keys(RESIDENT_ROLES).join('/')}) — it reads quoted`);
+  }
+  return role;
+}
+
+/**
+ * Normalize an authored `residency` bag into the record every consumer reads.
+ *
+ * Returns `{ok: true, residency, notes}` — `notes` naming everything that was
+ * clamped, dropped or defaulted — or `{ok: false, why}` when the bag names no
+ * instance or no mind. As with particles, a failure here is never a fold
+ * failure: the component still persists and still reads as *someone's* marker
+ * (`describeResidency`). It only means the record is not machine-usable.
+ *
+ * @param {unknown} data
+ * @param {{entityId?: string}} [opts]
+ */
+export function normalizeResidency(data, { entityId = '' } = {}) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { ok: false, why: 'residency data must be an object {instance, system, mind, agents?, …}' };
+  }
+  const d = /** @type {Record<string, any>} */ (data);
+  const instance = text(d.instance, LIMITS.instance);
+  if (!instance) return { ok: false, why: 'residency needs an `instance` — the name the hosting system calls itself (never a hostname or an address)' };
+  const mindName = text(d.mind?.name, LIMITS.name);
+  if (!mindName) return { ok: false, why: 'residency needs `mind.name` — the mind that runs the instance; a system with nobody home is not a residency' };
+
+  const notes = [];
+  const seen = new Set();
+  const agents = [];
+  for (const raw of Array.isArray(d.agents) ? d.agents : []) {
+    if (agents.length >= RESIDENCY_MAX_AGENTS) {
+      notes.push(`roster truncated to ${RESIDENCY_MAX_AGENTS} — a marker names an instance's standing agents, not every worker it ever spawns`);
+      break;
+    }
+    const id = text(typeof raw === 'string' ? raw : raw?.id, LIMITS.id);
+    if (!id) { notes.push('an agent entry with no id was dropped'); continue; }
+    const wears = text(raw?.as, LIMITS.id).toLowerCase() || wornName(id);
+    if (seen.has(wears)) { notes.push(`two agents wear "${wears}" here — the later one was dropped`); continue; }
+    seen.add(wears);
+    const role = noteRole(text(raw?.role, 32), id, notes);
+    agents.push({ id, wears, ...some('role', role), ...some('about', text(raw?.about, LIMITS.about)) });
+  }
+
+  const mindRole = noteRole(text(d.mind?.role, 32), mindName, notes);
+  const lib = markerLib(d.marker?.lib);
+  if (d.marker?.lib != null && !lib) {
+    notes.push(`marker.lib ${JSON.stringify(d.marker.lib)} is not a library path (.glb/.vrm, no ascent) — using ${RESIDENCY_MARKER_FALLBACK}`);
+  }
+  const scale = Number(d.marker?.scale);
+  const yaw = Number(d.marker?.yaw);
+
+  const mindId = text(d.mind?.id, LIMITS.id);
+  const residency = {
+    instance,
+    ...some('system', text(d.system, LIMITS.system)),
+    mind: {
+      name: mindName,
+      ...some('role', mindRole),
+      ...some('about', text(d.mind?.about, LIMITS.about)),
+      wears: text(d.mind?.as, LIMITS.id).toLowerCase() || wornName(mindId || mindName),
+      ...some('id', mindId),
+    },
+    agents,
+    ...some('lore', text(d.lore, LIMITS.lore)),
+    marker: {
+      lib: lib ?? RESIDENCY_MARKER_FALLBACK,
+      ...(Number.isFinite(scale) && scale > 0 ? { scale: Math.min(8, scale) } : {}),
+      ...(Number.isFinite(yaw) ? { yaw } : {}),
+    },
+  };
+  const since = sinceMs(d.since, notes);
+  if (since != null) residency.since = since;
+  // A durable id for the record itself, so two markers planted by the same
+  // instance in two worlds are recognizably the same residency.
+  residency.key = `${instance}:${residency.mind.wears}`;
+  if (entityId) residency.entity = entityId;
+  return { ok: true, residency, notes };
+}
+
+// ---- perception ------------------------------------------------------------
+
+/**
+ * How a residency reads in prose, from the RAW component bag.
+ *
+ * Deliberately tolerant where `normalizeResidency` is strict: a record this
+ * world cannot fully parse still says whose marker it is, for the same reason
+ * an unknown particle preset still reads as an emitter. Names the semantic
+ * thing on the entity that owns it — never a bare `components: residency`.
+ */
+export function describeResidency(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return 'a residency marker (malformed record)';
+  const d = /** @type {Record<string, any>} */ (data);
+  const mind = text(d.mind?.name, LIMITS.name);
+  const instance = text(d.instance, LIMITS.instance) || 'an unnamed system';
+  const system = text(d.system, LIMITS.system);
+  const who = mind ? `${mind} (${roleReads(d.mind?.role)})` : 'nobody named';
+  const roster = (Array.isArray(d.agents) ? d.agents : [])
+    .map((a) => text(typeof a === 'string' ? a : a?.id, LIMITS.id))
+    .filter(Boolean);
+  const bits = [`instance ${instance}${system ? ` (${system})` : ''}`, `mind ${who}`];
+  bits.push(roster.length
+    ? `${roster.length} agent${roster.length === 1 ? '' : 's'}: ${roster.map(wornName).join(', ')}`
+    : 'no agents declared');
+  const since = sinceMs(d.since, []);
+  // The DATE, never "N days ago": this module is not allowed to know what
+  // time it is, and a perception line that silently ages is not replayable.
+  if (since != null) bits.push(`resident since ${new Date(since).toISOString().slice(0, 10)}`);
+  const lore = text(d.lore, LIMITS.lore);
+  // The claim is deliberately thin. A residency record asserts that a system
+  // says it lives here — not that anything of it is RUNNING here, not that
+  // its agents are present, and not that any of them ever acted. The log
+  // answers all three (traceResidents), and a resident who reads "5 agents"
+  // as "5 agents are here" would act on it.
+  return `residency: ${bits.join('; ')} — a declaration, not a presence${lore ? ` · “${lore.length > 120 ? `${lore.slice(0, 119)}…` : lore}”` : ''}`;
+}
+
+/** begin / change / end, from the two component states around a live `comp`.
+ *  `null` on either side means there was no record. Returns null when nothing
+ *  perceptible happened (an identical re-author). Mirrors particles.js
+ *  exactly — one shape for every "a component changed near you" narration. */
+export function residencyTransition(prev, next) {
+  const p = prev && typeof prev === 'object' ? prev : null;
+  const n = next && typeof next === 'object' ? next : null;
+  if (!p && !n) return null;
+  const nameOf = (x) => text(x?.mind?.name, LIMITS.name) || text(x?.instance, LIMITS.instance) || 'a system';
+  if (!p) return { kind: 'begin', who: nameOf(n) };
+  if (!n) return { kind: 'end', who: nameOf(p) };
+  if (JSON.stringify(p) === JSON.stringify(n)) return null;
+  return { kind: 'change', who: nameOf(n), from: nameOf(p) };
+}
+
+/** The one ambient line a live attach/replace/remove produces. `who` is the
+ *  line's subject; the caller supplies the tags and the radius gate. */
+export function residencyLine(actor, entityId, transition) {
+  if (!transition) return null;
+  if (transition.kind === 'begin') return `${actor} records ${transition.who}'s residency on [${entityId}] (residency)`;
+  if (transition.kind === 'end') return `${actor} withdraws ${transition.who}'s residency from [${entityId}] (residency)`;
+  return transition.from && transition.from !== transition.who
+    ? `${actor} rededicates [${entityId}]: ${transition.from} → ${transition.who} (residency)`
+    : `${actor} revises ${transition.who}'s residency record on [${entityId}] (residency)`;
+}
+
+// ---- traces ----------------------------------------------------------------
+
+/**
+ * What the LOG says about the roster: per member, what they actually did here.
+ *
+ * This is the evidence half of the model and it is kept scrupulously apart
+ * from the claim half. Anyone with builder rights can write a residency
+ * record naming anyone; nobody can write someone else's acts into the log,
+ * because the sequencer stamps `actor` from the connection. So the record
+ * says who an instance CLAIMS to field and this says who was here — and a
+ * member with `acts: 0` is reported as declared-but-unseen rather than
+ * quietly dropped, which is the only way the difference stays visible.
+ *
+ * Pure over the entries handed in: the caller decides how much history to
+ * read (a page, a window, the whole file), and the result says so.
+ *
+ * @param {{actor?: string, verb?: string, ts?: number, seq?: number}[]} entries
+ * @param {unknown} data raw residency bag
+ * @returns {{id: string, wears: string, role?: string, mind: boolean,
+ *            acts: number, verbs: Record<string, number>, first: number|null,
+ *            last: number|null, lastSeq: number|null}[]}
+ */
+export function traceResidents(entries, data) {
+  const r = normalizeResidency(data);
+  if (!r.ok) return [];
+  const roster = [
+    { id: r.residency.mind.id ?? r.residency.mind.name, wears: r.residency.mind.wears,
+      role: r.residency.mind.role, mind: true },
+    ...r.residency.agents.map((a) => ({ id: a.id, wears: a.wears, role: a.role, mind: false })),
+  ];
+  const byWorn = new Map();
+  const traces = roster.map((m) => {
+    const t = { ...m, acts: 0, verbs: /** @type {Record<string, number>} */ ({}), first: null, last: null, lastSeq: null };
+    if (m.role == null) delete t.role;
+    // Two rosters wearing one name is already a normalization note; here the
+    // first claimant simply keeps the acts rather than both counting them.
+    if (!byWorn.has(m.wears)) byWorn.set(m.wears, t);
+    return t;
+  });
+  for (const e of Array.isArray(entries) ? entries : []) {
+    const actor = String(e?.actor ?? '').toLowerCase();
+    if (!actor) continue;
+    const t = byWorn.get(actor);
+    if (!t) continue;
+    const verb = String(e?.verb ?? 'unknown');
+    t.acts++;
+    t.verbs[verb] = (t.verbs[verb] ?? 0) + 1;
+    const ts = typeof e?.ts === 'number' ? e.ts : null;
+    if (ts != null) {
+      if (t.first == null || ts < t.first) t.first = ts;
+      if (t.last == null || ts > t.last) t.last = ts;
+    }
+    if (typeof e?.seq === 'number' && (t.lastSeq == null || e.seq > t.lastSeq)) t.lastSeq = e.seq;
+  }
+  return traces;
+}
+
+/** The traces, in prose — one line per member, busiest first, the mind always
+ *  leading. Relative ages need a clock, so the caller passes `now`; without
+ *  one the lines carry dates, which is what a replay wants anyway. */
+export function describeTraces(traces, { now = null } = {}) {
+  const ago = (ts) => {
+    if (ts == null) return '';
+    if (now == null) return ` (last ${new Date(ts).toISOString().replace('T', ' ').slice(0, 16)}Z)`;
+    const s = Math.max(0, Math.round((now - ts) / 1000));
+    const rel = s < 90 ? `${s}s` : s < 5400 ? `${Math.round(s / 60)}m` : s < 172800 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 86400)}d`;
+    return ` (last acted ${rel} ago)`;
+  };
+  return [...(traces ?? [])]
+    .sort((a, b) => (b.mind ? 1 : 0) - (a.mind ? 1 : 0) || b.acts - a.acts || a.wears.localeCompare(b.wears))
+    .map((t) => {
+      const head = `${t.wears}${t.role ? ` — ${roleReads(t.role)}` : ''}${t.mind ? ' (the mind)' : ''}`;
+      if (!t.acts) return `${head}: declared, but has done nothing in the history read`;
+      const verbs = Object.entries(t.verbs).sort((a, b) => b[1] - a[1]).slice(0, 6)
+        .map(([v, n]) => `${v} ×${n}`).join(', ');
+      return `${head}: ${t.acts} act${t.acts === 1 ? '' : 's'} — ${verbs}${ago(t.last)}`;
+    });
+}
+
+// ---- projection ------------------------------------------------------------
+
+/**
+ * The verbs that plant a residency — descriptor in, ordinary log entries out.
+ *
+ * One projection, so the planting tool, a behavior script, and whatever an
+ * instance writes for itself all put the SAME marker in the world: a spawn of
+ * the declared asset, the record on it, and (by default) a `lock`, because a
+ * marker that can be punted across the map is a marker that stops meaning
+ * where a system lives. Emitting these is the caller's job; deciding what
+ * they are is this module's.
+ *
+ * A planted marker is LOCKED by default, and the lock refuses a same-id
+ * `spawn` — for everyone, including whoever locked it. That is the accident
+ * guard doing its job, not an obstacle: re-authoring the record on a marker
+ * that already stands is `skipSpawn: true`, which emits only the comps (a
+ * locked entity accepts every component that doesn't relocate it).
+ *
+ * @param {unknown} descriptor
+ * @param {{id?: string, pos?: number[], yaw?: number, lock?: boolean,
+ *          skipSpawn?: boolean}} [opts]
+ * @returns {{ok: true, id: string, entries: {verb: string, args: Record<string, unknown>}[], notes: string[]}
+ *          | {ok: false, why: string}}
+ */
+export function residencyEntries(descriptor, { id = null, pos = [0, 0, 0], yaw = null, lock = true, skipSpawn = false } = {}) {
+  const r = normalizeResidency(descriptor);
+  if (!r.ok) return r;
+  const res = r.residency;
+  // Deterministic by default: re-planting the same instance's marker in the
+  // same world re-authors the ONE entity rather than littering copies, which
+  // is what makes this safe to run from a cron.
+  const slug = res.instance.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase();
+  const eid = id ?? `residency-${slug || 'marker'}`;
+  const marker = res.marker;
+  const { entity: _e, marker: _m, ...record } = res;
+  const entries = [];
+  if (!skipSpawn) {
+    entries.push({ verb: 'spawn', args: { id: eid, lib: marker.lib, pos, yaw: yaw ?? marker.yaw ?? 0, ...(marker.scale != null ? { scale: marker.scale } : {}) } });
+  }
+  entries.push({ verb: 'comp', args: { id: eid, type: 'residency', data: record } });
+  if (lock) entries.push({ verb: 'comp', args: { id: eid, type: 'lock', data: true } });
+  return { ok: true, id: eid, entries, notes: r.notes };
+}

--- a/tools/residency-plant.ts
+++ b/tools/residency-plant.ts
@@ -1,0 +1,122 @@
+// Plant a residency marker — a hosting system saying, in-world, where it
+// lives — and read back who a world says lives in it.
+//
+//   bun tools/residency-plant.ts residency/example.json --dry-run
+//   WORLD_URL=ws://localhost:8940/ws JOIN_TOKEN=… \
+//     bun tools/residency-plant.ts <descriptor>.json --world commons --pos 4,0,-6
+//   WORLD_URL=… bun tools/residency-plant.ts --report --world commons
+//
+// The DESCRIPTOR is the host system's own instance data and lives wherever
+// that host keeps it (`$RESIDENCY_DESCRIPTOR`, or a path — residency/README.md
+// on why it does not belong in this repo). The VERBS it becomes are
+// shared/residency.js's `residencyEntries`, so this tool decides nothing about
+// what a residency IS — it carries entries to a door and reads the projection
+// back. Ordinary builder rank: a spawn, a comp, and a lock.
+//
+// Re-running is the normal case (plant it from a schedule and the record stays
+// current): if the marker already stands, the spawn is dropped and only the
+// record is re-authored — which is also the only thing that WOULD work, since
+// the lock refuses a same-id spawn for everyone including its author.
+
+import { existsSync, readFileSync } from "node:fs";
+import {
+  normalizeResidency, residencyEntries, describeResidency, describeTraces,
+} from "../shared/residency.js";
+
+const argv = process.argv.slice(2);
+const flag = (name: string, fallback: string | null = null) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[i + 1] : fallback;
+};
+const has = (name: string) => argv.includes(`--${name}`);
+
+const URL_ = process.env.WORLD_URL ?? "ws://localhost:8940/ws";
+const TOKEN = process.env.JOIN_TOKEN ?? "";
+const WORLD = flag("world") ?? "commons";
+const ME = flag("as") ?? process.env.RESIDENCY_ID ?? "residency-planter";
+/** The projection rides the same host as the door: ws→http, minus /ws. */
+const httpBase = URL_.replace(/^ws/, "http").replace(/\/ws$/, "");
+
+/** The read side: what this world says about everyone who lives in it — the
+ *  claim and the log's own evidence for it, in prose. */
+async function report(): Promise<number> {
+  const where = `${httpBase}/residency?world=${encodeURIComponent(WORLD)}`;
+  // A readout that throws must not take the run down with it — this runs from
+  // a socket callback, where an unhandled rejection is a dead process rather
+  // than a failed read.
+  const body = await fetch(where).then(async (res) => {
+    if (!res.ok) throw new Error(`${res.status}`);
+    return res.json() as Promise<any>;
+  }).catch((err) => { console.error(`✗ ${where} — ${err.message}`); return null; });
+  if (!body) return 1;
+  if (!body.residencies?.length) { console.log(`\nnobody has recorded a residency in "${WORLD}"\n`); return 0; }
+  const now = Date.now();
+  for (const r of body.residencies) {
+    console.log(`\n[${r.entity}] ${r.record ? describeResidency(r.record) : `unreadable record — ${r.why}`}`);
+    for (const line of describeTraces(r.traces ?? [], { now })) console.log(`    ${line}`);
+  }
+  console.log(`\n(evidence read from ${body.history?.entries ?? 0} log entries)\n`);
+  return 0;
+}
+
+const file = argv.find((a) => !a.startsWith("--") && a.endsWith(".json")) ?? process.env.RESIDENCY_DESCRIPTOR;
+// `--report` with no descriptor to plant is the read-only mode
+if (has("report") && !file) process.exit(await report());
+if (!file || !existsSync(file)) {
+  console.error("usage: bun tools/residency-plant.ts <descriptor.json> [--world W] [--pos x,y,z] [--id E] [--no-lock] [--dry-run]");
+  console.error("       bun tools/residency-plant.ts --report [--world W]        # read back who lives there");
+  console.error("       the descriptor path may also come from $RESIDENCY_DESCRIPTOR");
+  process.exit(2);
+}
+
+const descriptor = JSON.parse(readFileSync(file, "utf8"));
+const check = normalizeResidency(descriptor);
+if (!check.ok) {
+  console.error(`✗ ${file}: ${check.why}`);
+  process.exit(1);
+}
+for (const n of check.notes) console.warn(`  ! ${n}`);
+
+const pos = (flag("pos") ?? "0,0,0").split(",").map(Number);
+if (pos.length !== 3 || pos.some((n) => !Number.isFinite(n))) {
+  console.error("--pos wants x,y,z");
+  process.exit(2);
+}
+const plan = residencyEntries(descriptor, {
+  id: flag("id"), pos, lock: !has("no-lock"),
+  ...(flag("yaw") != null ? { yaw: Number(flag("yaw")) } : {}),
+});
+if (!plan.ok) { console.error(`✗ ${plan.why}`); process.exit(1); }
+
+const record = plan.entries.find((e) => e.verb === "comp" && (e.args as { type?: string }).type === "residency")!;
+console.log(`\n${describeResidency((record.args as { data: unknown }).data)}\n`);
+
+if (has("dry-run")) {
+  for (const e of plan.entries) console.log(`  ${e.verb} ${JSON.stringify(e.args)}`);
+  console.log(`\n${plan.entries.length} verbs, ${JSON.stringify(record.args).length} bytes of component (8192 cap) — nothing was sent\n`);
+  process.exit(0);
+}
+
+const ws = new WebSocket(`${URL_}?token=${encodeURIComponent(TOKEN)}`);
+const send = (o: unknown) => ws.send(JSON.stringify(o));
+let refused = 0;
+
+ws.onopen = () => send({ type: "join", world: WORLD, id: ME, token: TOKEN });
+ws.onmessage = async (ev: MessageEvent) => {
+  const m = JSON.parse(String(ev.data));
+  if (m.type === "error") { refused++; console.error(`  refused: ${m.error}`); return; }
+  if (m.type !== "snapshot") return;
+  const standing = m.state?.entities?.[plan.id];
+  const entries = standing ? plan.entries.filter((e) => e.verb !== "spawn") : plan.entries;
+  if (standing) console.log(`  [${plan.id}] already stands — re-authoring its record only`);
+  for (const e of entries) send({ type: "verb", verb: e.verb, args: e.args });
+  console.log(`\n✓ planted [${plan.id}] in "${WORLD}" via ${URL_} (${entries.length} verbs as ${ME})`);
+  // Give the sequencer a moment to answer with any refusal, then read the
+  // world's own account of it back — a plant nobody can see is not a plant.
+  setTimeout(async () => {
+    ws.close();
+    const reportStatus = has("report") ? await report() : 0;
+    process.exit(refused ? 1 : reportStatus);
+  }, 1200);
+};
+ws.onerror = () => { console.error(`✗ cannot reach ${URL_}`); process.exit(1); };

--- a/tools/residency-test.ts
+++ b/tools/residency-test.ts
@@ -1,0 +1,287 @@
+// The `residency` component's meaning, projection and evidence — serverless
+// for three legs, and against a real sequencer for the fourth.
+//
+//   bun tools/residency-test.ts
+//
+// Four legs, matching what a residency has to be worth:
+//
+//   1. DECLARATION — what a record may say, what it may not, and what fails
+//      LEGIBLY (an unknown role still reads; a marker path that isn't a
+//      library path falls back with a note; a record with nobody home is
+//      refused outright).
+//   2. PROJECTION  — descriptor → the verbs that plant it, deterministic and
+//      re-plantable, under the component-bag cap.
+//   3. EVIDENCE    — the claim/trace split: a roster is what a system SAYS,
+//      the log is what its bodies DID, and a declared-but-absent agent stays
+//      visible as exactly that.
+//   4. IN THE WORLD — a real sequencer: look()-shaped perception through the
+//      mcpl agent, the advisory lint in the flight recorder, and the
+//      /residency projection another instance polls.
+//
+// Every check here fails against the old behavior by construction: none of
+// this existed.
+
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  RESIDENT_ROLES, RESIDENCY_MAX_AGENTS, RESIDENCY_MARKER_FALLBACK,
+  normalizeResidency, describeResidency, residencyEntries, residencyTransition,
+  residencyLine, traceResidents, describeTraces, wornName, roleReads,
+} from "../shared/residency.js";
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: unknown, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const HARBOR = {
+  instance: "example:harbor", system: "ExampleHost", since: "2026-09-04",
+  mind: { name: "Harbor", id: "agent:harbor@example", role: "coordinator" },
+  agents: [
+    { id: "agent:harbor.wright@example", role: "builder" },
+    { id: "agent:harbor.scribe@example", role: "scribe" },
+  ],
+  lore: "one instance, one mind, its standing agents — none of them a person",
+  marker: { lib: "eidoverse/assets/models/crate_large_red.glb" },
+};
+
+// ---- 1. declaration --------------------------------------------------------
+console.log("\ndeclaration — what a record may say, and what fails legibly\n");
+{
+  const r = normalizeResidency(HARBOR, { entityId: "marker1" });
+  check("a well-formed record normalizes clean", r.ok === true && r.notes.length === 0, r.ok ? "" : r.why);
+  const rec = (r as { residency: any }).residency;
+  check("the mind's worn name is derived from its durable id", rec.mind.wears === "harbor");
+  check("...and so is each agent's", rec.agents[0].wears === "harbor.wright");
+  check("an ISO `since` becomes epoch ms", typeof rec.since === "number" && new Date(rec.since).toISOString().startsWith("2026-09-04"));
+  check("the record carries a key stable across worlds", rec.key === "example:harbor:harbor");
+
+  check("a record with no instance is refused", normalizeResidency({ mind: { name: "X" } }).ok === false);
+  check("a record with nobody home is refused", normalizeResidency({ instance: "example:x" }).ok === false);
+  check("a non-object bag fails legibly", normalizeResidency(42).ok === false);
+
+  const odd = normalizeResidency({ ...HARBOR, mind: { name: "Harbor", role: "hierophant" } });
+  check("an unknown role is kept, with a note", (odd as any).residency.mind.role === "hierophant"
+    && (odd as any).notes.some((n: string) => n.includes("hierophant")));
+  check("...and still reads in prose", roleReads("hierophant") === '"hierophant"');
+  check("known roles read as phrases", roleReads("coordinator") === RESIDENT_ROLES["coordinator"]);
+
+  const escaped = normalizeResidency({ ...HARBOR, marker: { lib: "../../etc/passwd" } });
+  check("a marker path that isn't a library path falls back, with a note",
+    (escaped as any).residency.marker.lib === RESIDENCY_MARKER_FALLBACK
+    && (escaped as any).notes.some((n: string) => n.includes("marker.lib")));
+
+  const dup = normalizeResidency({ ...HARBOR, agents: [{ id: "agent:a@x" }, { id: "agent:a@y" }] });
+  check("two agents wearing one name is a note, not two rows",
+    (dup as any).residency.agents.length === 1 && (dup as any).notes.some((n: string) => n.includes("wear")));
+
+  const many = normalizeResidency({ ...HARBOR, agents: Array.from({ length: 40 }, (_, i) => ({ id: `agent:w${i}@x` })) });
+  check(`a roster is capped at ${RESIDENCY_MAX_AGENTS}, with a note`,
+    (many as any).residency.agents.length === RESIDENCY_MAX_AGENTS && (many as any).notes.some((n: string) => n.includes("truncated")));
+
+  const long = normalizeResidency({ ...HARBOR, lore: "x".repeat(4000) });
+  check("lore is clamped rather than allowed to eat the bag", (long as any).residency.lore.length === 400);
+
+  // The privacy rule the model exists to make structural: there is nowhere to
+  // put an address, so an authored one simply is not in the record.
+  const sneaky = normalizeResidency({ ...HARBOR, host: "some-host.example", url: "http://10.0.0.4:5555", token: "sekrit" });
+  const flat = JSON.stringify((sneaky as any).residency);
+  check("a record has nowhere to carry a host, a URL or a token",
+    !flat.includes("some-host") && !flat.includes("10.0.0.4") && !flat.includes("sekrit"));
+
+  check("wornName strips the scheme and the home node", wornName("agent:harbor.wright@example") === "harbor.wright");
+}
+
+// ---- 2. projection ---------------------------------------------------------
+console.log("\nprojection — descriptor to verbs\n");
+{
+  const plan = residencyEntries(HARBOR, { pos: [4, 0, -6] });
+  check("a plan is a spawn, a record and a lock", plan.ok === true
+    && (plan as any).entries.map((e: any) => e.verb).join(",") === "spawn,comp,comp");
+  const p = plan as any;
+  check("the marker id is derived from the instance, so re-planting re-authors one entity",
+    p.id === "residency-example-harbor" && residencyEntries(HARBOR).id === p.id);
+  check("the record rides a `residency` comp on that entity",
+    p.entries[1].args.type === "residency" && p.entries[1].args.id === p.id);
+  check("the marker is nailed down by default", p.entries[2].args.type === "lock" && p.entries[2].args.data === true);
+  check("--no-lock leaves it loose", residencyEntries(HARBOR, { lock: false }).entries.length === 2);
+  check("the record fits the component bag with room to spare",
+    JSON.stringify(p.entries[1].args).length < 8192);
+  check("the planted record carries no marker asset — that rode the spawn",
+    p.entries[1].args.data.marker === undefined);
+  // the lock refuses a same-id spawn, so re-planting must be comps only
+  const again = residencyEntries(HARBOR, { skipSpawn: true });
+  check("re-planting a standing marker emits no spawn for its lock to refuse",
+    (again as any).entries.every((e: any) => e.verb !== "spawn"));
+  check("a record that won't normalize projects nothing", residencyEntries({ instance: "x" }).ok === false);
+}
+
+// ---- 3. evidence -----------------------------------------------------------
+console.log("\nevidence — the claim and the log, kept apart\n");
+{
+  const log = [
+    { seq: 10, ts: 1_000, actor: "harbor", verb: "say" },
+    { seq: 11, ts: 2_000, actor: "harbor.wright", verb: "spawn" },
+    { seq: 12, ts: 3_000, actor: "harbor.wright", verb: "comp" },
+    { seq: 13, ts: 4_000, actor: "harbor.wright", verb: "spawn" },
+    { seq: 14, ts: 5_000, actor: "somebody-else", verb: "spawn" },
+  ];
+  const traces = traceResidents(log, HARBOR);
+  const byName = Object.fromEntries(traces.map((t) => [t.wears, t]));
+  check("the mind's acts are counted", byName.harbor.acts === 1 && byName.harbor.verbs.say === 1);
+  check("an agent's acts are counted per verb", byName["harbor.wright"].acts === 3 && byName["harbor.wright"].verbs.spawn === 2);
+  check("first and last are the entries' own timestamps",
+    byName["harbor.wright"].first === 2_000 && byName["harbor.wright"].last === 4_000 && byName["harbor.wright"].lastSeq === 13);
+  check("a declared agent that never acted is reported, not dropped",
+    byName["harbor.scribe"].acts === 0 && traces.length === 3);
+  check("a stranger's acts attach to nobody", !traces.some((t) => t.wears === "somebody-else"));
+
+  const prose = describeTraces(traces, { now: 6_000 });
+  check("the mind leads the prose", prose[0].startsWith("harbor "), prose[0]);
+  check("an unseen agent says so in words", prose.some((l) => l.includes("declared, but has done nothing")));
+  check("relative ages need a clock the caller passes", prose[0].includes("ago")
+    && describeTraces(traces)[0].includes("last 1970"));
+
+  // an `as` on the roster is how a body that joins under some other name is
+  // still recognizable as this instance's
+  const aliased = traceResidents([{ seq: 1, ts: 1, actor: "vw-7", verb: "say" }],
+    { ...HARBOR, agents: [{ id: "agent:harbor.wright@example", as: "vw-7" }] });
+  check("an explicit `as` binds a body joining under another name",
+    aliased.find((t) => t.wears === "vw-7")!.acts === 1);
+  check("a record that won't normalize traces nothing", traceResidents([], { instance: "x" }).length === 0);
+}
+
+// ---- 3b. perception, serverless -------------------------------------------
+console.log("\nperception — what a reader is told, and what is never claimed\n");
+{
+  const line = describeResidency(normalizeResidency(HARBOR).residency);
+  check("the line names the instance, the mind and the roster size",
+    line.includes("example:harbor") && line.includes("Harbor") && line.includes("2 agents"), line);
+  check("...and the residency date, not an age that would silently drift", line.includes("resident since 2026-09-04"));
+  check("...and says it is a declaration rather than a presence", line.includes("not a presence"));
+  check("...and claims nothing about anyone being here",
+    !/\b(present|online|connected|running|here now)\b/i.test(line), line);
+  check("a malformed record still reads as somebody's marker",
+    describeResidency({ instance: "example:x" }).includes("nobody named"));
+  check("a non-object bag reads as malformed", describeResidency(7).includes("malformed"));
+
+  const begin = residencyLine("antra", "m1", residencyTransition(null, HARBOR));
+  check("a record beginning narrates once, naming the mind", begin!.includes("records Harbor's residency"));
+  const end = residencyLine("antra", "m1", residencyTransition(HARBOR, null));
+  check("a withdrawal narrates as a withdrawal", end!.includes("withdraws"));
+  const swap = residencyLine("antra", "m1", residencyTransition(HARBOR, { ...HARBOR, mind: { name: "Hesper" } }));
+  check("a rededication names both minds", swap!.includes("Harbor") && swap!.includes("Hesper"));
+  const tweak = residencyLine("antra", "m1", residencyTransition(HARBOR, { ...HARBOR, lore: "changed" }));
+  check("an ordinary revision narrates as a revision", tweak!.includes("revises"));
+  check("an identical re-author narrates nothing", residencyTransition(HARBOR, { ...HARBOR }) === null);
+}
+
+// ---- 4. in the world -------------------------------------------------------
+console.log("\nin the world — a real sequencer, its lint, and the projection\n");
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); }
+    catch { return cand; }               // nothing answered: free
+  }
+  throw new Error("no free port found in 20 tries");
+}
+const PORT = await freePort();
+const WORLD = `residency-${Date.now().toString(36)}`;
+// process.execPath, not "bun": on Windows the PATH "bun" is an npm shim whose
+// pid dies the moment it has launched the real binary, orphaning the server.
+const server = spawn(process.execPath, [join(import.meta.dir, "..", "server", "server.ts")], {
+  env: { ...process.env, PORT: String(PORT), WORLDS_DIR: mkdtempSync(join(tmpdir(), "ew-residency-")), JOIN_TOKEN: "" },
+  stdio: "ignore",
+});
+process.on("exit", () => { try { server.kill(); } catch { /* already gone */ } });
+
+let up = false;
+for (let i = 0; i < 40; i++) {
+  try { await fetch(`http://127.0.0.1:${PORT}/avatars`); up = true; break; }
+  catch { await sleep(250); }
+}
+check("child sequencer came up on a verified-free port", up, `:${PORT}`);
+if (!up) { console.log("\n  refusing to test a server that never started\n"); process.exit(1); }
+
+// One body, wearing the roster name a wright wears, doing the planting — so
+// the traces this world reports are the acts this test actually performed.
+const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+const inbox: any[] = [];
+await new Promise<void>((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error("join timeout")), 8000);
+  ws.onopen = () => ws.send(JSON.stringify({ type: "join", world: WORLD, id: "harbor.wright" }));
+  ws.onmessage = (ev) => {
+    const m = JSON.parse(String(ev.data));
+    inbox.push(m);
+    if (m.type === "snapshot") { clearTimeout(t); resolve(); }
+  };
+  ws.onerror = () => { clearTimeout(t); reject(new Error("socket error")); };
+});
+const plan = residencyEntries(HARBOR, { pos: [2, 0, 3] }) as any;
+for (const e of plan.entries) ws.send(JSON.stringify({ type: "verb", verb: e.verb, args: e.args }));
+// a record nobody can read, to prove the recorder says so
+ws.send(JSON.stringify({ type: "verb", verb: "spawn", args: { id: "broken-marker", lib: RESIDENCY_MARKER_FALLBACK, pos: [9, 0, 9] } }));
+ws.send(JSON.stringify({ type: "verb", verb: "comp", args: { id: "broken-marker", type: "residency", data: { instance: "example:nobody" } } }));
+await sleep(600);
+
+const res = await fetch(`http://127.0.0.1:${PORT}/residency?world=${WORLD}`);
+const body = await res.json() as any;
+check("GET /residency answers for a live world", res.ok && body.world === WORLD);
+const planted = body.residencies.find((r: any) => r.entity === plan.id);
+check("...naming the instance that planted the marker", planted?.record?.instance === "example:harbor");
+check("...with the roster it declared", planted?.record?.agents?.length === 2);
+check("...and where the marker stands", Array.isArray(planted?.pos) && planted.pos[0] === 2);
+const wright = planted?.traces?.find((t: any) => t.wears === "harbor.wright");
+check("the log's evidence rides alongside the claim", wright?.acts >= 3, JSON.stringify(wright?.verbs ?? {}));
+check("...and a declared agent that never acted is still listed",
+  planted?.traces?.find((t: any) => t.wears === "harbor.scribe")?.acts === 0);
+const broken = body.residencies.find((r: any) => r.entity === "broken-marker");
+check("an unreadable record is reported as unreadable, not omitted",
+  broken && broken.record === null && typeof broken.why === "string");
+check("an unknown world is a 404, and never created",
+  (await fetch(`http://127.0.0.1:${PORT}/residency?world=no-such-world`)).status === 404);
+
+// the advisory lint: the author of the broken record has no other way to learn
+const dbg = await new Promise<any>((resolve) => {
+  const onMsg = (ev: MessageEvent) => {
+    const m = JSON.parse(String(ev.data));
+    if (m.type === "debug" && m.reqId === "res-dbg") { ws.removeEventListener("message", onMsg); resolve(m); }
+  };
+  ws.addEventListener("message", onMsg);
+  ws.send(JSON.stringify({ type: "debug", reqId: "res-dbg", kinds: ["residency-lint"], limit: 50 }));
+  setTimeout(() => resolve({ events: [] }), 3000);
+});
+check("the flight recorder says why a record won't read",
+  (dbg.events ?? []).some((e: any) => e.kind === "residency-lint" && String(e.why ?? e.detail?.why ?? "").includes("mind.name")),
+  JSON.stringify(dbg.events ?? []).slice(0, 160));
+
+// perception, through the same agent a resident reads with
+const { WorldAgent } = await import("../mcpl/agent.ts");
+{
+  const ag: any = new WorldAgent({ name: "reader" });
+  ag.applyEntry({ verb: "spawn", args: { id: plan.id, lib: HARBOR.marker.lib, pos: [2, 0, 3] }, ts: 1, seq: 1, actor: "harbor.wright" }, false);
+  ag.applyEntry({ verb: "comp", args: { id: plan.id, type: "residency", data: plan.entries[1].args.data }, ts: 2, seq: 2, actor: "harbor.wright" }, false);
+  const out = ag.look();
+  check("look() names the residency on the entity that carries it",
+    new RegExp(`\\[${plan.id}\\][^\\n]*residency: instance example:harbor`).test(out),
+    out.split("\n").find((l: string) => l.includes(plan.id)));
+  check("...and does not fall back to `components: residency`", !/components:[^\n]*residency/.test(out));
+
+  const events: any[] = [];
+  ag.onEvent = (ev: any) => { if (ev.kind === "world-change") events.push(ev); };
+  ag.applyEntry({ verb: "comp", args: { id: plan.id, type: "residency", data: { ...plan.entries[1].args.data, lore: "revised" } }, ts: 3, seq: 3, actor: "antra" }, true);
+  check("a live revision arrives as one ambient world-change line",
+    events.length === 1 && events[0].text.includes("revises Harbor's residency"), JSON.stringify(events));
+  ag.applyEntry({ verb: "comp", args: { id: plan.id, type: "residency", data: { ...plan.entries[1].args.data, lore: "again" } }, ts: 4, seq: 4, actor: "reader" }, true);
+  check("...and your own authoring is never echoed back at you", events.length === 1);
+}
+
+ws.close();
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/tools/residency-test.ts
+++ b/tools/residency-test.ts
@@ -180,6 +180,23 @@ console.log("\nperception — what a reader is told, and what is never claimed\n
   check("an identical re-author narrates nothing", residencyTransition(HARBOR, { ...HARBOR }) === null);
 }
 
+// Normalized records are inputs to planting and projection too: aliases
+// must survive that second normalization and remain bound to actor evidence.
+{
+  const raw = { ...HARBOR, mind: {...HARBOR.mind, as: "Captain"}, agents: [{id:"agent:worker@example", as:"Dockhand"}] };
+  const once = normalizeResidency(raw).residency;
+  const twice = normalizeResidency(once).residency;
+  check("normalized aliases survive another normalization", twice.mind.wears === "captain" && twice.agents[0].wears === "dockhand");
+  const plan = residencyEntries(raw);
+  const planted = plan.entries.find(e => e.verb === "comp" && e.args.type === "residency").args.data;
+  check("planting preserves aliases in actor traces", traceResidents([{actor:"dockhand",verb:"use",ts:1,seq:1}], planted)[1].acts === 1);
+  for (const since of [1e100, -1e100, Infinity, NaN]) {
+    const r = normalizeResidency({...raw, since});
+    check("out-of-range residency dates are dropped with a note", r.ok && r.residency.since == null && r.notes.some(n=>n.includes("since")));
+    check("invalid authored dates remain perceivable", typeof describeResidency({...raw,since}) === "string");
+  }
+}
+
 // ---- 4. in the world -------------------------------------------------------
 console.log("\nin the world — a real sequencer, its lint, and the projection\n");
 


### PR DESCRIPTION
An actor id is not a resident: a log entry does not describe the standing household declaring that actor. This adds optional `residency` component semantics through the existing shared evaluator lane, with text perception, advisory lint, a public history-window projection, and a planter using ordinary spawn/comp/lock verbs.

Claims and matching actor activity are returned separately. A declaration never establishes current presence or verified affiliation. There are no new verbs, fold changes, runtime dependencies, or host-specific instance data; the worked example is a fictional Harbor household and custom roles remain legible. This complements the arrival briefing discussion in #50.

Closes #163.

Validation: `bun tools/residency-test.ts` (61 passed, including an isolated scratch sequencer and MCPL perception), `bun tools/foldfix-test.ts` (24 passed), and `bun tools/residency-plant.ts residency/example.json --dry-run` (3 verbs, 1830-byte component). Dependencies installed with the frozen lockfile. No running worlds were restarted.
