### PR TITLE
feat: anchor particle emitters to named model parts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,11 @@ comp {id: "hearth", type: "particles", data: null}      # put it out
 ```
 
 `preset` is one of `fire · sparks · embers · smoke · dust · snow · magic ·
-stars · muzzle`. `origin` is ENTITY-RELATIVE metres (bounded to ±8): the
+stars · muzzle`. `part: "wax"` optionally attaches the emitter to a rendered GLB node by name.
+With `part`, `origin` is in that node's LOCAL frame, so it rides nested part
+motion. Missing parts fall back to the entity frame and report a
+`particles-lint` advisory; the component still folds. Without `part`,
+`origin` is ENTITY-RELATIVE metres (bounded to ±8): the
 emitter hangs off the thing that owns it and rides every `place`, `mount` and
 `motion` that thing does. `seed` makes the spawn deterministic — omit it and
 one is derived from the entity id, which is just as persistent and just as

--- a/client/lib/emitters.js
+++ b/client/lib/emitters.js
@@ -30,7 +30,7 @@
 import { THREE, scene } from './core.js';
 import { bus } from './base.js';
 import { loadEidoModule, primeFiles } from './assets.js';
-import { entities } from './world.js';
+import { entities, findPart } from './world.js';
 import { normalizeParticles, resolvedCount, withSeededRandom, QUALITY_TIERS } from '../../shared/particles.js';
 import { makeEmitterRegistry, retireEmitter, adoptSystem } from './emitter_field.js';
 import { autoHooks as autos, ownHook } from './autohooks.js';
@@ -120,11 +120,14 @@ async function build(emitter, { id }) {
   ownHook(sys.update);           // ours, so no diffing subsystem may claim it
 
   return adoptSystem(sys, autos(), () => {
-    // Entity-relative, not world-origin: the emitter is a CHILD of the thing
-    // that owns it, so it rides every place/mount/motion that thing does. The
-    // authored origin is a local offset in the entity's own frame.
+    // A part-relative origin is in the named node's local frame. Parenting
+    // composes the entire animated hierarchy, including entity mounts/motion.
+    // Missing parts keep the emitter visible in the entity frame; the server
+    // records the advisory and this client reports its own realization.
+    const part = emitter.part ? findPart(parent, emitter.part) : null;
+    if (emitter.part && !part) console.warn(`[emitters] ${id}: part "${emitter.part}" unavailable — using the entity frame`);
     sys.mesh.position.set(emitter.origin[0], emitter.origin[1], emitter.origin[2]);
-    parent.add(sys.mesh);
+    (part ?? parent).add(sys.mesh);
     sys.mesh.userData.emitterOf = id;
     // The world owns this, not the sky: an async sky build that happens to
     // snapshot scene.children mid-flight must never claim (and then dispose)

--- a/server/geometry.ts
+++ b/server/geometry.ts
@@ -80,6 +80,9 @@ export type GeomSummary = {
    *  [0,0,0] is the node origin (where a hinge usually lives). */
   nodes: { name: string; center: number[]; size: number[]; origin: number[];
            local: { center: number[]; size: number[] }; tris: number }[];
+  /** All named nodes in active scenes, including transform-only groups.
+   *  Unlike the bounded mesh summaries, suitable for attachment lookup. */
+  nodeNames: string[];
   /** true when the mesh was too big to walk exhaustively */
   sampled: boolean;
   /** the box-top lie (m, model frame): bbox top minus the median 24×24
@@ -404,6 +407,7 @@ export async function summarizeGlb(absPath: string): Promise<GeomSummary | null>
     } : { min: [0, 0, 0], max: [0, 0, 0], size: [0, 0, 0], center: [0, 0, 0] },
     topSurfaces,
     nodes,
+    nodeNames: [...new Set(doc.getRoot().listNodes().filter(n => inScene.has(n)).map(n => n.getName()).filter(Boolean))],
     sampled: stride > 1,
     ...(lie !== undefined ? { lie } : {}),
     ...(topGrid ? { topGrid } : {}),

--- a/server/lint.ts
+++ b/server/lint.ts
@@ -97,17 +97,32 @@ export function lintMotion(w: LintHost, entry: LogEntry): void {
  *  the component has already folded, and an unrenderable emitter still
  *  persists and still reads as an emitter in text-tier perception. */
 export function lintParticles(w: LintHost, entry: LogEntry): void {
-  try {
-    const a = entry.args as Record<string, unknown>;
-    const id = String(a.id ?? "");
-    if (a.data == null) return;                      // put out — nothing to lint
-    const r = normalizeParticles(a.data, { entityId: id });
-    if (!r.ok) {
-      w.debug("particles-lint", { entity: id, by: entry.actor, why: r.why });
-      return;
-    }
-    if (r.notes.length) {
-      w.debug("particles-lint", { entity: id, by: entry.actor, why: r.notes.join(" · ") });
-    }
-  } catch { /* lint must never hurt anything */ }
+  void (async () => {
+    try {
+      const a = entry.args as Record<string, unknown>;
+      const id = String(a.id ?? "");
+      if (a.data == null) return;                      // put out — nothing to lint
+      const r = normalizeParticles(a.data, { entityId: id });
+      if (!r.ok) {
+        w.debug("particles-lint", { entity: id, by: entry.actor, why: r.why });
+        return;
+      }
+      if (r.notes.length) {
+        w.debug("particles-lint", { entity: id, by: entry.actor, why: r.notes.join(" · ") });
+      }
+      if (r.emitter.part) {
+        const part = r.emitter.part;
+        const ent = w.state.entities[id];
+        const file = ent?.lib ? resolveLibFile(ent.lib) : null;
+        const sum = file ? await summarizeGlb(file) : null;
+        const names = sum?.nodeNames;
+        if (!names || !names.includes(part)) {
+          w.debug("particles-lint", { entity: id, by: entry.actor,
+            why: names
+              ? `part "${part}" is not among ${id}'s rendered parts [${names.join(", ")}] — using the entity frame`
+              : `part "${part}" could not be checked because ${id}'s geometry is unavailable — clients use the entity frame if the part is missing` });
+        }
+      }
+    } catch { /* lint must never hurt anything */ }
+  })();
 }

--- a/shared/particles.js
+++ b/shared/particles.js
@@ -74,7 +74,7 @@ const NUMERIC_BOUNDS = {
   lifetime: [0.05, 30],
   area:     [0, 8],
 };
-const KNOWN_KEYS = new Set(['preset', 'seed', 'texture', 'origin', 'quality', ...Object.keys(NUMERIC_BOUNDS)]);
+const KNOWN_KEYS = new Set(['preset', 'seed', 'texture', 'origin', 'quality', 'part', ...Object.keys(NUMERIC_BOUNDS)]);
 
 // ---- determinism -----------------------------------------------------------
 
@@ -141,14 +141,14 @@ const clamp = (v, [lo, hi]) => Math.min(hi, Math.max(lo, v));
 function normalizeOrigin(origin, problems) {
   if (origin == null) return [0, 0, 0];
   if (!Array.isArray(origin) || origin.length !== 3 || !origin.every((n) => typeof n === 'number' && Number.isFinite(n))) {
-    problems.push('origin must be [x, y, z] numbers (entity-relative metres)');
+    problems.push('origin must be [x, y, z] numbers (entity-relative, or part-relative when part is named)');
     return [0, 0, 0];
   }
   // Entity-RELATIVE by contract: the emitter hangs off the thing that owns it
   // and travels with it. A 200m offset is not a local origin, it is a second
   // entity nobody can see, move or remove.
   if (origin.some((n) => Math.abs(n) > 8)) {
-    problems.push('origin is entity-relative and bounded to ±8m — place a far emitter on its own entity');
+    problems.push('origin is entity-relative (part-relative with part) and bounded to ±8m — place a far emitter on its own entity');
     return origin.map((n) => clamp(n, [-8, 8]));
   }
   return origin.slice();
@@ -183,6 +183,10 @@ export function normalizeParticles(data, { entityId = '' } = {}) {
     origin: normalizeOrigin(data.origin, notes),
     quality: Object.hasOwn(QUALITY_TIERS, data.quality) ? data.quality : 'auto',
   };
+  if (data.part != null) {
+    if (typeof data.part === 'string' && data.part.trim() && data.part.length <= 256) emitter.part = data.part;
+    else notes.push('part must be a non-empty name of at most 256 characters — using the entity frame');
+  }
   if (data.quality != null && !Object.hasOwn(QUALITY_TIERS, data.quality)) {
     notes.push(`quality ${JSON.stringify(data.quality)} is unknown (${Object.keys(QUALITY_TIERS).join('/')}) — using auto`);
   }
@@ -245,6 +249,9 @@ export function describeParticles(data) {
   const bits = ['particles'];
   const o = Array.isArray(data.origin) && data.origin.length === 3 && data.origin.every((n) => typeof n === 'number' && Number.isFinite(n))
     ? data.origin : null;
+  if (typeof data.part === 'string' && data.part.trim() && data.part.length <= 256) {
+    bits.push(`declared part ${JSON.stringify(data.part)} (part-local origin; entity fallback if unavailable)`);
+  }
   bits.push(`local origin [${(o ?? [0, 0, 0]).join(', ')}]`);
   if (!known) bits.push('preset unknown to this client');
   // "active" is the honest claim: the component IS the emitter's state, and a

--- a/tools/particle-part-geometry-test.ts
+++ b/tools/particle-part-geometry-test.ts
@@ -1,0 +1,24 @@
+// bun tools/particle-part-geometry-test.ts
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Document, NodeIO } from '@gltf-transform/core';
+import { summarizeGlb } from '../server/geometry.ts';
+const dir = mkdtempSync(join(tmpdir(), 'particle-part-geometry-'));
+try {
+  const doc = new Document();
+  const scene = doc.createScene();
+  const group = doc.createNode('hinge'); scene.addChild(group);
+  group.addChild(doc.createNode('wax'));
+  doc.createNode('orphan');
+  for(let i=0;i<40;i++) group.addChild(doc.createNode(`part-${i}`));
+  const file = join(dir,'parts.glb');
+  await new NodeIO().write(file,doc);
+  const sum = await summarizeGlb(file);
+  assert(sum.nodeNames.includes('hinge') && sum.nodeNames.includes('wax'));
+  assert(sum.nodeNames.includes('part-39'), 'attachment names are not capped with mesh summaries');
+  assert(!sum.nodeNames.includes('orphan'), 'unattached export nodes cannot anchor emitters');
+  assert.equal(sum.nodes.length,0, 'transform-only attachment nodes need no mesh');
+  console.log('particle attachment geometry names passed');
+} finally { rmSync(dir,{recursive:true,force:true}); }

--- a/tools/particle-parts-test.ts
+++ b/tools/particle-parts-test.ts
@@ -1,0 +1,90 @@
+// bun tools/particle-parts-test.ts — actual browser host, real Object3D
+// transforms, mocked GPU builder; advisory lint uses a named geometry fixture.
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as THREE from 'three';
+import { normalizeParticles, describeParticles } from '../shared/particles.js';
+
+const handlers = new Map<string, Function[]>();
+const bus = { on(k: string, f: Function) { handlers.set(k, [...(handlers.get(k) ?? []), f]); } };
+const emit = (k: string, v: unknown) => handlers.get(k)?.forEach(f => f(v));
+const entities = new Map<string, THREE.Object3D>();
+const scene = new THREE.Scene();
+const base = `${import.meta.dir}/../client/lib/`;
+mock.module(`${base}core.js`, () => ({ THREE, scene }));
+mock.module(`${base}base.js`, () => ({ bus }));
+mock.module(`${base}world.js`, () => ({ entities, findPart(root: THREE.Object3D, name: string) {
+  let found: THREE.Object3D | null = null;
+  root.traverse(c => { if (!found && c !== root && c.name === name) found = c; });
+  return found;
+} }));
+mock.module(`${base}assets.js`, () => ({ loadEidoModule: async () => {}, primeFiles: async () => {} }));
+const hooks: Function[] = [];
+(globalThis as any)._autoParticleSystems = hooks;
+let disposed = 0;
+(globalThis as any).makeParticles = () => {
+  const mesh = new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial());
+  mesh.geometry.addEventListener('dispose', () => disposed++);
+  const update = () => {};
+  hooks.push(update); scene.add(mesh);
+  return { mesh, update };
+};
+const { _registry: registry, clearEmitters } = await import('../client/lib/emitters.js');
+const settle = async () => { for (let i = 0; i < 8; i++) await Promise.resolve(); };
+const apply = async (part?: unknown) => {
+  emit('comp', { id: 'lantern', type: 'particles', data: { preset: 'fire', origin: [0, .05, 0], ...(part === undefined ? {} : {part}) } });
+  await settle();
+};
+const root = new THREE.Group(); root.position.set(4, 1, -3); scene.add(root);
+const arm = new THREE.Group(); arm.position.set(2, 0, 0); arm.rotation.z = Math.PI / 2; root.add(arm);
+const wax = new THREE.Group(); wax.name = 'wax'; wax.position.set(0, 3, 0); arm.add(wax);
+entities.set('lantern', root);
+await apply('wax');
+const mesh = wax.children[0];
+assert(mesh, 'emitter attaches to named nested node');
+assert.deepEqual(mesh.position.toArray(), [0, .05, 0]);
+scene.updateMatrixWorld(true);
+assert(mesh.getWorldPosition(new THREE.Vector3()).distanceTo(new THREE.Vector3(2.95, 1, -3)) < 1e-6);
+arm.rotation.z = 0; root.position.x = 10;
+scene.updateMatrixWorld(true);
+assert(mesh.getWorldPosition(new THREE.Vector3()).distanceTo(new THREE.Vector3(12, 4.05, -3)) < 1e-6, 'motion and entity movement compose');
+await apply('wax'); assert.equal(hooks.length, 1, 'identical replay is idempotent');
+await apply('missing'); assert.equal(wax.children.length, 0); assert.equal(hooks.length, 1);
+assert(root.children.some(c => c.userData.emitterOf === 'lantern'), 'unknown part uses entity frame');
+await apply(); assert.equal(hooks.length, 1, 'legacy entity emitter remains supported');
+emit('entity', {id: 'lantern', kind: 'demote'}); assert.equal(hooks.length, 0);
+const replacement = new THREE.Group(); const newWax = new THREE.Group(); newWax.name = 'wax'; replacement.add(newWax);
+entities.set('lantern', replacement); emit('entity', {id: 'lantern', kind: 'spawn'});
+await apply('wax'); assert.equal(newWax.children.length, 1, 'promotion resolves the replacement subtree');
+emit('comp', {id: 'lantern', type: 'particles', data: null}); await settle(); assert.equal(hooks.length, 0);
+entities.delete('lantern'); await apply('wax'); assert.equal(hooks.length, 0, 'late join waits for model');
+entities.set('lantern', replacement); emit('entity', {id: 'lantern', kind: 'spawn'}); await settle();
+assert.equal(newWax.children.length, 1, 'deferred model resolves part');
+clearEmitters(); assert.equal(hooks.length, 0); assert.equal(newWax.children.length, 0); assert.equal(disposed, 5);
+
+for (const part of ['', ' ', 7, {}, 'x'.repeat(257)]) {
+  const r = normalizeParticles({preset: 'fire', part});
+  assert(r.ok && !r.emitter.part && r.notes.some(n => n.includes('part')));
+}
+const normalized = normalizeParticles({preset:'fire', part:'wax'});
+assert(normalized.ok && normalized.emitter.part === 'wax' && normalized.notes.length === 0);
+assert(describeParticles({preset:'fire',part:'wax'}).includes('declared part "wax"'));
+assert(describeParticles({preset:'fire',part:'missing'}).includes('fallback if unavailable'));
+
+// Lint remains advisory and uses the rendered-node summary (orphans excluded).
+const dir = mkdtempSync(join(tmpdir(), 'particle-parts-'));
+writeFileSync(join(dir, 'fixture.glb'), 'fixture');
+mock.module(`${import.meta.dir}/../server/config.ts`, () => ({OPT_DIR:dir, LIBRARY_DIR:dir}));
+mock.module(`${import.meta.dir}/../server/geometry.ts`, () => ({ summarizeGlb: async () => ({nodeNames:['wax'], nodes:[], orphans:['orphan']}) }));
+const {lintParticles} = await import('../server/lint.ts');
+const findings: any[] = [];
+const world: any = {state:{entities:{lantern:{lib:'fixture.glb'}}}, debug:(kind:string,detail:any)=>findings.push({kind,...detail})};
+const lint = async (part:string) => {lintParticles(world,{verb:'comp',args:{id:'lantern',type:'particles',data:{preset:'fire',part}},actor:'builder'} as any); await settle();};
+await lint('wax'); assert.equal(findings.length,0);
+await lint('orphan'); assert.equal(findings.length,1); assert(findings[0].why.includes('orphan') && findings[0].why.includes('entity frame'));
+assert.equal(findings[0].kind,'particles-lint');
+world.state.entities.lantern.lib = 'absent.glb'; await lint('wax'); assert(findings[1].why.includes('geometry is unavailable'));
+console.log('particle part transforms, fallback, replay/lifecycle, normalization, perception and lint passed');

--- a/tools/particle-parts-test.ts
+++ b/tools/particle-parts-test.ts
@@ -5,7 +5,11 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import * as THREE from 'three';
+// three by explicit client path, not a bare specifier: tools/ sits outside
+// client/, where the install lives, so this resolves to the SAME module
+// instance the client modules under test get (tools/core-stub.mjs) and the
+// test no longer depends on a root install being present.
+import * as THREE from '../client/node_modules/three/build/three.module.js';
 import { normalizeParticles, describeParticles } from '../shared/particles.js';
 
 const handlers = new Map<string, Function[]>();


### PR DESCRIPTION
A particle emitter on a moving named part currently stays anchored to its entity frame. Add optional `part` to the shared particle declaration and parent the sprite mesh to that node, with `origin` interpreted in the node's local frame. Nested part transforms, entity movement, and mounts then compose through the scene hierarchy.

Unknown parts fall back to the existing entity frame, with a named `particles-lint` advisory and client warning. Malformed part names also produce advisory normalization notes. Text perception identifies the declared part and the possible fallback without claiming that a text-only client resolved the geometry. Existing declarations retain their entity-relative behavior; the fold and verb set are unchanged.

Geometry now exposes active-scene node names separately from the bounded mesh summaries, so transform-only groups and parts beyond the first 32 are valid anchors while orphan export nodes are excluded. Registry lifecycle behavior remains responsible for replacement, promotion, removal, and late model loading.

Closes #158.

Validation:
- `bun tools/particle-parts-test.ts`: real THREE hierarchy transforms, fallback, replay, replacement, demotion/promotion, deferred loading, cleanup, normalization, perception and advisory lint passed.
- `bun tools/particle-part-geometry-test.ts`: group nodes, more than 32 names, and orphan exclusion passed.
- `bun tools/particles-test.ts`: 93 passed.
- `bun tools/emitter-percept-test.ts`: reported 28 passed; its existing activity intervals kept the process alive, so it was terminated after the results.
- `git diff --check`: clean.

No production world was changed. GPU rendering was not exercised; the host test runs the actual emitter adapter with a mocked particle builder and real Object3D transforms.
