### PR TITLE
fix: explain object loading and provide targeted retry

### DIFF
--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -533,7 +533,10 @@ export async function loadGLB(libPath, { tier = 'full' } = {}) {
   loadsInFlight.set(glbKey, (loadsInFlight.get(glbKey) ?? 0) + 1);
   try {
   if (!glbCache.has(glbKey)) {
-    const key = `glb:${short}`;
+    // the tray key is the CACHE key, not the truncated label: two libs whose
+    // names collide in 28 chars — or one lib at two tiers — are distinct loads
+    // and must track separately
+    const key = `glb:${glbKey}`;
     loadTrack(key, short);
     const p = (async () => {
       const work = beginWork(`glb ${short}`);

--- a/client/lib/realize/models.js
+++ b/client/lib/realize/models.js
@@ -32,7 +32,7 @@ import { makeLight, updateLight, disposeLight } from '../lights.js';
 import { entities, entityMeta, comps, avatarMounts, findPart, editHolds } from '../world.js';
 import { state, onWorldChange } from '../state.js';
 import { schedule, cancelOwner } from '../scheduler.js';
-import { planReconcile, bandForDistance, mountsTouching, collisionOwnedElsewhere } from './models_field.js';
+import { planReconcile, bandForDistance, mountsTouching, collisionOwnedElsewhere, loadStatus } from './models_field.js';
 
 /** The verbs this realizer owns — the whole flat entity-id namespace. */
 export const PORTED = new Set(['spawn', 'place', 'remove', 'light', 'comp', 'motion', 'mount', 'dismount']);
@@ -210,7 +210,9 @@ function createModel(id, ent) {
 
 function scheduleLoad(id, ent, gen, tier = null) {
   const t0 = tracked.get(id);
-  if (t0) t0.loading = true;   // the sweep must not re-promote a load in flight
+  if (!t0 || t0.gen !== gen || t0.loading) return;
+  t0.phase = 'queued';
+  t0.loading = true;   // the sweep must not re-promote a load in flight
   schedule({
     key: `entity:${id}`, owner: `entity:${id}`, lane: 'net',
     // live distance from the camera to the entity's CURRENT folded position —
@@ -218,6 +220,9 @@ function scheduleLoad(id, ent, gen, tier = null) {
     priority: () => bandForDistance(camera.position.distanceTo(
       _v.set(...(state.st.entities[id]?.pos ?? [0, 0, 0])))),
     run: async (signal) => {
+      if (signal.aborted || tracked.get(id)?.gen !== gen) return;
+      t0.phase = 'loading';
+      bus.emit('materialization', { id });
       // a first load chooses its tier at DEQUEUE, once /version has answered
       // (key and recipe are what make a lod ask real — assets.js
       // lodNegotiable) and from the live distance; a re-tier brings the tier
@@ -238,6 +243,10 @@ function scheduleLoad(id, ent, gen, tier = null) {
         if (tracked.get(id)?.gen === gen) tracked.delete(id);
         return;
       }
+      // the bytes arrived: this id is no longer failing, no longer queued
+      delete t.failedAt;
+      delete t.error;
+      delete t.phase;
       // a TIER SWAP replaces a REAL object, and authority is re-checked at
       // the moment of application, not only when the sweep scheduled it
       // (review of #170, point 3): while the bytes flew a body may have sat
@@ -256,9 +265,13 @@ function scheduleLoad(id, ent, gen, tier = null) {
     },
   }).done.catch((e) => {
     const t = tracked.get(id);
-    if (t?.gen === gen) t.loading = false;
+    if (t?.gen !== gen) return;
+    t.loading = false;
+    delete t.phase;
     if (e?.name === 'AbortError') return;
-    if (t) t.failedAt = Date.now();   // the sweep backs off, not machine-guns (review S3)
+    t.failedAt = Date.now();
+    t.error = 'Could not load this object. Check your connection or try again.';
+    bus.emit('materialization', { id });   // the sweep backs off, not machine-guns (review S3)
     // a failed load keeps its reservation, exactly like legacy: the id stays
     // addressable (a later remove folds cleanly), it just never renders
     report(`realize spawn ${id}`, e);
@@ -806,6 +819,25 @@ export function residencySweep() {
       scheduleLoad(id, ent, t.gen);
     }
   }
+}
+
+/** One bounded client-local snapshot; no loader or folded state is duplicated. */
+export function materializationStatus(id) {
+  const ent = state.st.entities[id];
+  const t = tracked.get(id);
+  if (!ent || !t) return null;
+  const obj = entities.get(id);
+  return loadStatus(t, Boolean(obj && !isPlaceholder(obj)), entDist(ent) <= residencyRadius(ent));
+}
+
+/** Explicit recovery uses the same owned queue, residency gate and backoff. */
+export function retryMaterialization(id) {
+  if (!materializationStatus(id)?.retryAvailable) return false;
+  const t = tracked.get(id);
+  t.gen = nextGen++;
+  scheduleLoad(id, state.st.entities[id], t.gen);
+  bus.emit('materialization', { id });
+  return true;
 }
 
 export const residencyDebug = () => {

--- a/client/lib/realize/models_field.js
+++ b/client/lib/realize/models_field.js
@@ -107,3 +107,13 @@ export function mountsTouching(stEntities, touchedId, childrenOf = null) {
 export function collisionOwnedElsewhere(ent, mounted = false) {
   return !!mounted || !!ent?.comp?.structure;
 }
+
+/** Derived materialization UI state; error content is a fixed safe summary. */
+export function loadStatus(tracked, realized, inRange) {
+  const state = realized ? 'ready' : tracked.loading ? (tracked.phase ?? 'queued')
+    : !inRange ? 'deferred' : tracked.failedAt ? 'failed' : 'queued';
+  return { state, error: tracked.error ?? null,
+    retryAvailable: state === 'failed',
+    label: ({ready: 'Ready', queued: 'Queued', loading: 'Loading',
+      deferred: 'Loads when nearby', failed: 'Loading failed'})[state] };
+}

--- a/client/lib/scenegraph.js
+++ b/client/lib/scenegraph.js
@@ -31,6 +31,8 @@
 import { THREE } from './core.js';
 import { CONFIG, bus } from './base.js';
 import { entities, entityMeta, comps, avatarMounts } from './world.js';
+import { state } from './state.js';
+import { materializationStatus, retryMaterialization } from './realize/models.js';
 import { editorsFor } from './inspect.js';
 import './lights.js';   // for its registered light editor (world.js pulls it in anyway)
 import { sendVerb, requestDebug } from './net.js';
@@ -105,10 +107,11 @@ function paintScene(force = false) {
   const { roots, kids, riders } = treeData();
   const rows = [];
   const row = (id, depth) => {
-    const meta = entityMeta.get(id);
+    const meta = entityMeta.get(id) ?? state.st.entities[id];
     const short = (meta?.lib ?? meta?.kind ?? '?').split('/').pop().replace('.glb', '')
       .split('_').slice(0, 3).join(' ');
-    const badges = badgesFor(id);
+    const status = materializationStatus(id);
+    const badges = [...badgesFor(id), status?.label ?? ''];
     const scripts = behaviorRows.filter((b) => b.attach === id).map((b) => `📜${b.id}`);
     rows.push(`<div class="who-row sg-row" data-id="${esc(id)}" style="cursor:pointer;padding-left:${depth * 14}px;${id === selected ? 'background:rgba(255,255,255,.06)' : ''}">
       <span class="n">${depth ? '└ ' : ''}<b>${esc(id)}</b> <span style="color:var(--dim)">${esc(short)}</span></span>
@@ -126,6 +129,7 @@ function paintScene(force = false) {
     const obj = entities.get(selected);
     const meta = entityMeta.get(selected);
     const bag = comps.get(selected);
+    const status = materializationStatus(selected);
     const pos = obj ? obj.getWorldPosition(_wp) : null;
     const isLight = !!obj?.userData?.isLight;
 
@@ -176,6 +180,8 @@ function paintScene(force = false) {
     inspector = `<div style="border-top:1px solid var(--edge);margin-top:6px;padding-top:6px">
       <div><b>${esc(selected)}</b> <span style="color:var(--dim)">${esc(meta?.lib ?? '')}</span></div>
       <div style="color:var(--dim)">placed by ${esc(meta?.actor ?? '?')} · ${pos ? `at (${pos.x.toFixed(1)}, ${pos.y.toFixed(1)}, ${pos.z.toFixed(1)})` : 'loading'}${obj?.userData?.mountedTo ? ` · mounted on ${esc(obj.userData.mountedTo)}` : ''}</div>
+      <div role="status" style="overflow-wrap:anywhere;margin:6px 0">${esc(status?.label ?? '')}${status?.error ? ` — ${esc(status.error)}` : ''}</div>
+      ${status?.retryAvailable ? '<button data-act="retry" style="min-height:44px">Retry loading</button>' : ''}
       ${transform}
       ${eds.map((e) => e.html).join('')}
       ${compRows.join('')}${newComp}
@@ -198,6 +204,11 @@ function paintScene(force = false) {
       paintScene(true);
     };
   }
+  const retryButton = sceneBody.querySelector('[data-act="retry"]');
+  retryButton?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+  });
+  retryButton?.addEventListener('click', () => { retryMaterialization(selected); paintScene(true); });
   sceneBody.querySelector('[data-act="find"]')?.addEventListener('click', () => {
     const obj = entities.get(selected);
     if (!obj) return;
@@ -398,6 +409,7 @@ export function initSceneGraph() {
     setTimeout(() => { repaintQueued = false; if (sceneApi?.isOpen) paintScene(); }, 300);
   };
   bus.on('entity', repaint);
+  bus.on('materialization', repaint);
   bus.on('comp', repaint);
   bus.on('mount', repaint);
 }

--- a/tools/loading-recovery-probe.mjs
+++ b/tools/loading-recovery-probe.mjs
@@ -1,0 +1,77 @@
+// Disposable sequencer + actual renderer: persistent failure, keyboard retry,
+// success, and a reservation without geometry metadata. Run with bun.
+import { ownedWorld, launchBrowser } from './probe-harness.mjs';
+import { Document, NodeIO } from '@gltf-transform/core';
+const doc = new Document();
+const buffer = doc.createBuffer();
+const positions = doc.createAccessor().setType('VEC3').setArray(new Float32Array([0,0,0, 1,0,0, 0,1,0])).setBuffer(buffer);
+const mesh = doc.createMesh().addPrimitive(doc.createPrimitive().setAttribute('POSITION', positions));
+doc.createScene().addChild(doc.createNode().setMesh(mesh));
+const bytes = Buffer.from(await new NodeIO().writeBinary(doc));
+const world = await ownedWorld();
+let browser;
+try {
+  browser = await launchBrowser();
+  const page = await browser.page();
+  page.on('pageerror', e => console.log('pageerror', e.message));
+  let attempts = 0;
+  await page.route('**/library/recovery.glb*', route => {
+    attempts++;
+    return attempts === 1 ? route.fulfill({status: 503, body: 'unavailable'})
+      : route.fulfill({status: 200, contentType: 'model/gltf-binary', body: bytes});
+  });
+  await page.goto(`${world.origin}/?key=${world.key}&name=recovery-probe&world=recovery`);
+  await page.waitForFunction(() => window.EW?.sendVerb, {timeout: 60000});
+  await page.evaluate(async () => {
+    window.loadingModels = await import('/lib/realize/models.js');
+    const { camera } = await import('/lib/core.js');
+    const { foldLive } = await import('/lib/state.js');
+    // Drive a logged-shape entry through the normal client fold; network
+    // authority is irrelevant to the local failure/retry contract.
+    foldLive({verb:'spawn',args:{id:'recovery',lib:'recovery.glb',pos:camera.position.toArray()},seq:100,ts:Date.now(),actor:'probe'});
+  });
+  await page.waitForFunction(() => window.loadingModels.materializationStatus('recovery')?.state === 'failed');
+  await page.evaluate(async () => (await import('/lib/scenegraph.js')).sceneSelect('recovery'));
+  const retry = page.getByRole('button', {name: 'Retry loading'});
+  await retry.waitFor();
+  await retry.focus();
+  await page.keyboard.press('Enter');
+  if (await page.evaluate(() => window.loadingModels.retryMaterialization('recovery'))) throw new Error('duplicate retry admitted');
+  await page.waitForFunction(() => window.loadingModels.materializationStatus('recovery')?.state === 'ready');
+  const status = await page.evaluate(async () => (await import('/lib/realize/models.js')).materializationStatus('recovery'));
+  if (status.error || attempts !== 2) throw new Error(JSON.stringify({status, attempts}));
+  const held = [];
+  await page.route('**/library/collision-*.glb*', route => { held.push(route); });
+  await page.evaluate(async () => {
+    const assets = await import('/lib/assets.js');
+    const { foldLive } = await import('/lib/state.js');
+    const { camera } = await import('/lib/core.js');
+    let seq = 101;
+    window.probeFold = (verb, args) => foldLive({verb,args,seq:seq++,ts:Date.now(),actor:'probe'});
+    for (const id of ['collision-a', 'collision-b']) {
+      assets.libLabels.set(`${id}.glb`, 'identical display name prefix longer than 28');
+      window.probeFold('spawn', {id,lib:`${id}.glb`,pos:camera.position.toArray()});
+    }
+    window.probeFold('spawn', {id:'far',lib:'never-fetch.glb',pos:[100000,0,0]});
+  });
+  for (let n = 0; held.length < 2 && n < 1500; n++) await new Promise(r => setTimeout(r, 20));
+  if (held.length !== 2) throw new Error('held downloads timed out');
+  const simultaneous = await page.evaluate(async () => (await import('/lib/assets.js')).loadingItems().filter(x => x.label === 'identical display name prefix longer than 28'.slice(0,28)).length);
+  if (simultaneous !== 2) throw new Error(`progress collision: ${simultaneous}`);
+  await page.evaluate(() => {
+    if (window.loadingModels.materializationStatus('far').state !== 'deferred' || window.loadingModels.retryMaterialization('far')) throw new Error('residency bypass');
+    window.probeFold('remove', {id:'collision-a'});
+    window.probeFold('spawn', {id:'collision-b',lib:'recovery.glb',pos:[0,0,0]});
+  });
+  for (const route of held) await route.fulfill({status:503, body:'stale failure'});
+  await page.waitForFunction(() => window.loadingModels.materializationStatus('collision-b')?.state === 'ready');
+  await page.evaluate(async () => {
+    if (window.loadingModels.materializationStatus('collision-a') !== null || window.loadingModels.materializationStatus('collision-b').error) throw new Error('stale failure resurrected');
+    (await import('/lib/state.js')).reset();
+    if (window.loadingModels.materializationStatus('recovery') !== null) throw new Error('reset retained status');
+  });
+  console.log('PASS: rendered keyboard retry recovered existing object once; failure cleared; progress identity, replacement, removal, reset and residency passed');
+} finally {
+  await browser?.close();
+  await world.close();
+}

--- a/tools/loading-recovery-probe.mjs
+++ b/tools/loading-recovery-probe.mjs
@@ -67,8 +67,15 @@ try {
   await page.waitForFunction(() => window.loadingModels.materializationStatus('collision-b')?.state === 'ready');
   await page.evaluate(async () => {
     if (window.loadingModels.materializationStatus('collision-a') !== null || window.loadingModels.materializationStatus('collision-b').error) throw new Error('stale failure resurrected');
-    (await import('/lib/state.js')).reset();
-    if (window.loadingModels.materializationStatus('recovery') !== null) throw new Error('reset retained status');
+    window.probeFold('spawn', {id:'collision-reset',lib:'collision-reset.glb',pos:[0,0,0]});
+  });
+  for (let n = 0; held.length < 3 && n < 1500; n++) await new Promise(r => setTimeout(r, 20));
+  if (held.length !== 3) throw new Error('reset download timed out');
+  await page.evaluate(async () => (await import('/lib/state.js')).reset());
+  await held[2].fulfill({status:503, body:'old world failure'});
+  await page.evaluate(() => new Promise(r => setTimeout(r, 100)));
+  await page.evaluate(() => {
+    for (const id of ['recovery', 'collision-reset']) if (window.loadingModels.materializationStatus(id) !== null) throw new Error('reset retained status');
   });
   console.log('PASS: rendered keyboard retry recovered existing object once; failure cleared; progress identity, replacement, removal, reset and residency passed');
 } finally {

--- a/tools/models-field-test.ts
+++ b/tools/models-field-test.ts
@@ -10,7 +10,7 @@
 // every linkage a completed spawn could unblock); distance bands promote
 // what is in front of you.
 
-import { planReconcile, bandForDistance, mountsTouching, collisionOwnedElsewhere } from "../client/lib/realize/models_field.js";
+import { planReconcile, bandForDistance, mountsTouching, collisionOwnedElsewhere, loadStatus } from "../client/lib/realize/models_field.js";
 import { P } from "../client/lib/scheduler.js";
 
 let passed = 0, failed = 0;
@@ -101,6 +101,14 @@ const light = () => ({ kind: "light", pos: [0, 1, 0], color: 0xffd9a0, intensity
     !collisionOwnedElsewhere({ ...model("x.glb"), comp: { lock: true } }, false));
   check("missing entity is not a crash", !collisionOwnedElsewhere(undefined, false));
 }
+
+check('ready geometry takes precedence', loadStatus({failedAt: 1}, true, true).state === 'ready');
+check('out of range explains deferred failure', loadStatus({failedAt: 1}, false, false).state === 'deferred');
+check('deferred failures cannot bypass residency', !loadStatus({failedAt: 1}, false, false).retryAvailable);
+check('failed in-range object offers retry', loadStatus({failedAt: 1}, false, true).retryAvailable);
+check('queued retry coalesces clicks', !loadStatus({loading: true, phase: 'queued', failedAt: 1}, false, true).retryAvailable);
+check('running job is loading', loadStatus({loading: true, phase: 'loading'}, false, true).state === 'loading');
+check('failure summary persists while retrying', loadStatus({loading: true, error: 'safe'}, false, true).error === 'safe');
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed) process.exit(1);


### PR DESCRIPTION
An unavailable object previously left an invisible reservation with only temporary console feedback. Scene rows and the inspector now show ready, queued, loading, failed or “Loads when nearby”, and failed nearby objects offer keyboard-accessible Retry loading. Retry uses the existing owned scheduler, coalesces clicks and preserves automatic retry backoff and residency.

Progress records use full asset paths, so matching truncated display names remain independent. Failure writes are generation-guarded, and successful recovery clears the fixed, safe error summary. No shared world state or verbs are changed by retry.

Closes #162. Related to #113's server-side advisory lint; this supplies client recovery and visibility.

Validation:
- `bun tools/models-field-test.ts`: 25 passed.
- `bun tools/object-lod-test.ts`: 0 failed.
- `SFU_TEST_CHROME=<Chrome executable> bun tools/loading-recovery-probe.mjs`: disposable sequencer and actual browser renderer; keyboard retry recovers one existing object, duplicate retry is rejected, matching labels retain separate progress, deferred objects refuse retry, and removal/replacement/world reset during downloads cannot restore stale failures.
