### PR TITLE
fix: make ground sitting explicit and discoverable

### DIFF
--- a/client/lib/commands/handlers.js
+++ b/client/lib/commands/handlers.js
@@ -347,7 +347,7 @@ register('use', (arg) => {
 });
 
 register('sit', (arg) => {
-  // /sit [thing] — a declared seat nearby wins; otherwise sit on the ground
+  // /sit ground|here explicitly bypasses seats; /sit [thing] keeps seat discovery.
   if (!trySitOn((arg || '').trim() || null)) setPosture('sit');
 });
 

--- a/client/lib/commands/registry.js
+++ b/client/lib/commands/registry.js
@@ -20,7 +20,7 @@ export const COMMANDS = [
   { name: 'name', aliases: ['rename'], help: '/name <new name> — change what the world calls you' },
   { name: 'me', help: 'describe an action — "/me waves"' },
   { name: 'emote', help: '/emote <name> — the emote bar\'s gestures (🎭, or number keys)' },
-  { name: 'sit', help: 'sit down, on a seat if one is near' },
+  { name: 'sit', help: '/sit [thing] — use a nearby seat; /sit ground (or /sit here) sits where you are' },
   { name: 'push', aliases: ['shove'], help: '/push [name] [power] — shove someone within reach (their client decides); /push <thing> works the thing' },
   { name: 'touch', help: '/touch [name] [point] [left|right] — reach out and rest a hand on someone (nearest person, their shoulder, your right hand by default); the hand tracks them until /letgo' },
   { name: 'letgo', aliases: ['release'], help: 'let go — lower your reaching hand (or just one: /letgo left|right)' },

--- a/client/lib/localbody.js
+++ b/client/lib/localbody.js
@@ -142,6 +142,9 @@ function nearestSeat(arg, reach) {
  *  SAY so — the silent ground-sit fallback read as "sitting is broken" to
  *  anyone standing four meters from a swing they could name but not see. */
 export function trySitOn(arg) {
+  // Explicit ground posture must not accidentally match an entity prefix.
+  // Return through the command's existing ground-sit fallback, with no mount.
+  if (typeof arg === 'string' && /^(ground|here)$/i.test(arg.trim())) return false;
   const best = nearestSeat(arg, arg ? Infinity : 3.5);
   if (!best) {
     const far = arg ? null : nearestSeat(null, 30);
@@ -164,7 +167,7 @@ export function updateSeatHint(dt) {
   if (CONFIG.renderer || CONFIG.spectate) return;
   let hint = null;
   if (avatarMounts.has(CONFIG.name)) hint = '<kbd>X</kbd> get up · <kbd>WASD</kbd> hop off';
-  else if (!downed && nearestSeat(null, 3.5)) hint = '<kbd>X</kbd> — sit';
+  else if (!downed && nearestSeat(null, 3.5)) hint = '<kbd>X</kbd> — sit · /sit ground to sit here';
   setAmbientHint(hint);
 }
 

--- a/tools/ground-sit-test.ts
+++ b/tools/ground-sit-test.ts
@@ -1,0 +1,41 @@
+/** bun tools/ground-sit-test.ts — real seat selector, stubbed browser boundaries. */
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+const base = import.meta.dir + '/../client/lib/';
+class Vector3 { x=0; y=0; z=0; set(x:number,y:number,z:number){Object.assign(this,{x,y,z});return this;} }
+const noop = () => {};
+const sent:any[] = [];
+const comps = new Map();
+const myState = { pos:new Vector3(), yaw:0 };
+mock.module(base+'core.js', () => ({ THREE:{Vector3} }));
+mock.module(base+'base.js', () => ({CONFIG:{name:'self'},bus:{on:noop}}));
+mock.module(base+'controller.js', () => ({myState,updateFollowCamera:noop,setPosture:noop,keys:new Set(),setSeatHook:noop}));
+mock.module(base+'world.js', () => ({avatarMounts:new Map(),mountTransform:noop,comps,
+  socketWorldPos:(id:string,_slot:string,v:Vector3)=>v.set(comps.get(id).x,0,0)}));
+mock.module(base+'net.js', () => ({sendVerb:(...args:any[])=>sent.push(args),sendAnim:noop}));
+mock.module(base+'bodysim.js', () => ({makeRagdoll:noop}));
+mock.module(base+'ragdoll.js', () => ({jointPositions:noop}));
+mock.module(base+'bodydrag.js', () => ({initBodyDrag:noop,beingDragged:()=>false,revokeDragged:noop}));
+mock.module(base+'ui.js', () => ({toast:noop,flashHint:noop,setAmbientHint:noop}));
+mock.module(base+'consent.js', () => ({posable:true,pushable:true}));
+mock.module(base+'reachnet.js', () => ({clearMyReach:noop}));
+mock.module(base+'mybody.js', () => ({getMe:()=>null}));
+const {trySitOn} = await import(base+'localbody.js');
+const {COMMANDS} = await import(base+'commands/registry.js');
+// Names that previously hijacked the accidental fallback, even far away.
+comps.set('ground-bench',{x:3,sockets:{seat:{}}});
+comps.set('here-chair',{x:20,sockets:{seat:{}}});
+for(const arg of ['ground','here',' GROUND ','Here']) {
+  assert.equal(trySitOn(arg),false,`${arg} returns to ground posture`);
+  assert.equal(sent.length,0,'explicit ground never emits mount');
+  assert.deepEqual([myState.pos.x,myState.pos.y,myState.pos.z],[0,0,0]);
+}
+assert.equal(trySitOn(null),true,'ordinary sit keeps existing 3.5m discovery');
+assert.deepEqual(sent.pop(),['mount',{id:'self',to:'ground-bench',slot:'seat'}]);
+assert.equal(trySitOn('here-chair'),true,'full entity IDs remain selectable');
+assert.deepEqual(sent.pop(),['mount',{id:'self',to:'here-chair',slot:'seat'}]);
+comps.clear();
+assert.equal(trySitOn(null),false,'no seat keeps ground fallback');
+assert.equal(sent.length,0);
+assert.match(COMMANDS.find((c:any)=>c.name==='sit').help,/\/sit ground/);
+console.log('ground-sit: explicit bypass, conflicting IDs, named/automatic seats and help passed');


### PR DESCRIPTION
Makes `/sit ground` and `/sit here` explicitly bypass socket matching, including when objects have IDs such as `ground-bench`. Autocomplete and the nearby-seat hint expose the option. Automatic seat distance, named-seat reach, and mounted get-up controls retain their existing behavior, following the maintainer clarification on #152.

Fixes #152.

Validation: `bun tools/ground-sit-test.ts` passes explicit ground bypass, conflicting entity IDs, unchanged automatic/named selection, no-seat fallback, and help coverage. `git diff --check` passes.
