### PR TITLE
/library-models: the OPT_DIR walk filters every serving artifact, not just ktx2

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -704,9 +704,11 @@ const ROUTES: Route[] = [
       for (const d of dirs) {
         if (!existsSync(d)) continue;
         for (const f of readdirSync(d)) {
-          // ktx2 variants live beside originals in OPT_DIR — they are the
-          // same model, not a catalog entry (the ghost-listing fix, §20c)
-          if (!f.endsWith(".glb") || f.endsWith(".ktx2.glb")) continue;
+          // variants live beside originals in OPT_DIR — ktx2 (§20c's ghost
+          // listing) and, since #156, .lod.<recipe>.glb — the same model, not
+          // a catalog entry; markers and .tmp likewise. One predicate, the one
+          // /library-list already walks with (store-variants.ts).
+          if (!f.endsWith(".glb") || isServingArtifact(f)) continue;
           const low = f.toLowerCase();
           const score = q.length ? q.filter((t) => low.includes(t)).length : 1;
           if (score > 0) files.set(f, Math.max(files.get(f) ?? 0, score));

--- a/tools/object-lod-test.ts
+++ b/tools/object-lod-test.ts
@@ -512,6 +512,18 @@ console.log("\n  the library arm — the sweep queues LODs, and mutable sources 
     if (landed) {
       const res = await S.get(withLod(negotiate(REL, S.key), S.lod));
       check("the library LOD serves under the recipe URL", isLodGlb(res.bytes));
+      // the catalog humans pick from must not show the variant as a model. The
+      // store section asserts this for a store hash — where OPT_DIR is never
+      // walked as a models dir. THIS is the library side, where /library-models
+      // walks OPT_DIR/eidoverse/assets/models beside the originals (routes.ts):
+      // the walk's filter was written for the ktx2 arm alone, and every baked
+      // library LOD listed as a model of its own. Fails on main; the fix is one
+      // predicate, the one /library-list already used (isServingArtifact).
+      const catalog: { path: string }[] = await fetch(`${S.base}/library-models`).then((r) => r.json());
+      const leaked = catalog.filter((h) => isLodVariant(h.path)).map((h) => h.path);
+      check("/library-models lists the library original once and NEVER its lod variant (the OPT_DIR walk)",
+        catalog.filter((h) => h.path === REL).length === 1 && leaked.length === 0,
+        `original×${catalog.filter((h) => h.path === REL).length}, leaked: ${leaked.slice(0, 2).join(" | ") || "none"}`);
       // the source mutates (a library file is MUTABLE): the old variant must
       // never serve under the new source — provisional until rebuilt
       await sleep(1100);   // a strictly newer mtime, beyond timestamp granularity


### PR DESCRIPTION
## What

`/library-models` (the catalog humans pick from in the build pane) walks `OPT_DIR/eidoverse/assets/models` beside the library originals. Its filter was written for the ktx2 arm alone (`.ktx2.glb`), so every library LOD that #156's boot sweep bakes — `<rel>.lod.<recipe>.glb` — shows up in the catalog as a model of its own.

On the show box right now (99be0f7): 7 such entries, named like

```
eidoverse/assets/models/oil_fluid_drilling_rig_…platform.glb.lod.lod1-r25e01-texel1024.glb
```

Picking one places the reduced mesh as a first-class object. `/library-list` never had this hole — it walks with `isServingArtifact` (variants, markers, `.tmp`). The catalog now uses the same predicate. One line in `server/routes.ts`; no serving, negotiation, or cache behaviour changes.

## Why #156's tests did not catch it

`object-lod-test` asserted "never the variant" on `/library-models` for a **store** hash — where OPT_DIR is not walked as a models dir, so the check could not fail. The library section of the same test, where the walk happens, now asserts it: the library original listed once, no `.lod.` path anywhere.

## Receipts

- Negative control: the new check with the route unpatched — `✗ original×1, leaked: eidoverse/assets/models/apocalyptic_destroyed_rubble_debris_pile_building_collapse.glb.lod.lod1-r25e01-texel1024.glb | …streetlight_lamp_light_street.glb.lod.lod1-r25e01-texel1024.glb` (the local OPT_DIR had real baked library LODs, same as the show box).
- With the fix: `object-lod-test` 84/84 (one new check); `store-variants-test` unchanged.
- Found in the field while wiring the client chooser (next PR): a local sequencer with hand-baked library LODs listed them in the catalog, then the prod catalog was checked and showed the same 7.

This is my miss from #156 — I read "listings artifact-free" off `/library-list` and never walked the catalog route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR2U8SynCcmYLYEvVTXAo
