### PR TITLE
Client chooses the object LOD tier before the fetch (#156's client half)

### DIFF
--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -8,8 +8,8 @@
 //   vrmPool    whole parsed VRM instances at rest (§19b — no clone exists
 //              for a bound rig, so released bodies are reworn intact)
 
-import { keyFromVersion, negotiate, lodFromVersion, withLod } from '../../shared/ktx2.js';
-import { tierOf } from './lod_policy.js';
+import { keyFromVersion, negotiate, lodFromVersion } from '../../shared/ktx2.js';
+import { tierOf, askFor } from './lod_policy.js';
 import { THREE, renderer, camera, scene } from './core.js';
 import { report, bus } from './base.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -174,6 +174,23 @@ export const ktx2KeyReady = versionReady.then(keyFromVersion);
  *  — or null: no tier is ever asked for that the running process did not
  *  declare, the same split-brain gate as the key. */
 export const lodRecipeReady = versionReady.then(lodFromVersion);
+// the resolved answers, for SYNCHRONOUS policy reads (the residency sweep
+// runs at 2Hz and cannot await): null until /version answers, null forever
+// when it published nothing
+let ktx2Key = null, lodRecipe = null;
+ktx2KeyReady.then((k) => { ktx2Key = k; }).catch(() => {});
+lodRecipeReady.then((r) => { lodRecipe = r; }).catch(() => {});
+/** Settles once /version has answered (or failed) — a tier choice made
+ *  after this knows whether a lod ask can cross the wire. Never rejects. */
+export const negotiationReady = Promise.all([ktx2KeyReady, lodRecipeReady]).then(() => {}, () => {});
+/** Can a lod ask for this lib CROSS THE WIRE from this browser, right now
+ *  (review of #170, point 2)? The reduced variant's textures are KTX2, so
+ *  the ask rides the ktx2 negotiation: the transcoder must have detected
+ *  support, the running sequencer must have published a key AND a recipe,
+ *  and only bare .glb paths negotiate. The policy treats "no" as no recipe
+ *  — nothing is asked that could not be, and nothing is reported as asked. */
+export const lodNegotiable = (libPath) =>
+  askFor({ libPath, key: ktx2Key, capable: !!ktx2.workerConfig, recipe: lodRecipe, tier: 'lod' }).tier === 'lod';
 /** GPU memory against the proto budget — the policy's "device pressure". */
 export const gpuPressure = () => (renderer.info?.memory?.total ?? 0) / GPU_BUDGET;
 /** Tiered loading, one seam (#156 client contract): `loadGLB(lib, { tier })`
@@ -495,6 +512,12 @@ export const libLabels = new Map();
 
 const glbCache = new Map();
 export async function loadGLB(libPath, { tier = 'full' } = {}) {
+  // the WIRE decides which tier this load IS (review of #170, point 2): a
+  // lod wish that cannot negotiate — no transcoder, no key, no recipe, not
+  // a .glb — is a full load, keyed, fetched, and reported as one
+  await negotiationReady;
+  const ask = askFor({ libPath, key: ktx2Key, capable: !!ktx2.workerConfig, recipe: lodRecipe, tier });
+  tier = ask.tier;
   const glbKey = tier === 'lod' ? `${libPath}#lod` : libPath;
   const short = (libLabels.get(libPath) ?? libPath.split('/').pop()).slice(0, 28) + (tier === 'lod' ? '·lod' : '');
   loadsInFlight.set(glbKey, (loadsInFlight.get(glbKey) ?? 0) + 1);
@@ -506,18 +529,13 @@ export async function loadGLB(libPath, { tier = 'full' } = {}) {
       const work = beginWork(`glb ${short}`);
       try {
         work.phase('download');
-        // §20: ask for the KTX2 variant only when the transcoder detected
-        // support (detectSupport stamps workerConfig) and only for bare .glb
-        // paths — the server answers with the variant when one exists, the
-        // original otherwise. The full URL keys byteCache, so variant and
-        // original are distinct entries, which is correct.
-        let url = await negotiated(libPath, libPath.endsWith('.glb'));
-        // The geometry tier (#156) rides the ktx2 negotiation, with the RECIPE
-        // the running sequencer published — none published, none asked. The
-        // server answers the variant when one exists, the original chain
-        // otherwise (provisional): a lod request is never a worse model.
-        if (tier === 'lod' && url !== libPath) url = withLod(url, await lodRecipeReady);
-        const buf = await fetchBytes(`/library/${url}`);
+        // §20 + #156: the URL was decided above (askFor) — the running
+        // server's key when this GPU decodes KTX2 and the path negotiates,
+        // the lod recipe on top only when the ask is real. The server answers
+        // the variant when one exists, the original chain otherwise
+        // (provisional): a lod request is never a worse model. The full URL
+        // keys byteCache, so variant and original are distinct entries.
+        const buf = await fetchBytes(`/library/${ask.url}`);
         work.phase('queued');
         return await enqueue(async () => {
           work.phase('parse');
@@ -529,8 +547,8 @@ export async function loadGLB(libPath, { tier = 'full' } = {}) {
           // identity the realizer reads: which cache entry this proto is (for
           // retain/release/eviction) and which tier the SERVER actually sent
           gltf.scene.userData.glbKey = glbKey;
-          gltf.scene.userData.tierServed = tierOf(gltf.parser?.json);
-          gltf.scene.userData.tierAsked = tier;   // what the policy asked — the sweep compares against THIS
+          gltf.scene.userData.tierServed = tierOf(gltf.parser?.json, lodRecipe);   // the reducer's stamp, this recipe
+          gltf.scene.userData.tierAsked = tier;   // what crossed the wire — the sweep compares against THIS
           await work.yield();
           work.phase('textures');
           await primeTextures(gltf.scene, work);

--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -8,7 +8,8 @@
 //   vrmPool    whole parsed VRM instances at rest (§19b — no clone exists
 //              for a bound rig, so released bodies are reworn intact)
 
-import { keyFromVersion, negotiate } from '../../shared/ktx2.js';
+import { keyFromVersion, negotiate, lodFromVersion, withLod } from '../../shared/ktx2.js';
+import { tierOf } from './lod_policy.js';
 import { THREE, renderer, camera, scene } from './core.js';
 import { report, bus } from './base.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -166,8 +167,17 @@ export const ktx2Capable = () => !!ktx2.workerConfig;
 // wrong, on any deploy, in any order. One fetch per page, awaited by every
 // negotiating load (they are all async already; the prefetcher awaits it
 // once before building its queue).
-export const ktx2KeyReady = fetch('/version', { cache: 'no-store' })
-  .then((r) => (r.ok ? r.json() : null)).then(keyFromVersion).catch(() => null);
+const versionReady = fetch('/version', { cache: 'no-store' })
+  .then((r) => (r.ok ? r.json() : null)).catch(() => null);
+export const ktx2KeyReady = versionReady.then(keyFromVersion);
+/** The geometry-LOD recipe the running sequencer bakes (#156, lodFromVersion)
+ *  — or null: no tier is ever asked for that the running process did not
+ *  declare, the same split-brain gate as the key. */
+export const lodRecipeReady = versionReady.then(lodFromVersion);
+/** GPU memory against the proto budget — the policy's "device pressure". */
+export const gpuPressure = () => (renderer.info?.memory?.total ?? 0) / GPU_BUDGET;
+/** Tiered loading, one seam (#156 client contract): `loadGLB(lib, { tier })`
+ *  — 'full' or 'lod' — is the only place a tier turns into bytes. */
 /** The path a negotiating load fetches: the running server's key appended
  *  when this GPU decodes KTX2 and `eligible` (the asset class negotiates),
  *  the bare path otherwise. */
@@ -484,11 +494,12 @@ export const poolStats = () => ({
 export const libLabels = new Map();
 
 const glbCache = new Map();
-export async function loadGLB(libPath) {
-  const short = (libLabels.get(libPath) ?? libPath.split('/').pop()).slice(0, 28);
-  loadsInFlight.set(libPath, (loadsInFlight.get(libPath) ?? 0) + 1);
+export async function loadGLB(libPath, { tier = 'full' } = {}) {
+  const glbKey = tier === 'lod' ? `${libPath}#lod` : libPath;
+  const short = (libLabels.get(libPath) ?? libPath.split('/').pop()).slice(0, 28) + (tier === 'lod' ? '·lod' : '');
+  loadsInFlight.set(glbKey, (loadsInFlight.get(glbKey) ?? 0) + 1);
   try {
-  if (!glbCache.has(libPath)) {
+  if (!glbCache.has(glbKey)) {
     const key = `glb:${short}`;
     loadTrack(key, short);
     const p = (async () => {
@@ -500,7 +511,12 @@ export async function loadGLB(libPath) {
         // paths — the server answers with the variant when one exists, the
         // original otherwise. The full URL keys byteCache, so variant and
         // original are distinct entries, which is correct.
-        const url = await negotiated(libPath, libPath.endsWith('.glb'));
+        let url = await negotiated(libPath, libPath.endsWith('.glb'));
+        // The geometry tier (#156) rides the ktx2 negotiation, with the RECIPE
+        // the running sequencer published — none published, none asked. The
+        // server answers the variant when one exists, the original chain
+        // otherwise (provisional): a lod request is never a worse model.
+        if (tier === 'lod' && url !== libPath) url = withLod(url, await lodRecipeReady);
         const buf = await fetchBytes(`/library/${url}`);
         work.phase('queued');
         return await enqueue(async () => {
@@ -510,6 +526,11 @@ export async function loadGLB(libPath) {
           // shares its wrapped materials and copies its mesh markers
           prepareObject(gltf.scene, { kind: 'model' });
           markDrawBatchSource(gltf.scene);
+          // identity the realizer reads: which cache entry this proto is (for
+          // retain/release/eviction) and which tier the SERVER actually sent
+          gltf.scene.userData.glbKey = glbKey;
+          gltf.scene.userData.tierServed = tierOf(gltf.parser?.json);
+          gltf.scene.userData.tierAsked = tier;   // what the policy asked — the sweep compares against THIS
           await work.yield();
           work.phase('textures');
           await primeTextures(gltf.scene, work);
@@ -520,10 +541,10 @@ export async function loadGLB(libPath) {
     // a REJECTED promise must not be the lib's answer forever — the residency
     // sweep re-promotes near placeholders, and a cached rejection turned one
     // bad fetch into an instant-fail loop (review S3; models backs off too)
-    p.catch(() => { if (glbCache.get(libPath) === p) glbCache.delete(libPath); });
-    glbCache.set(libPath, p);
+    p.catch(() => { if (glbCache.get(glbKey) === p) glbCache.delete(glbKey); });
+    glbCache.set(glbKey, p);
   }
-  const proto = await glbCache.get(libPath);
+  const proto = await glbCache.get(glbKey);
   const obj = skeletonClone(proto); // safe for rigged + static alike
   // Precompile pipelines OFF the render path — otherwise the first frame that
   // sees a new material stalls the main thread (the ~1.5s spawn freeze).
@@ -534,7 +555,7 @@ export async function loadGLB(libPath) {
   // even the laned ones fight each other. Only the FIRST use of a model pays
   // real codegen + pipeline creation; repeats are cache hits — prod trace:
   // "queued 19311ms · compile 5ms".
-  if (compiledLibs.has(libPath)) {
+  if (compiledLibs.has(glbKey)) {
     await warm(`compile ${short}`, () => renderer.compileAsync(obj, camera, scene).catch(() => {}));
     return obj;
   }
@@ -543,12 +564,12 @@ export async function loadGLB(libPath) {
   // for one model). Clones share material references, so one compile warms
   // them all: the first caller compiles, everyone else awaits it and then
   // cache-hits.
-  if (!libCompiles.has(libPath)) {
+  if (!libCompiles.has(glbKey)) {
     // In the loading tray too: on Safari a single material graph compiles for
     // SECONDS — a spinner named after the model turns that from mystery jank
     // into visible progress. (The conductor's own beginWork carries the
     // queued/warm phases the old record here tracked.)
-    loadTrack(`compile:${libPath}`, `⚙ ${short}`);
+    loadTrack(`compile:${glbKey}`, `⚙ ${short}`);
     // Per-MESH inside the item, a real frame between: one compileAsync over a
     // multi-material object batches every pipeline into one GPU-process gulp
     // (the CRT monitor's 1123ms warm still stalled a frame 617ms even
@@ -566,9 +587,9 @@ export async function loadGLB(libPath) {
         await nextFrame();
       }
     })
-      .then(() => compiledLibs.add(libPath))
-      .finally(() => { libCompiles.delete(libPath); loadDone(`compile:${libPath}`); });
-    libCompiles.set(libPath, p);
+      .then(() => compiledLibs.add(glbKey))
+      .finally(() => { libCompiles.delete(glbKey); loadDone(`compile:${glbKey}`); });
+    libCompiles.set(glbKey, p);
     await p;
     return obj;
   }
@@ -576,12 +597,12 @@ export async function loadGLB(libPath) {
   // conductor (a conductor item must never await another conductor item —
   // that is item-awaits-item, a deadlock at concurrency 1), then queues its
   // own now-cheap warm.
-  await libCompiles.get(libPath).catch(() => {});
+  await libCompiles.get(glbKey).catch(() => {});
   await warm(`compile ${short}`, () => renderer.compileAsync(obj, camera, scene).catch(() => {}));
   return obj;
   } finally {
-    const n = (loadsInFlight.get(libPath) ?? 1) - 1;
-    if (n <= 0) loadsInFlight.delete(libPath); else loadsInFlight.set(libPath, n);
+    const n = (loadsInFlight.get(glbKey) ?? 1) - 1;
+    if (n <= 0) loadsInFlight.delete(glbKey); else loadsInFlight.set(glbKey, n);
   }
 }
 // Libs whose pipelines have been compiled once this session — repeat spawns

--- a/client/lib/assets.js
+++ b/client/lib/assets.js
@@ -189,8 +189,18 @@ export const negotiationReady = Promise.all([ktx2KeyReady, lodRecipeReady]).then
  *  support, the running sequencer must have published a key AND a recipe,
  *  and only bare .glb paths negotiate. The policy treats "no" as no recipe
  *  — nothing is asked that could not be, and nothing is reported as asked. */
-export const lodNegotiable = (libPath) =>
-  askFor({ libPath, key: ktx2Key, capable: !!ktx2.workerConfig, recipe: lodRecipe, tier: 'lod' }).tier === 'lod';
+export const lodNegotiable = (libPath) => resolveLoadRequest(libPath, 'lod').tier === 'lod';
+/** THE decision seam of a tiered load (review of #170, round three): from a
+ *  tier wish to everything loadGLB derives from it — the URL it fetches, the
+ *  tier that URL asks (askFor over this module's LIVE state: the running key
+ *  and recipe, this GPU's transcoder) and the cache identity it keys. One
+ *  function, exported, so the product-door gate executes the real seam and
+ *  never a restatement of it: tools/lod-loader-probe.ts runs THIS module
+ *  against an owned sequencer, and a mutation here fails it. */
+export function resolveLoadRequest(libPath, tier = 'full') {
+  const ask = askFor({ libPath, key: ktx2Key, capable: !!ktx2.workerConfig, recipe: lodRecipe, tier });
+  return { url: ask.url, tier: ask.tier, glbKey: ask.tier === 'lod' ? `${libPath}#lod` : libPath };
+}
 /** GPU memory against the proto budget — the policy's "device pressure". */
 export const gpuPressure = () => (renderer.info?.memory?.total ?? 0) / GPU_BUDGET;
 /** Tiered loading, one seam (#156 client contract): `loadGLB(lib, { tier })`
@@ -516,9 +526,9 @@ export async function loadGLB(libPath, { tier = 'full' } = {}) {
   // lod wish that cannot negotiate — no transcoder, no key, no recipe, not
   // a .glb — is a full load, keyed, fetched, and reported as one
   await negotiationReady;
-  const ask = askFor({ libPath, key: ktx2Key, capable: !!ktx2.workerConfig, recipe: lodRecipe, tier });
-  tier = ask.tier;
-  const glbKey = tier === 'lod' ? `${libPath}#lod` : libPath;
+  const req = resolveLoadRequest(libPath, tier);
+  tier = req.tier;
+  const glbKey = req.glbKey;
   const short = (libLabels.get(libPath) ?? libPath.split('/').pop()).slice(0, 28) + (tier === 'lod' ? '·lod' : '');
   loadsInFlight.set(glbKey, (loadsInFlight.get(glbKey) ?? 0) + 1);
   try {
@@ -529,13 +539,13 @@ export async function loadGLB(libPath, { tier = 'full' } = {}) {
       const work = beginWork(`glb ${short}`);
       try {
         work.phase('download');
-        // §20 + #156: the URL was decided above (askFor) — the running
+        // §20 + #156: the URL was decided above (resolveLoadRequest) — the running
         // server's key when this GPU decodes KTX2 and the path negotiates,
         // the lod recipe on top only when the ask is real. The server answers
         // the variant when one exists, the original chain otherwise
         // (provisional): a lod request is never a worse model. The full URL
         // keys byteCache, so variant and original are distinct entries.
-        const buf = await fetchBytes(`/library/${ask.url}`);
+        const buf = await fetchBytes(`/library/${req.url}`);
         work.phase('queued');
         return await enqueue(async () => {
           work.phase('parse');

--- a/client/lib/governor.js
+++ b/client/lib/governor.js
@@ -27,6 +27,8 @@
 //   slots     the light-slot cap drops (idle slots are uniform zeros)
 //   emitters  per-emitter instance counts thin (auto → med → low)
 //   grass     the meadow thins (instanced count — no rebuild)
+//   lod       far placed objects fetch their reduced tier sooner (#156: the
+//             policy's edge halves; swaps happen on the residency sweep)
 //   pixels    render scale, −0.25 steps to 0.7
 //   detail    LOD bias 2 (far bodies at half rate) + shadow map 1024
 //
@@ -53,7 +55,7 @@ import { renderer, sun, BASE_PIXEL_RATIO } from './core.js';
 import { CONFIG } from './base.js';
 import { warmStats } from './warmqueue.js';
 import { laneBusy } from './loadwork.js';
-import { promoteTailPending } from './realize/models.js';
+import { promoteTailPending, modelQuality } from './realize/models.js';
 import { setSlotCap, getSlotCap, maxSlots, litCount,
   setCasterBudget, getCasterBudget, casterCount } from './lightrig.js';
 import { setEmitterQuality, emitterQuality, emitterCount } from './emitters.js';
@@ -190,6 +192,24 @@ const LEVERS = [
       if (!hasGrass() || grassDial >= 1) return false;
       grassDial = grassDial < 0.5 ? 0.6 : 1;
       setGrassDensity(grassDial);
+      return true;
+    },
+  },
+  {
+    name: 'lod',
+    // The tier policy's session dial (lod_policy.js shed): under load the
+    // reduce-at edge halves, so placed objects at middling distance fetch the
+    // reduced variant on their next sweep; restore widens it again. Nothing
+    // rebuilds — the swap rides the residency sweep's own retier path.
+    shed() {
+      if (modelQuality.shed || modelQuality.quality !== 'auto') return false;
+      modelQuality.setShed(true);
+      toast('distant objects reduced to keep the frame rate', 'warn', 8000);
+      return true;
+    },
+    restore() {
+      if (!modelQuality.shed) return false;
+      modelQuality.setShed(false);
       return true;
     },
   },

--- a/client/lib/lod_policy.js
+++ b/client/lib/lod_policy.js
@@ -28,6 +28,8 @@
 //
 // DOM-free and side-effect-free: unit-tested in tools/lod-policy-test.ts.
 
+import { negotiate, withLod } from '../../shared/ktx2.js';
+
 export const MODEL_QUALITY = ['auto', 'full', 'eco'];
 /** Fraction of the residency radius beyond which 'auto' fetches the reduced
  *  tier. R = 80m + diag×4 (models.js), so a 2m prop goes reduced past ~40m,
@@ -81,8 +83,32 @@ export function chooseTier({ dist, radius, quality = 'auto', recipe = null, pres
 }
 
 /** Which tier a parsed GLB actually is — the server's word, read off the
- *  identity stamp the reducer writes (#156: asset.extras.recipe). A lod
- *  request answered by the original chain is 'full', honestly. */
-export function tierOf(gltfJson) {
-  return gltfJson?.asset?.extras?.recipe ? 'lod' : 'full';
+ *  identity stamp the reducer writes (#156: asset.extras {lodOf, recipe,
+ *  tools}) and bound to the RUNNING recipe. Not "any recipe extra": the
+ *  reducer preserves source extras, and an authored model may carry an
+ *  unrelated `recipe` of its own (review of #170, point 1) — reading that as
+ *  a lod would strip a full source model of its collider. lodOf must be
+ *  present and recipe must equal what /version published; anything else —
+ *  a wrong-generation stamp, a bare recipe, the original chain answering a
+ *  lod ask — is 'full', honestly. */
+export function tierOf(gltfJson, recipe) {
+  const x = gltfJson?.asset?.extras;
+  if (!recipe || !x || typeof x !== 'object') return 'full';
+  return typeof x.lodOf === 'string' && x.lodOf.length > 0 && x.recipe === recipe ? 'lod' : 'full';
+}
+
+/** The WIRE truth of a tier choice (review of #170, point 2): the URL a load
+ *  actually fetches and which tier that URL asks for. A lod ask rides the
+ *  KTX2 negotiation because the reduced variant's textures ARE KTX2 — a
+ *  browser without the transcoder (`capable` false), a sequencer that
+ *  published no key or no recipe, or a non-.glb path cannot ask, and the
+ *  answer says so: tier 'full', no `lod=` on the wire. The realizer keys
+ *  its hysteresis and its reporting on THIS, never on what the policy
+ *  wished. */
+export function askFor({ libPath, key = null, capable = false, recipe = null, tier = 'full' }) {
+  const glb = typeof libPath === 'string' && libPath.endsWith('.glb');
+  const k = glb && capable && key ? key : null;
+  const url = negotiate(libPath, k);
+  if (tier === 'lod' && k && recipe) return { url: withLod(url, recipe), tier: 'lod' };
+  return { url, tier: 'full' };
 }

--- a/client/lib/lod_policy.js
+++ b/client/lib/lod_policy.js
@@ -1,0 +1,88 @@
+// lod_policy — which geometry tier a placement fetches, decided BEFORE the
+// fetch (the #156 client contract), from three local inputs and nothing the
+// world shares:
+//
+//   the RESIDENT's dial     models⚙ — auto / full detail / eco (reduce
+//                           sooner: the pressured band, always). Persisted per
+//                           browser like clouds⚙ and grass⚙; never a verb.
+//   the DISTANCE            how far the placement sits from the resident's
+//                           eye, against the entity's own residency radius
+//                           (R_BASE + bbox diagonal × k, models.js) — so a
+//                           cathedral goes reduced later than a mug.
+//   DEVICE PRESSURE         GPU memory against the proto budget (assets.js
+//                           gpuPressure) and the frame governor's shed — a
+//                           6GB card and a 24GB card should not fetch alike.
+//
+// The answer is 'full' or 'lod'. 'lod' asks the running sequencer for the
+// recipe it PUBLISHED on /version (shared/ktx2.js lodFromVersion) — no
+// recipe published, no tier asked, ever: an older sequencer, or a failed
+// /version fetch, degrades to exactly today's behaviour. And a lod request
+// is never a WORSE model: the server answers with the variant when one
+// exists and the original chain otherwise (provisional), the loader records
+// which arrived (userData.tierServed), and colliders/support/raycast never
+// read the reduced mesh at all (models.js: a lod-tier placement owns no
+// collider until it upgrades on approach).
+//
+// Hysteresis: a placement at the band edge must not flip tiers every sweep.
+// The upgrade edge sits inside the downgrade edge by LOD_HYST on each side.
+//
+// DOM-free and side-effect-free: unit-tested in tools/lod-policy-test.ts.
+
+export const MODEL_QUALITY = ['auto', 'full', 'eco'];
+/** Fraction of the residency radius beyond which 'auto' fetches the reduced
+ *  tier. R = 80m + diag×4 (models.js), so a 2m prop goes reduced past ~40m,
+ *  a 20m building past ~70m. */
+export const LOD_FRACTION = 0.45;
+/** Band hysteresis: upgrade below edge×(1−H), downgrade above edge×(1+H). */
+export const LOD_HYST = 0.25;
+/** Under pressure — and on the 'eco' dial — the edge halves: reduced
+ *  tiers come in much closer, but never to arm's length. */
+export const PRESSURE_EDGE = 0.5;
+/** GPU memory / proto budget at which the policy calls it pressure. */
+export const PRESSURE_AT = 0.8;
+
+const KEY = 'ew-model-quality';
+
+/** The dial state. `store` is localStorage in the browser, anything with
+ *  getItem/setItem in tests, or absent (state then lives for the session). */
+export function makeModelQuality(store) {
+  const saved = store?.getItem?.(KEY);
+  let quality = MODEL_QUALITY.includes(saved) ? saved : 'auto';
+  let shed = false;   // the governor's session dial — never persisted
+  return {
+    get quality() { return quality; },
+    get shed() { return shed; },
+    setQuality(q) {
+      if (!MODEL_QUALITY.includes(q)) return quality;
+      quality = q;
+      store?.setItem?.(KEY, q);
+      return quality;
+    },
+    setShed(v) { shed = !!v; return shed; },
+  };
+}
+
+/** The tier to fetch for a placement.
+ *  `dist` metres from the resident's eye; `radius` the entity's residency
+ *  radius; `quality` the dial; `recipe` what /version published (null → no
+ *  negotiation, ever); `pressure` gpu memory / budget (0..∞); `shed` the
+ *  governor's session dial; `current` the tier it wears now, for hysteresis. */
+export function chooseTier({ dist, radius, quality = 'auto', recipe = null, pressure = 0, shed = false, current = null }) {
+  if (!recipe || quality === 'full') return 'full';
+  // 'eco' is the pressured band, always: the edge halves. It does NOT reduce
+  // what you stand beside — the first field run did, and a 66m rig's girders
+  // at arm's length became slabs across the camera. Near stays full on every
+  // dial; only 'full' ignores distance (in the other direction).
+  const squeezed = quality === 'eco' || pressure >= PRESSURE_AT || shed;
+  const edge = (radius > 0 ? radius : 80) * LOD_FRACTION * (squeezed ? PRESSURE_EDGE : 1);
+  if (current === 'lod') return dist < edge * (1 - LOD_HYST) ? 'full' : 'lod';
+  if (current === 'full') return dist > edge * (1 + LOD_HYST) ? 'lod' : 'full';
+  return dist > edge ? 'lod' : 'full';
+}
+
+/** Which tier a parsed GLB actually is — the server's word, read off the
+ *  identity stamp the reducer writes (#156: asset.extras.recipe). A lod
+ *  request answered by the original chain is 'full', honestly. */
+export function tierOf(gltfJson) {
+  return gltfJson?.asset?.extras?.recipe ? 'lod' : 'full';
+}

--- a/client/lib/realize/models.js
+++ b/client/lib/realize/models.js
@@ -23,7 +23,8 @@
 
 import { THREE, scene, camera } from '../core.js';
 import { report, bus } from '../base.js';
-import { loadGLB, retainGLB, releaseGLB, evictIdleProtos } from '../assets.js';
+import { loadGLB, retainGLB, releaseGLB, evictIdleProtos, lodRecipeReady, gpuPressure } from '../assets.js';
+import { makeModelQuality, chooseTier } from '../lod_policy.js';
 import { colliders, fitCollider, removeCollider, reindexCollider, refitCollider } from '../colliders.js';
 import { attachLamps, releaseOwner, registerCaster, releaseCaster } from '../lightrig.js';
 import { makeLight, updateLight, disposeLight } from '../lights.js';
@@ -206,7 +207,7 @@ function createModel(id, ent) {
   scheduleLoad(id, ent, gen);
 }
 
-function scheduleLoad(id, ent, gen) {
+function scheduleLoad(id, ent, gen, tier = tierFor(ent, null)) {
   const t0 = tracked.get(id);
   if (t0) t0.loading = true;   // the sweep must not re-promote a load in flight
   schedule({
@@ -216,7 +217,7 @@ function scheduleLoad(id, ent, gen) {
     priority: () => bandForDistance(camera.position.distanceTo(
       _v.set(...(state.st.entities[id]?.pos ?? [0, 0, 0])))),
     run: async (signal) => {
-      const obj = await loadGLB(ent.lib);
+      const obj = await loadGLB(ent.lib, { tier });
       const cur = state.st.entities[id];
       const t = tracked.get(id);
       if (t?.gen === gen) t.loading = false;
@@ -249,9 +250,22 @@ function scheduleLoad(id, ent, gen) {
 // task batch used to land six boulders in a single frame (§16.1e). A seat/
 // surface/camera query in the frames before the collider lands simply
 // misses the brand-new object — accepted (§16.2.C).
+/** Everything a realized object holds that its replacement must not
+ *  inherit — the demote teardown, factored so a tier swap (real → real) and
+ *  a demote (real → placeholder) release identically. */
+function teardownRealized(id, obj) {
+  promoteTail.delete(id);   // a pending heavy tail dies — the replacement earns its own
+  indexSceneMount(id, null);
+  releaseGLB(obj.userData?.glbKey ?? obj.userData?.lib);
+  cancelOwner(`entity:${id}`);
+  releaseOwner(`entity:${id}`);          // lamp requests die with the meshes
+  releaseCaster(id);
+  removeCollider(id);
+}
+
 function realizeModel(id, cur, obj) {
   const stand = entities.get(id);
-  if (isPlaceholder(stand)) {
+  if (stand && (isPlaceholder(stand) || stand.userData?.lib)) {
     // durable children attach to placeholders by design (execMount takes any
     // truthy parent) — step them out BEFORE the stand's subtree is removed,
     // and clear mountRel so the tail's execMount pass re-attaches them to the
@@ -270,10 +284,18 @@ function realizeModel(id, cur, obj) {
     // the stand itself may have ridden a carrier; the fresh clone starts
     // unattached — the tail's mountsTouching pass re-executes the linkage
     if (stand.userData.mountedTo) indexSceneMount(id, null);
+    // a real object being REPLACED (a tier swap) releases what it held; a
+    // placeholder held nothing
+    if (!isPlaceholder(stand)) teardownRealized(id, stand);
     (stand.parent ?? scene).remove(stand);   // the real thing takes the spot
   }
-  retainGLB(cur.lib);   // the proto is worn — eviction must not undress it
+  retainGLB(obj.userData.glbKey ?? cur.lib);   // the proto is worn — eviction must not undress it
   obj.userData.lib = cur.lib;
+  obj.userData.tier = obj.userData.tierServed ?? 'full';   // the server's word, not the request
+  // tierAsked rides along from loadGLB: a lod ask the server answered with the
+  // original (not baked yet, or honestly refused — 'already light') wears
+  // tier 'full' but ASKED 'lod'; the sweep compares wants against the ask, so
+  // it is not re-asked every cooldown — only when the policy flips and back.
   obj.userData.entityId = id;
   const sc = cur.scale;
   obj.position.set(...(cur.pos ?? [0, 0, 0]));
@@ -335,7 +357,10 @@ function runPromoteTail(id, obj) {
   // invisible crate-sized obstacle at the origin of every building — the mesh
   // is hidden, the collider was not. Same law as the mounted case above: an
   // entity whose collision is owned elsewhere does not get one fitted here.
-  if (!collisionOwnedElsewhere(cur, obj.userData.mountedTo)) {
+  // …and neither does a REDUCED-TIER placement: collision, support, and
+  // raycast semantics stay off the LOD mesh (#156's narrowed claim) — the
+  // full tier fits its collider when the placement upgrades on approach.
+  if (obj.userData.tier !== 'lod' && !collisionOwnedElsewhere(cur, obj.userData.mountedTo)) {
     // localFrame: the spawn transform is already applied here (unlike the
     // old at-identity fit), so the box must be computed root-local. The fit
     // buckets at the live position — the old post-transform reindexCollider
@@ -406,7 +431,7 @@ function refreshModel(id, ent) {
     obj.userData.base = { pos: obj.position.toArray(), yaw: obj.rotation.y };
   }
   if (ent.scale != null) obj.scale.setScalar(ent.scale);
-  if (!isPlaceholder(obj)) refitCollider(id);   // placeholders own no collider
+  if (!isPlaceholder(obj) && obj.userData.tier !== 'lod') refitCollider(id);   // placeholders and lod tiers own no collider
   bus.emit('entity', { id, kind: 'place' });
 }
 
@@ -450,7 +475,7 @@ function retire(id) {
   releaseOwner(`entity:${id}`);   // lamp + placed-light requests die with it
   promoteTail.delete(id);         // a pending heavy tail dies with the id
   const obj = entities.get(id);
-  if (obj && !isPlaceholder(obj) && obj.userData?.lib) releaseGLB(obj.userData.lib);
+  if (obj && !isPlaceholder(obj) && obj.userData?.lib) releaseGLB(obj.userData.glbKey ?? obj.userData.lib);
   if (obj) {
     if (obj.userData?.isLight) disposeLight(obj);
     // cargo steps off before the carrier vanishes — at the pose the FOLD
@@ -608,13 +633,31 @@ function syncBodyMounts() {
 // clone shared every GPU resource with the cached prototype, so demote frees
 // CPU and frame cost; VRAM falls when the proto itself evicts (R2).
 
+// ---- the geometry tier (#156 client contract) ------------------------------
+// Chosen BEFORE the fetch, from the resident's dial, the distance against
+// the entity's own residency radius, and device pressure (lod_policy.js).
+// The recipe comes from the RUNNING sequencer's /version — none published,
+// no tier ever asked. A lod-tier placement is VISUAL only: it owns no
+// collider, no support surface, until it upgrades to full on approach.
+let lodRecipe = null;
+lodRecipeReady.then((r) => { lodRecipe = r; }).catch(() => {});
+export const modelQuality = makeModelQuality(globalThis.localStorage);
+function tierFor(ent, current = null) {
+  return chooseTier({ dist: entDist(ent), radius: residencyRadius(ent), quality: modelQuality.quality,
+    recipe: lodRecipe, pressure: gpuPressure(), shed: modelQuality.shed, current });
+}
+/** Only a placement nothing depends on may change tier in place — the same
+ *  predicate as demotion (no riders, no seats, no part motion): a tier swap
+ *  is a demote-and-promote with the placeholder frame skipped. */
+const canRetier = (id, ent) => canDemote(id, ent);
+
 const R_BASE = 80;     // meters: promote below R, demote above R + R_HYST
 const R_HYST = 20;     // the band that keeps a walk along the edge quiet
 const DIAG_K = 4;      // big things stay: radius grows with bbox diagonal
 const DIAG_DEFAULT = 12; // assumed bbox diagonal (m) before the geom
                          // side-channel lands — err LARGE, so a big thing
                          // near the edge still loads at join (§16.2.C)
-const resStats = { demotes: 0, promotes: 0 };
+const resStats = { demotes: 0, promotes: 0, retiers: 0 };
 
 function residencyRadius(ent) {
   const s = ent?.lib ? libGeom.get(ent.lib)?.bbox?.size : null;
@@ -668,14 +711,7 @@ function canDemote(id, ent) {
 function demote(id) {
   const ent = state.st.entities[id];
   const obj = entities.get(id);
-  promoteTail.delete(id);   // a demoted stand-in must not inherit the real
-                            // model's collider/lamps — the pending tail dies
-  indexSceneMount(id, null);   // belt: canDemote refuses mounted children
-  if (obj.userData?.lib) releaseGLB(obj.userData.lib);
-  cancelOwner(`entity:${id}`);
-  releaseOwner(`entity:${id}`);          // lamp requests die with the meshes
-  releaseCaster(id);
-  removeCollider(id);                    // far beyond interaction range by construction
+  teardownRealized(id, obj);   // a demoted stand-in must not inherit the real model's collider/lamps
   (obj.parent ?? scene).remove(obj);
   const grp = makePlaceholder(id, ent, libGeom.get(ent.lib));
   entities.set(id, grp);
@@ -704,6 +740,20 @@ function residencySweep() {
     const d = entDist(ent);
     if (obj && !isPlaceholder(obj) && d > R + R_HYST) {
       if (canDemote(id, ent)) demote(id);
+    // inside the radius, a realized placement may want the OTHER tier now —
+    // walked toward (full), walked away from (lod), pressure came or went.
+    // Hysteresis lives in the policy; the cooldown keeps a swap from
+    // stacking on its own in-flight load. The new tier loads first and
+    // replaces in place (realizeModel) — no placeholder frame in between.
+    } else if (obj && !isPlaceholder(obj) && !t.loading && obj.userData.lib) {
+      const asked = obj.userData.tierAsked ?? obj.userData.tier ?? 'full';
+      const want = tierFor(ent, asked);
+      if (want !== asked && now - (t.retierAt ?? 0) > 5000 && canRetier(id, ent)) {
+        t.retierAt = now;
+        resStats.retiers++;
+        t.gen = nextGen++;
+        scheduleLoad(id, ent, t.gen, want);
+      }
     // BOTH stand-in shapes promote by distance: the join gate leaves far
     // entities as bare null reservations (no geom yet, or a geom-less lib
     // that never grows a placeholder) — if only placeholders promoted, a
@@ -730,7 +780,12 @@ export const residencyDebug = () => {
     else if (isPlaceholder(obj)) standins++;
     else if (obj) real++;
   }
-  return { real, standins, loading, waiting, ...resStats, rBase: R_BASE, rHyst: R_HYST };
+  let lod = 0, lodAsked = 0;   // served vs asked: the gap is the server's honest fall-throughs
+  for (const obj of entities.values()) {
+    if (obj?.userData?.tier === 'lod') lod++;
+    if (obj?.userData?.tierAsked === 'lod') lodAsked++;
+  }
+  return { real, standins, loading, waiting, lod, lodAsked, quality: modelQuality.quality, recipe: lodRecipe, ...resStats, rBase: R_BASE, rHyst: R_HYST };
 };
 
 // ---- reconcile + dispatch ---------------------------------------------------

--- a/client/lib/realize/models.js
+++ b/client/lib/realize/models.js
@@ -671,6 +671,18 @@ function tierFor(ent, current = null) {
   return chooseTier({ dist: entDist(ent), radius: residencyRadius(ent), quality: modelQuality.quality,
     recipe: lodNegotiable(ent?.lib) ? lodRecipe : null, pressure: gpuPressure(), shed: modelQuality.shed, current });
 }
+/** The models⚙ row's whole behaviour — skypanel.js binds it to the row and
+ *  shows what it returns: set the resident's dial, and say honestly whether
+ *  a reduced tier can be asked from this browser at all (the variant's
+ *  textures are KTX2: no transcoder, or a sequencer that published no
+ *  recipe, and every placement stays full detail). Out of the DOM so the
+ *  product-door harness gates it (tools/lod-client-test). */
+export function dialModelQuality(v) {
+  const q = modelQuality.setQuality(v);
+  return lodNegotiable('eidoverse/assets/models/any.glb')
+    ? `models: ${q} (yours only)`
+    : `models: ${q} (yours only) — reduced tiers cannot be asked from this browser; everything stays full detail`;
+}
 /** Only a placement nothing depends on may change tier in place — the same
  *  predicate as demotion (no riders, no seats, no part motion): a tier swap
  *  is a demote-and-promote with the placeholder frame skipped. */

--- a/client/lib/realize/models.js
+++ b/client/lib/realize/models.js
@@ -23,7 +23,8 @@
 
 import { THREE, scene, camera } from '../core.js';
 import { report, bus } from '../base.js';
-import { loadGLB, retainGLB, releaseGLB, evictIdleProtos, lodRecipeReady, gpuPressure } from '../assets.js';
+import { loadGLB, retainGLB, releaseGLB, evictIdleProtos, lodRecipeReady, gpuPressure,
+  lodNegotiable, negotiationReady } from '../assets.js';
 import { makeModelQuality, chooseTier } from '../lod_policy.js';
 import { colliders, fitCollider, removeCollider, reindexCollider, refitCollider } from '../colliders.js';
 import { attachLamps, releaseOwner, registerCaster, releaseCaster } from '../lightrig.js';
@@ -207,7 +208,7 @@ function createModel(id, ent) {
   scheduleLoad(id, ent, gen);
 }
 
-function scheduleLoad(id, ent, gen, tier = tierFor(ent, null)) {
+function scheduleLoad(id, ent, gen, tier = null) {
   const t0 = tracked.get(id);
   if (t0) t0.loading = true;   // the sweep must not re-promote a load in flight
   schedule({
@@ -217,7 +218,14 @@ function scheduleLoad(id, ent, gen, tier = tierFor(ent, null)) {
     priority: () => bandForDistance(camera.position.distanceTo(
       _v.set(...(state.st.entities[id]?.pos ?? [0, 0, 0])))),
     run: async (signal) => {
-      const obj = await loadGLB(ent.lib, { tier });
+      // a first load chooses its tier at DEQUEUE, once /version has answered
+      // (key and recipe are what make a lod ask real — assets.js
+      // lodNegotiable) and from the live distance; a re-tier brings the tier
+      // the sweep chose
+      await negotiationReady;
+      if (signal.aborted) return;
+      const want = tier ?? tierFor(ent, null);
+      const obj = await loadGLB(ent.lib, { tier: want });
       const cur = state.st.entities[id];
       const t = tracked.get(id);
       if (t?.gen === gen) t.loading = false;
@@ -228,6 +236,20 @@ function scheduleLoad(id, ent, gen, tier = tierFor(ent, null)) {
       if (!cur || cur.kind === 'light' || cur.lib !== ent.lib) {
         clearReservation(id);
         if (tracked.get(id)?.gen === gen) tracked.delete(id);
+        return;
+      }
+      // a TIER SWAP replaces a REAL object, and authority is re-checked at
+      // the moment of application, not only when the sweep scheduled it
+      // (review of #170, point 3): while the bytes flew a body may have sat
+      // down, cargo mounted, a part motion or socket arrived, an edit hold
+      // begun — each makes the swap illegal now. The loaded clone is simply
+      // not worn (nothing was retained for it; the proto stays pooled) and
+      // the standing object keeps its collider, lamps, riders and mounts.
+      // The sweep may try again after its cooldown, through the same gate.
+      const standing = entities.get(id);
+      if (standing && !isPlaceholder(standing) && standing.userData?.lib && !canRetier(id, cur)) {
+        resStats.retiersRefused++;
+        if (t) t.retierAt = Date.now();
         return;
       }
       realizeModel(id, cur, obj);
@@ -643,8 +665,11 @@ let lodRecipe = null;
 lodRecipeReady.then((r) => { lodRecipe = r; }).catch(() => {});
 export const modelQuality = makeModelQuality(globalThis.localStorage);
 function tierFor(ent, current = null) {
+  // the recipe counts only where a lod ask can cross the wire (assets.js
+  // lodNegotiable: transcoder + key + recipe + a .glb) — elsewhere the
+  // policy sees no recipe, and nothing is asked or reported as asked
   return chooseTier({ dist: entDist(ent), radius: residencyRadius(ent), quality: modelQuality.quality,
-    recipe: lodRecipe, pressure: gpuPressure(), shed: modelQuality.shed, current });
+    recipe: lodNegotiable(ent?.lib) ? lodRecipe : null, pressure: gpuPressure(), shed: modelQuality.shed, current });
 }
 /** Only a placement nothing depends on may change tier in place — the same
  *  predicate as demotion (no riders, no seats, no part motion): a tier swap
@@ -657,7 +682,7 @@ const DIAG_K = 4;      // big things stay: radius grows with bbox diagonal
 const DIAG_DEFAULT = 12; // assumed bbox diagonal (m) before the geom
                          // side-channel lands — err LARGE, so a big thing
                          // near the edge still loads at join (§16.2.C)
-const resStats = { demotes: 0, promotes: 0, retiers: 0 };
+const resStats = { demotes: 0, promotes: 0, retiers: 0, retiersRefused: 0 };
 
 function residencyRadius(ent) {
   const s = ent?.lib ? libGeom.get(ent.lib)?.bbox?.size : null;
@@ -723,7 +748,9 @@ function demote(id) {
 }
 
 let lastEvict = 0;
-function residencySweep() {
+/** One residency beat (initModelsRealizer runs it at 2Hz; exported so a
+ *  headless harness can beat it deterministically — tools/lod-client-test). */
+export function residencySweep() {
   // the VRAM tier (R2): every ~5s, if GPU memory is over budget, zero-ref
   // protos dispose. Self-gating and usually a no-op single number read.
   const now = Date.now();

--- a/client/lib/skypanel.js
+++ b/client/lib/skypanel.js
@@ -18,6 +18,8 @@ import { previewSky, skyArgs, skyImpl, WEATHERS, CLOUDS, SKY_WORLDS,
 import { GRASS_QUALITY, getGrassQuality, setGrassQuality,
   getGrassDensity, getGrassShed, getGrassApplied } from './terrain.js';
 import { RENDER_SCALES, getRenderScale, setRenderScale } from './governor.js';
+import { MODEL_QUALITY } from './lod_policy.js';
+import { modelQuality } from './realize/models.js';
 
 const SLIDERS = [
   ['hours', 'time', 0, 24, 0.1, 12],
@@ -187,6 +189,22 @@ export function paintSky(body) {
   rs.setAttribute('aria-label', 'render scale — local only, never shared with the world');
   rsRow.title = 'local performance setting — not shared with the world';
   body.appendChild(rsRow);
+
+  // The geometry tier is YOURS too (#156): which version of each placed
+  // object THIS machine fetches. 'auto' reduces far objects, sooner under
+  // GPU pressure; 'full' never reduces; 'eco' reduces sooner always (the
+  // pressured band) — no dial reduces what you stand beside. Bodies are
+  // never reduced (server contract). Persisted; never a verb.
+  const { row: mqRow, select: mq } = selectRow('models⚙',
+    MODEL_QUALITY.map((v) => [v, v === 'auto' ? 'auto' : v === 'full' ? 'full detail' : 'eco (reduce sooner)']),
+    modelQuality.quality,
+    (v) => {
+      modelQuality.setQuality(v);
+      flashHint(`models: ${v} (yours only)`);
+    });
+  mq.setAttribute('aria-label', 'model detail tier — local only, never shared with the world');
+  mqRow.title = 'local performance setting — not shared with the world';
+  body.appendChild(mqRow);
 
   // Sliders that only the BASIC sky answers. On the real sky the engine owns
   // sun direction and supplies its own bounce fill (sky.js documents the

--- a/client/lib/skypanel.js
+++ b/client/lib/skypanel.js
@@ -19,6 +19,7 @@ import { GRASS_QUALITY, getGrassQuality, setGrassQuality,
   getGrassDensity, getGrassShed, getGrassApplied } from './terrain.js';
 import { RENDER_SCALES, getRenderScale, setRenderScale } from './governor.js';
 import { MODEL_QUALITY } from './lod_policy.js';
+import { lodNegotiable } from './assets.js';
 import { modelQuality } from './realize/models.js';
 
 const SLIDERS = [
@@ -200,7 +201,13 @@ export function paintSky(body) {
     modelQuality.quality,
     (v) => {
       modelQuality.setQuality(v);
-      flashHint(`models: ${v} (yours only)`);
+      // the dial persists regardless; the hint says whether a reduced tier
+      // can be ASKED from this browser at all (the variant's textures are
+      // KTX2 — no transcoder, or a sequencer that published no recipe, and
+      // every placement stays full detail; assets.js lodNegotiable)
+      flashHint(lodNegotiable('eidoverse/assets/models/any.glb')
+        ? `models: ${v} (yours only)`
+        : `models: ${v} (yours only) — reduced tiers cannot be asked from this browser; everything stays full detail`);
     });
   mq.setAttribute('aria-label', 'model detail tier — local only, never shared with the world');
   mqRow.title = 'local performance setting — not shared with the world';

--- a/client/lib/skypanel.js
+++ b/client/lib/skypanel.js
@@ -19,8 +19,7 @@ import { GRASS_QUALITY, getGrassQuality, setGrassQuality,
   getGrassDensity, getGrassShed, getGrassApplied } from './terrain.js';
 import { RENDER_SCALES, getRenderScale, setRenderScale } from './governor.js';
 import { MODEL_QUALITY } from './lod_policy.js';
-import { lodNegotiable } from './assets.js';
-import { modelQuality } from './realize/models.js';
+import { modelQuality, dialModelQuality } from './realize/models.js';
 
 const SLIDERS = [
   ['hours', 'time', 0, 24, 0.1, 12],
@@ -199,16 +198,10 @@ export function paintSky(body) {
   const { row: mqRow, select: mq } = selectRow('models⚙',
     MODEL_QUALITY.map((v) => [v, v === 'auto' ? 'auto' : v === 'full' ? 'full detail' : 'eco (reduce sooner)']),
     modelQuality.quality,
-    (v) => {
-      modelQuality.setQuality(v);
-      // the dial persists regardless; the hint says whether a reduced tier
-      // can be ASKED from this browser at all (the variant's textures are
-      // KTX2 — no transcoder, or a sequencer that published no recipe, and
-      // every placement stays full detail; assets.js lodNegotiable)
-      flashHint(lodNegotiable('eidoverse/assets/models/any.glb')
-        ? `models: ${v} (yours only)`
-        : `models: ${v} (yours only) — reduced tiers cannot be asked from this browser; everything stays full detail`);
-    });
+    // the whole behaviour lives in models.js (dialModelQuality: set, persist,
+    // and say whether a reduced tier can be asked from this browser at all)
+    // so the product-door harness gates it; this row only binds and shows
+    (v) => flashHint(dialModelQuality(v)));
   mq.setAttribute('aria-label', 'model detail tier — local only, never shared with the world');
   mqRow.title = 'local performance setting — not shared with the world';
   body.appendChild(mqRow);

--- a/tools/lod-client-stub.mjs
+++ b/tools/lod-client-stub.mjs
@@ -90,6 +90,41 @@ export const makeLight = () => new THREE_.Group();
 export const updateLight = () => {};
 export const disposeLight = () => {};
 
+// ---- the governor's cone (governor.js is REAL in the harness) ---------------
+// core.js extras: the sun and the pixel-ratio base the 'detail' / 'pixels'
+// levers touch
+export const sun = { shadow: { mapSize: { width: 2048, set() {} }, map: null } };
+export const BASE_PIXEL_RATIO = 1;
+renderer.setPixelRatio = () => {};
+renderer.getPixelRatio = () => 1;
+// warmqueue.js / loadwork.js: never loading — the governor's grace never holds
+export const warmStats = () => ({ pending: 0, running: false });
+export const warm = (label, fn) => Promise.resolve().then(fn);
+export const laneBusy = () => false;
+// lightrig.js / emitters.js / terrain.js / frame.js / remotes.js: every lever
+// BELOW 'lod' in the ladder answers "nothing to shed", so a slow window
+// reaches the lod lever deterministically
+export const setSlotCap = () => {};
+export const getSlotCap = () => 0;
+export const maxSlots = () => 0;
+export const litCount = () => 0;
+export const setCasterBudget = () => {};
+export const getCasterBudget = () => 2;
+export const casterCount = () => 0;
+export const setEmitterQuality = () => false;
+export const emitterQuality = () => 'auto';
+export const emitterCount = () => 0;
+export const setGrassDensity = () => {};
+export const getGrassDensity = () => 1;
+export const hasGrass = () => false;
+export const setLodBias = () => {};
+const every = { autos: 2 };
+export const setSystemEvery = (k, v) => { every[k] = v; };
+export const getSystemEvery = (k) => every[k] ?? 1;
+// ui.js: toasts recorded
+export const toasts = [];
+export const toast = (msg, kind, ms) => { toasts.push({ msg, kind, ms }); };
+
 // ---- world.js (its maps) ----------------------------------------------------
 export const entities = new Map();
 export const entityMeta = new Map();

--- a/tools/lod-client-stub.mjs
+++ b/tools/lod-client-stub.mjs
@@ -1,0 +1,103 @@
+// tools/lod-client-stub.mjs — the realizer's dependency cone, stubbed for
+// tools/lod-client-test.ts. client/lib/realize/models.js is REAL there; so
+// are lod_policy.js, models_field.js, state.js (the fold), scheduler.js and
+// base.js (the bus). This one file stands in for:
+//
+//   core.js      a WebGPURenderer at import time — here a bare scene and camera
+//   assets.js    the loader — the WIRE truth (askFor) decides the tier a load
+//                IS, a pretend sequencer answers a stamped variant when it
+//                "baked" one and the original otherwise, and the test can
+//                HOLD every load open and release it by hand, so a tier swap
+//                can be caught mid-flight
+//   colliders.js / lightrig.js / lights.js — recorded, never built
+//   world.js     its maps only (entities, mounts, edit holds, findPart)
+//
+// Every side effect the test asserts on is a plain array or Map here.
+import * as THREE_ from '../client/node_modules/three/build/three.module.js';
+import { askFor, tierOf } from '../client/lib/lod_policy.js';
+
+// ---- core.js ----------------------------------------------------------------
+// makePlaceholder wants the node material class from three/webgpu; the
+// stand-in's material is never rendered here
+export const THREE = { ...THREE_, MeshBasicNodeMaterial: THREE_.MeshBasicMaterial };
+export const scene = new THREE_.Scene();
+export const camera = new THREE_.PerspectiveCamera();
+export const renderer = { info: { memory: { total: 0 } }, domElement: null };
+export const reports = [];
+export const report = (where, e) => { reports.push({ where, e }); };
+export const CONFIG = {};
+
+// ---- assets.js --------------------------------------------------------------
+/** The pretend sequencer + browser: what /version published, whether this
+ *  "browser" transcodes KTX2, and which libs have a baked variant. Mutable —
+ *  a section flips them and spawns fresh placements. */
+export const server = { key: '3', recipe: 'lod1-r25e01-texel1024', capable: true, variants: new Set() };
+/** Every loadGLB call, in order: { lib, tier (what crossed the wire), url }. */
+export const loads = [];
+/** Loads held open while `hold` is on: { lib, tier, url, release() }. */
+export const held = [];
+let hold = false;
+export const setHold = (v) => { hold = !!v; };
+let pressure = 0;
+export const setPressure = (p) => { pressure = p; };
+export const gpuPressure = () => pressure;
+export const retained = new Map();
+export const released = [];
+export const retainGLB = (k) => retained.set(k, (retained.get(k) ?? 0) + 1);
+export const releaseGLB = (k) => { released.push(k); retained.set(k, (retained.get(k) ?? 0) - 1); };
+export const evictIdleProtos = async () => 0;
+export const ktx2KeyReady = Promise.resolve(server.key);
+export const lodRecipeReady = Promise.resolve(server.recipe);
+export const negotiationReady = Promise.resolve();
+export const lodNegotiable = (lib) =>
+  askFor({ libPath: lib, key: server.key, capable: server.capable, recipe: server.recipe, tier: 'lod' }).tier === 'lod';
+/** The loader as the realizer sees it. Identity stamps are the real
+ *  loader's: glbKey (the cache entry worn), tierServed (tierOf over what the
+ *  "server" answered, bound to the running recipe), tierAsked (the wire). */
+export async function loadGLB(lib, { tier = 'full' } = {}) {
+  const ask = askFor({ libPath: lib, key: server.key, capable: server.capable, recipe: server.recipe, tier });
+  const rec = { lib, tier: ask.tier, url: ask.url };
+  loads.push(rec);
+  if (hold) await new Promise((release) => held.push({ ...rec, release }));
+  // the answer: a stamped variant for a lib the sequencer baked, the
+  // original chain (extras untouched — none here) otherwise
+  const json = ask.tier === 'lod' && server.variants.has(lib)
+    ? { asset: { extras: { lodOf: `sha-${lib}`, recipe: server.recipe, tools: { meshoptimizer: 'x', encoder: 'none' } } } }
+    : { asset: { extras: {} } };
+  const g = new THREE_.Group();
+  g.add(new THREE_.Mesh(new THREE_.BoxGeometry(1, 1, 1), new THREE_.MeshBasicMaterial()));
+  g.userData.glbKey = ask.tier === 'lod' ? `${lib}#lod` : lib;
+  g.userData.tierServed = tierOf(json, server.recipe);
+  g.userData.tierAsked = ask.tier;
+  return g;
+}
+
+// ---- colliders.js -----------------------------------------------------------
+export const colliders = new Map();
+/** ['fit' | 'remove' | 'refit', id] in order. */
+export const colliderLog = [];
+export const fitCollider = (id, obj, opts) => { colliders.set(id, { obj, opts }); colliderLog.push(['fit', id]); };
+export const removeCollider = (id) => { colliders.delete(id); colliderLog.push(['remove', id]); };
+export const refitCollider = (id) => { colliderLog.push(['refit', id]); };
+export const reindexCollider = () => {};
+
+// ---- lightrig.js / lights.js ------------------------------------------------
+export const attachLamps = () => {};
+export const releaseOwner = () => {};
+export const registerCaster = () => {};
+export const releaseCaster = () => {};
+export const makeLight = () => new THREE_.Group();
+export const updateLight = () => {};
+export const disposeLight = () => {};
+
+// ---- world.js (its maps) ----------------------------------------------------
+export const entities = new Map();
+export const entityMeta = new Map();
+export const comps = new Map();
+export const avatarMounts = new Map();
+export const editHolds = new Set();
+export function findPart(root, name) {
+  let hit = null;
+  root?.traverse?.((o) => { if (!hit && o.name === name) hit = o; });
+  return hit;
+}

--- a/tools/lod-client-test.ts
+++ b/tools/lod-client-test.ts
@@ -1,0 +1,346 @@
+// lod-client-test — the product door of #170, headless and owned.
+//
+//   bun tools/lod-client-test.ts
+//
+// What the pure chooser (tools/lod-policy-test.ts) cannot say: that the
+// resident's dial, the residency sweep, the loader's wire, the sequencer's
+// answer, the in-place replacement and the collider all AGREE. Review of
+// #170, point 4 — "the committed receipt stops at the pure chooser".
+//
+// Two halves. The REALIZER half runs the real client/lib/realize/models.js
+// (with the real policy, fold, scheduler and bus) over a stub of its
+// dependency cone — tools/lod-client-stub.mjs: no renderer; a loader whose
+// tier is the WIRE truth (askFor), whose "sequencer" answers a stamped
+// variant for libs it baked and the original otherwise, and which the test
+// can hold open and release by hand, so a tier swap is caught mid-flight;
+// colliders recorded, never built. The WIRE half spawns a sequencer child
+// PROCESS-OWNED (WORLD_INSTANCE_NONCE, as object-lod-test does) over a
+// fixture library and pushes the exact URLs the loader would send through
+// it — capable, incapable, wrong generation, an authored `recipe` extra —
+// reading the served tier with the same tierOf the loader uses.
+//
+// Negative controls, each named in its check: the churn of the first field
+// run (an "already light" answer re-asked every cooldown), a held tier swap
+// landing over a rider / cargo / a part motion / an edit hold, a lod ask a
+// non-KTX2 browser reports without ever sending, an authored `recipe`
+// extra read as a served lod. Dies at import on main (no lod_policy.js).
+import { plugin } from 'bun';
+import { fileURLToPath } from 'node:url';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn as spawnProc, type ChildProcess } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const STUB = fileURLToPath(new URL('./lod-client-stub.mjs', import.meta.url));
+plugin({
+  name: 'lod-client-stub',
+  setup(b) {
+    for (const f of ['^\\.\\./core\\.js$', '^\\.\\./assets\\.js$', '^\\.\\./colliders\\.js$',
+      '^\\.\\./lightrig\\.js$', '^\\.\\./lights\\.js$', '^\\.\\./world\\.js$']) {
+      b.onResolve({ filter: new RegExp(f) }, () => ({ path: STUB }));
+    }
+  },
+});
+// the dial persists through localStorage — a Map-backed one, inspectable
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => { store.set(k, v); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+const stub: any = await import('./lod-client-stub.mjs');
+const M: any = await import('../client/lib/realize/models.js');
+const S: any = await import('../client/lib/state.js');
+const { emptyState } = await import('../shared/fold.js');
+const { bus } = await import('../client/lib/base.js');
+const { makeModelQuality, askFor, tierOf } = await import('../client/lib/lod_policy.js');
+const { keyFromVersion, lodFromVersion, negotiate, withLod } = await import('../shared/ktx2.js');
+const { LOD_RECIPE } = await import('../server/store-variants.ts');
+const rig: any = await import('./rig-load.mjs');
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(`  ${ok ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m'} ${label}${!ok && detail ? `\n      ${detail}` : ''}`);
+  if (!ok) failures++;
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Let the scheduler's microtask pump and the stub loader run out. */
+const settle = async () => { for (let i = 0; i < 6; i++) await sleep(15); };
+const until = async (pred: () => boolean, ms: number) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) { if (pred()) return true; await sleep(250); }
+  return pred();
+};
+
+// ============================================================================
+console.log('\nlod-client — the realizer half (real models.js over a held loader)\n');
+
+const REC = stub.server.recipe as string;
+const enc = encodeURIComponent(REC);
+const lib = (id: string) => `eidoverse/assets/models/${id}.glb`;
+const GEOM = { bbox: { size: [1, 1, 1], center: [0, 0.5, 0] } };   // diag 1.73 → R ≈ 86.9m, auto edge ≈ 39m, halved ≈ 19.5m
+let seq = 1;
+const fold = (verb: string, args: any) => S.foldLive({ seq: seq++, ts: 1_000_000 + seq, actor: 't', verb, args });
+/** Place an entity on the z axis, `z` metres from the camera at the origin.
+ *  Each id has its own lib, so loads and variants attribute per placement. */
+const spawnAt = (id: string, z: number, variant = true) => {
+  if (variant) stub.server.variants.add(lib(id));
+  bus.emit('lib-geom', { [lib(id)]: GEOM });   // the geom side-channel, landed
+  fold('spawn', { id, lib: lib(id), pos: [0, 0, z] });
+};
+const obj = (id: string) => stub.entities.get(id);
+const loadsOf = (id: string) => stub.loads.filter((l: any) => l.lib === lib(id));
+const drain = () => { for (let i = 0; i < 50 && M.promoteTailPending() > 0; i++) M.drainPromoteTail(); };
+const res = () => M.residencyDebug();
+
+M.initModelsRealizer();          // geom side-channel + fold wiring (+ a 2Hz beat we ignore: we beat by hand)
+S.hydrate(emptyState(), [], 0);
+stub.camera.position.set(0, 0, 0);
+
+// ---- 1. the join: tiers chosen before the fetch, from distance against the entity's own radius
+{
+  spawnAt('near', 5);
+  spawnAt('far', 70);
+  spawnAt('light', 70, false);   // far, but the sequencer has no variant — its "already light" refusal answers the original
+  await settle();
+  check('three placements realized', res().real === 3, JSON.stringify(res()));
+  check('near (5m) asked FULL — a plain ktx2 fetch', loadsOf('near')[0]?.tier === 'full' && loadsOf('near')[0]?.url === `${lib('near')}?ktx2=3`, loadsOf('near')[0]?.url);
+  check('far (70m) asked LOD — the recipe rides the ktx2 negotiation on the wire', loadsOf('far')[0]?.tier === 'lod' && loadsOf('far')[0]?.url === `${lib('far')}?ktx2=3&lod=${enc}`, loadsOf('far')[0]?.url);
+  check('far wears the served lod: asked lod, served lod', obj('far')?.userData.tierAsked === 'lod' && obj('far')?.userData.tier === 'lod');
+  check('light asked lod, was answered the original, wears FULL honestly', obj('light')?.userData.tierAsked === 'lod' && obj('light')?.userData.tier === 'full');
+  check('EW.residency(): lod 1 (served) / lodAsked 2 (asked) — the gap is the sequencer\'s honest fall-through', res().lod === 1 && res().lodAsked === 2, JSON.stringify(res()));
+  drain();
+  check('the promote tail fits colliders for the full tiers only — the reduced mesh owns NO collider',
+    stub.colliders.has('near') && stub.colliders.has('light') && !stub.colliders.has('far'), JSON.stringify(stub.colliderLog));
+  // the churn control (the first field run: 21 re-tiers in 100s)
+  const nLoads = stub.loads.length;
+  for (let i = 0; i < 4; i++) { M.residencySweep(); await settle(); }
+  check('four beats later nothing re-asked: an "already light" answer is NOT re-fetched every cooldown (hysteresis keys on the ASK)',
+    stub.loads.length === nLoads && res().retiers === 0, `loads ${nLoads}→${stub.loads.length}, retiers ${res().retiers}`);
+}
+
+// ---- 2. the dial: persisted locally, never a verb; a flip re-tiers in place
+{
+  const worldBefore = JSON.stringify(S.state.st);
+  const farBefore = obj('far');
+  M.modelQuality.setQuality('full');
+  check('the dial persists in THIS browser (localStorage) and reads back on the next boot',
+    store.get('ew-model-quality') === 'full' && makeModelQuality(globalThis.localStorage).quality === 'full');
+  M.residencySweep(); await settle();
+  const last = loadsOf('far').at(-1);
+  check('"full detail" re-tiers far in place: a FULL load, the old lod proto released, the new object worn',
+    last?.tier === 'full' && obj('far') !== farBefore && obj('far')?.userData.tierAsked === 'full'
+    && stub.released.includes(`${lib('far')}#lod`), JSON.stringify({ last, retiers: res().retiers }));
+  // light wore the original already, but its ASK was lod — under "full detail" the ask must be full,
+  // so it re-asks once (a plain ktx2 fetch), and that is also how a provisional answer picks up a
+  // later bake: the ask flips, the wire asks again. Two re-tiers: far and light.
+  check('light (asked lod, wearing the original) re-asks FULL once — the ask is what the dial commands, and that is the path a later bake rides',
+    res().retiers === 2 && loadsOf('light').at(-1)?.tier === 'full' && obj('light')?.userData.tierAsked === 'full', JSON.stringify(res()));
+  drain();
+  check('…and the full tier earns its collider on landing', stub.colliders.has('far'), JSON.stringify(stub.colliderLog.slice(-3)));
+  check('the world fold is byte-identical: the dial and the swap wrote NOTHING shared', JSON.stringify(S.state.st) === worldBefore);
+
+  spawnAt('mid', 25);   // under "full": a full load, 25m inside the auto edge anyway
+  await settle();
+  check('mid (25m) joined full', obj('mid')?.userData.tierAsked === 'full');
+  M.modelQuality.setQuality('eco');
+  M.residencySweep(); await settle();
+  check('"eco" halves the edge: mid (25m > 19.5m) re-tiers to LOD; near (5m) stays full — no dial reduces what you stand beside',
+    obj('mid')?.userData.tierAsked === 'lod' && obj('mid')?.userData.tier === 'lod' && loadsOf('near').length === 1,
+    JSON.stringify({ mid: obj('mid')?.userData.tierAsked, nearLoads: loadsOf('near').length }));
+  M.modelQuality.setQuality('auto');
+}
+
+// ---- 3. a browser that cannot ask: the wire decides, and reports honestly (review point 2)
+{
+  const askedBefore = res().lodAsked;
+  stub.server.capable = false;             // no KTX2 transcoder in this browser
+  spawnAt('nolod', 70);
+  await settle();
+  const l = loadsOf('nolod')[0];
+  check('no transcoder: far placement loads FULL with NO lod= (and no ktx2=) on the wire', l?.tier === 'full' && l?.url === lib('nolod'), l?.url);
+  check('…and is reported as never asked: tierAsked full, lodAsked unchanged', obj('nolod')?.userData.tierAsked === 'full' && res().lodAsked === askedBefore);
+  M.modelQuality.setQuality('eco');
+  for (let i = 0; i < 2; i++) { M.residencySweep(); await settle(); }
+  check('even on "eco" it never re-asks: the policy sees no recipe where none can cross the wire', loadsOf('nolod').length === 1);
+  M.modelQuality.setQuality('auto');
+  stub.server.capable = true;
+  stub.server.recipe = null;               // a sequencer that published no recipe
+  spawnAt('norecipe', 70);
+  await settle();
+  const n = loadsOf('norecipe')[0];
+  check('no recipe published: ktx2 negotiates, lod does not — a plain ktx2 fetch, asked full', n?.tier === 'full' && n?.url === `${lib('norecipe')}?ktx2=3`, n?.url);
+  stub.server.recipe = REC;
+}
+
+// ---- 4. a tier swap is re-authorized at APPLICATION, not only when scheduled (review point 3)
+console.log('\n  held swaps — a dependency arrives while the bytes fly\n');
+/** Join reduced at 70m, walk it to 10m (a `place`), catch the FULL load in
+ *  flight, let `dep` land, then release the load. Returns what stood before. */
+async function heldSwap(id: string, dep: null | ((id: string) => void)) {
+  spawnAt(id, 70); await settle();
+  const before = obj(id);
+  check(`${id}: joined reduced (asked lod, served lod)`, before?.userData.tierAsked === 'lod' && before?.userData.tier === 'lod');
+  const mark = stub.colliderLog.length;
+  const refusedBefore = res().retiersRefused, retiersBefore = res().retiers;
+  stub.setHold(true);
+  fold('place', { id, pos: [0, 0, 10] });   // walked toward: 10m < the inner edge (29m) → the sweep wants full
+  M.residencySweep(); await settle();
+  const h = stub.held.find((x: any) => x.lib === lib(id));
+  // per-placement: other placements may legitimately re-tier in the same beat (a browser that
+  // regained KTX2 re-asks its far ones), so count THIS lib's loads, not the global counter
+  check(`${id}: the FULL load is in flight, held`, !!h && h.tier === 'full' && loadsOf(id).length === 2 && res().retiers > retiersBefore,
+    JSON.stringify({ held: !!h, loads: loadsOf(id).length }));
+  dep?.(id);                                 // …and now the world moves
+  await settle();
+  for (const x of stub.held.splice(0)) x.release();
+  stub.setHold(false);
+  await settle();
+  drain();
+  return { before, mark, refusedBefore };
+}
+const sinceMark = (mark: number, id: string) => stub.colliderLog.slice(mark).filter((e: any) => e[1] === id).map((e: any) => e[0]);
+
+{ // the control: nothing intervenes → the swap lands
+  const { before, mark } = await heldSwap('ctl', null);
+  check('control: with nothing riding, the held swap LANDS — new object, asked full, old lod proto released, collider fitted',
+    obj('ctl') !== before && obj('ctl')?.userData.tierAsked === 'full' && stub.released.includes(`${lib('ctl')}#lod`)
+    && sinceMark(mark, 'ctl').includes('fit'), JSON.stringify(sinceMark(mark, 'ctl')));
+}
+const deps: [string, (id: string) => void][] = [
+  ['a body sits on it (avatarMounts)', (id) => stub.avatarMounts.set(`rider-of-${id}`, { to: id })],
+  ['cargo mounts on it (a `mount` verb folds parent.to)', (id) => { spawnAt(`cargo-${id}`, 10); fold('mount', { id: `cargo-${id}`, to: id }); }],
+  ['a part motion arrives (comp.motion.part)', (id) => fold('motion', { id, type: 'swing', part: 'Door', axis: [0, 1, 0], amp: 0.3, period: 2 })],
+  ['an edit hold begins (editHolds)', (id) => stub.editHolds.add(id)],
+];
+let k = 0;
+for (const [what, dep] of deps) {
+  const id = `held${k++}`;
+  const { before, mark, refusedBefore } = await heldSwap(id, dep);
+  const same = obj(id) === before;
+  check(`${what}: the loaded clone is NOT worn — the standing object stays, asked lod, collider untouched, refusal counted`,
+    same && obj(id)?.userData.tierAsked === 'lod' && sinceMark(mark, id).length === 0 && res().retiersRefused === refusedBefore + 1,
+    JSON.stringify({ same, asked: obj(id)?.userData.tierAsked, colliderOps: sinceMark(mark, id), refused: res().retiersRefused - refusedBefore }));
+}
+check('no realizer error was reported through the whole realizer half', stub.reports.length === 0,
+  stub.reports.map((r: any) => `${r.where}: ${r.e?.message ?? r.e}`).join(' | '));
+
+// ============================================================================
+console.log('\nlod-client — the wire half (an OWNED sequencer answers the loader\'s exact URLs)\n');
+
+const ROOT = resolve(import.meta.dir, '..');
+const OPT = join(ROOT, 'assets', 'opt');
+const NOWHERE = mkdtempSync(join(tmpdir(), 'ew-lodc-nowhere-'));   // no encoder anywhere: an untextured fixture reduces without one
+const LIB = mkdtempSync(join(tmpdir(), 'ew-lodc-lib-'));
+mkdirSync(join(LIB, 'eidoverse', 'assets', 'models'), { recursive: true });
+const HEAVY = 'eidoverse/assets/models/lod_client_heavy.glb';        // 161² verts → reduced
+const AUTHORED = 'eidoverse/assets/models/lod_client_authored.glb';  // 81 verts, with an AUTHORED `recipe` extra equal to the running one
+const mine = [HEAVY, AUTHORED].flatMap((r) => [`${r}.lod.${LOD_RECIPE}.glb`, `${r}.lod.${LOD_RECIPE}.glb.failed`, `${r}.ktx2.glb`, `${r}.ktx2.glb.failed`]);
+let child: ChildProcess | null = null;
+const cleanup = () => {
+  try { child?.kill(); } catch { /* gone */ }
+  for (const rel of mine) try { rmSync(join(OPT, rel), { force: true }); } catch { /* best effort */ }
+  for (const d of [LIB, NOWHERE]) try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+};
+process.on('exit', cleanup);
+
+async function gridGlb(tag: string, cells: number, extras: object | null): Promise<Uint8Array> {
+  const { Document, NodeIO } = await import('@gltf-transform/core');
+  const doc = new Document();
+  if (extras) doc.getRoot().getAsset().extras = extras;
+  const buf = doc.createBuffer();
+  const n = cells + 1;
+  const pos = new Float32Array(n * n * 3);
+  for (let y = 0; y < n; y++) for (let x = 0; x < n; x++) {
+    const i = y * n + x;
+    pos[i * 3] = x / cells; pos[i * 3 + 1] = Math.sin(x * 0.37) * Math.cos(y * 0.29) * 0.02; pos[i * 3 + 2] = y / cells;
+  }
+  const idx = new Uint32Array(cells * cells * 6);
+  let q = 0;
+  for (let y = 0; y < cells; y++) for (let x = 0; x < cells; x++) {
+    const a = y * n + x, b = a + 1, c = a + n, d = c + 1;
+    idx[q++] = a; idx[q++] = c; idx[q++] = b; idx[q++] = b; idx[q++] = c; idx[q++] = d;
+  }
+  const prim = doc.createPrimitive().setMaterial(doc.createMaterial('m'))
+    .setIndices(doc.createAccessor().setType('SCALAR').setBuffer(buf).setArray(idx))
+    .setAttribute('POSITION', doc.createAccessor().setType('VEC3').setBuffer(buf).setArray(pos));
+  doc.createScene('s').addChild(doc.createNode(`hero-${tag}`).setMesh(doc.createMesh('gridMesh').addPrimitive(prim)));
+  return new NodeIO().writeBinary(doc);
+}
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); } catch { return cand; }
+  }
+  throw new Error('no free port in 20 tries');
+}
+/** Process-owned, as object-lod-test spawns it: the per-run nonce goes INTO
+ *  the child and must come back on /version before anything counts as up. */
+async function startServer() {
+  const PORT = await freePort();
+  const nonce = crypto.randomUUID();
+  const env: Record<string, string | undefined> = { ...process.env, PORT: String(PORT), JOIN_TOKEN: 'test-door',
+    WORLD_INSTANCE_NONCE: nonce, WORLDS_DIR: mkdtempSync(join(tmpdir(), 'ew-lodc-w-')), EIDOVERSE_DIR: LIB,
+    KTX2_TOKTX: join(NOWHERE, 'no-such'), PATH: NOWHERE, HOME: NOWHERE, USERPROFILE: NOWHERE };
+  const proc = spawnProc(process.execPath, [join(ROOT, 'server', 'server.ts')], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+  child = proc;
+  let log = '';
+  proc.stdout!.on('data', (d) => { log += d; });
+  proc.stderr!.on('data', (d) => { log += d; });
+  let up = false, version: any = null;
+  for (let i = 0; i < 120 && !up; i++) {
+    if (proc.exitCode != null) break;
+    try {
+      version = await fetch(`http://127.0.0.1:${PORT}/version`).then((r) => r.json());
+      if (version && typeof version === 'object' && version.instance === nonce) up = true;
+      else break;   // someone else answers here — refuse, never test into their world
+    } catch { await sleep(250); }
+  }
+  if (!up) console.log(`      child did not come up OWNED — log tail:\n      ${log.split('\n').slice(-6).join('\n      ')}`);
+  const base = `http://127.0.0.1:${PORT}`;
+  return { up, base, key: keyFromVersion(version), lod: lodFromVersion(version), log: () => log,
+    stop: async () => { try { proc.kill(); } catch { /* gone */ } child = null; await sleep(300); } };
+}
+
+writeFileSync(join(LIB, HEAVY), await gridGlb('heavy', 160, null));
+writeFileSync(join(LIB, AUTHORED), await gridGlb('authored', 8, { recipe: LOD_RECIPE, note: 'an author wrote this' }));
+const C = await startServer();
+try {
+  check('child sequencer came up OWNED over the fixture library', C.up);
+  if (C.up) {
+    const key = C.key as string, recipe = C.lod as string;
+    check('it published a key and the recipe this client was built against', !!key && recipe === LOD_RECIPE, `${key} / ${recipe}`);
+    const landed = await until(() => existsSync(join(OPT, `${HEAVY}.lod.${recipe}.glb`)), 60_000);
+    check('the boot sweep baked the heavy fixture\'s LOD (untextured: no encoder needed)', landed,
+      C.log().split('\n').filter((l) => l.includes('lod')).slice(-3).join(' | '));
+    const served = async (url: string) => {
+      const r = await fetch(`${C.base}/library/${url}`);
+      const bytes = new Uint8Array(await r.arrayBuffer());
+      const json = rig.glbJson(bytes);
+      return { status: r.status, cc: r.headers.get('cache-control'), json, tier: tierOf(json, recipe), url };
+    };
+    const capable = askFor({ libPath: HEAVY, key, capable: true, recipe, tier: 'lod' });
+    const a = await served(capable.url);
+    check('a CAPABLE browser\'s lod ask → the stamped variant; the loader\'s tierOf reads it as lod',
+      capable.tier === 'lod' && a.status === 200 && a.tier === 'lod' && typeof a.json.asset?.extras?.lodOf === 'string',
+      JSON.stringify({ url: a.url, extras: a.json.asset?.extras }));
+    const incapable = askFor({ libPath: HEAVY, key, capable: false, recipe, tier: 'lod' });
+    const b = await served(incapable.url);
+    check('an INCAPABLE browser sends neither lod= nor ktx2=: the original comes back, read as full',
+      incapable.tier === 'full' && !incapable.url.includes('=') && b.status === 200 && b.tier === 'full' && !b.json.asset?.extras?.lodOf, incapable.url);
+    const c = await served(withLod(negotiate(HEAVY, key), 'some-future-recipe'));
+    check('a WRONG-GENERATION ask answers provisionally (no-cache) and the loader reads it as full',
+      c.status === 200 && c.cc === 'no-cache' && c.tier === 'full', `cc=${c.cc}`);
+    const authored = askFor({ libPath: AUTHORED, key, capable: true, recipe, tier: 'lod' });
+    const refused = await until(() => existsSync(join(OPT, `${AUTHORED}.lod.${recipe}.glb.failed`)), 30_000);
+    const d = await served(authored.url);
+    check('an authored `recipe` extra EQUAL to the running recipe, through the lod door: the sweep refused it typed (already light), the original answers, the loader reads FULL',
+      refused && d.status === 200 && d.json.asset?.extras?.recipe === recipe && !d.json.asset?.extras?.lodOf && d.tier === 'full',
+      JSON.stringify({ refused, extras: d.json.asset?.extras, cc: d.cc }));
+  }
+} finally { await C.stop(); }
+
+console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : '\n\x1b[32m0 failed\x1b[0m');
+process.exit(failures ? 1 : 0);

--- a/tools/lod-client-test.ts
+++ b/tools/lod-client-test.ts
@@ -7,26 +7,37 @@
 // answer, the in-place replacement and the collider all AGREE. Review of
 // #170, point 4 — "the committed receipt stops at the pure chooser".
 //
-// Two halves. The REALIZER half runs the real client/lib/realize/models.js
-// (with the real policy, fold, scheduler and bus) over a stub of its
-// dependency cone — tools/lod-client-stub.mjs: no renderer; a loader whose
-// tier is the WIRE truth (askFor), whose "sequencer" answers a stamped
-// variant for libs it baked and the original otherwise, and which the test
-// can hold open and release by hand, so a tier swap is caught mid-flight;
-// colliders recorded, never built. The WIRE half spawns a sequencer child
-// PROCESS-OWNED (WORLD_INSTANCE_NONCE, as object-lod-test does) over a
-// fixture library and pushes the exact URLs the loader would send through
-// it — capable, incapable, wrong generation, an authored `recipe` extra —
-// reading the served tier with the same tierOf the loader uses.
+// Three parts. The REALIZER part runs the real client/lib/realize/models.js
+// and the real governor.js (with the real policy, fold, scheduler and bus)
+// over a stub of their dependency cone — tools/lod-client-stub.mjs: no
+// renderer; a loader whose tier is the WIRE truth (askFor), whose
+// "sequencer" answers a stamped variant for libs it baked and the original
+// otherwise, and which the test can hold open and release by hand, so a
+// tier swap is caught mid-flight; colliders recorded, never built; every
+// governor lever below 'lod' answering "nothing to shed". The WIRE part
+// spawns a sequencer child PROCESS-OWNED (WORLD_INSTANCE_NONCE, as
+// object-lod-test does) over a fixture library and pushes the exact URLs the
+// loader would send through it — capable, incapable, wrong generation, an
+// authored `recipe` extra — reading the served tier with the same tierOf the
+// loader uses. The PRODUCTION-LOADER part (round three of the review) then
+// runs the real, unmodified client/lib/assets.js against that same child
+// (tools/lod-loader-probe.ts: only a renderer that never draws and the frame
+// conductors injected below it, its relative fetches resolved to the child),
+// once per /version shape — the real one, one with no recipe, one with no
+// key — and asserts the URL it fetched, the cache key it chose and the
+// tierAsked / tierServed it stamped. A mutation at that seam (`tier =
+// req.tier`, the url, the stamps) fails here; a stubbed loader could not
+// say so, and the review caught exactly that.
 //
 // Negative controls, each named in its check: the churn of the first field
 // run (an "already light" answer re-asked every cooldown), a held tier swap
 // landing over a rider / cargo / a part motion / an edit hold, a lod ask a
 // non-KTX2 browser reports without ever sending, an authored `recipe`
-// extra read as a served lod. Dies at import on main (no lod_policy.js).
+// extra read as a served lod, a governor lever overriding the resident's
+// "full detail". Dies at import on main (no lod_policy.js).
 import { plugin } from 'bun';
 import { fileURLToPath } from 'node:url';
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { spawn as spawnProc, type ChildProcess } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -35,8 +46,13 @@ const STUB = fileURLToPath(new URL('./lod-client-stub.mjs', import.meta.url));
 plugin({
   name: 'lod-client-stub',
   setup(b) {
+    // the realizer's cone (imported from realize/ as ../x.js) and the
+    // governor's cone (imported from lib/ as ./x.js) — state, scheduler,
+    // policy, fold and the bus stay REAL, and so do models.js and governor.js
     for (const f of ['^\\.\\./core\\.js$', '^\\.\\./assets\\.js$', '^\\.\\./colliders\\.js$',
-      '^\\.\\./lightrig\\.js$', '^\\.\\./lights\\.js$', '^\\.\\./world\\.js$']) {
+      '^\\.\\./lightrig\\.js$', '^\\.\\./lights\\.js$', '^\\.\\./world\\.js$',
+      '^\\./core\\.js$', '^\\./warmqueue\\.js$', '^\\./loadwork\\.js$', '^\\./lightrig\\.js$',
+      '^\\./emitters\\.js$', '^\\./terrain\\.js$', '^\\./remotes\\.js$', '^\\./frame\\.js$', '^\\./ui\\.js$']) {
       b.onResolve({ filter: new RegExp(f) }, () => ({ path: STUB }));
     }
   },
@@ -226,6 +242,49 @@ for (const [what, dep] of deps) {
 check('no realizer error was reported through the whole realizer half', stub.reports.length === 0,
   stub.reports.map((r: any) => `${r.where}: ${r.e?.message ?? r.e}`).join(' | '));
 
+// ---- 5. the other entry points (round three): the REAL governor's lever crosses into the sweep; the dial's callback is gated
+console.log('\n  entry points — the governor lever and the dial callback\n');
+{
+  const G: any = await import('../client/lib/governor.js');   // real, over the same stub cone: every lever below "lod" answers "nothing to shed"
+  M.modelQuality.setQuality('auto');
+  spawnAt('gov', 25); await settle();                          // inside the auto edge (39m) — full
+  drain();
+  check('gov (25m) joined full under "auto"', obj('gov')?.userData.tierAsked === 'full');
+  const toastsBefore = stub.toasts.length;
+  const hist = () => G.governorDebug().history as string[];
+  let windows = 0;
+  while (!hist().some((h) => h.startsWith('− lod')) && windows++ < 4) for (let i = 0; i < 4; i++) G.governPerformance(12);
+  check('slow seconds with nothing else to shed: the ladder reaches "lod" — the session dial sheds, the resident is told once',
+    M.modelQuality.shed === true && hist().some((h) => h.startsWith('− lod')) && stub.toasts.length === toastsBefore + 1,
+    JSON.stringify({ shed: M.modelQuality.shed, hist: hist().slice(-3), toasts: stub.toasts.slice(-1) }));
+  M.residencySweep(); await settle(); drain();   // drained: the governor's grace holds while a promote tail is pending
+  check('…and it CROSSES into the realizer: gov (25m > the halved 19.5m edge) re-tiers to lod on the next beat',
+    obj('gov')?.userData.tierAsked === 'lod' && obj('gov')?.userData.tier === 'lod', JSON.stringify(obj('gov')?.userData));
+  windows = 0;
+  while (M.modelQuality.shed && windows++ < 4) for (let i = 0; i < 6; i++) G.governPerformance(60);
+  check('smooth seconds: "lod" restores SILENTLY — the dial is off, no toast',
+    !M.modelQuality.shed && hist().some((h) => h.startsWith('+ lod')) && stub.toasts.length === toastsBefore + 1,
+    JSON.stringify({ shed: M.modelQuality.shed, hist: hist().slice(-3) }));
+  M.modelQuality.setQuality('full');
+  drain();
+  const histLen = hist().length;
+  for (let i = 0; i < 4; i++) G.governPerformance(12);
+  check('the resident\'s "full detail" is never overridden: under load the lever declines and the ladder passes it by',
+    M.modelQuality.shed === false && !hist().slice(histLen).some((h) => h.startsWith('− lod')), JSON.stringify(hist().slice(histLen)));
+  M.modelQuality.setQuality('auto');
+
+  // the dial's callback — skypanel.js binds it to the models⚙ row and shows what it returns
+  const hintEco = M.dialModelQuality('eco');
+  check('the row\'s callback sets and persists the dial and says it is yours only',
+    M.modelQuality.quality === 'eco' && store.get('ew-model-quality') === 'eco' && hintEco === 'models: eco (yours only)', hintEco);
+  stub.server.recipe = null;
+  const hintNone = M.dialModelQuality('auto');
+  check('…and where no reduced tier can be asked from this browser, the hint says so', /cannot be asked/.test(hintNone) && M.modelQuality.quality === 'auto', hintNone);
+  stub.server.recipe = REC;
+  const hintUnknown = M.dialModelQuality('ultra');
+  check('an unknown level is refused; the dial stands', M.modelQuality.quality === 'auto' && hintUnknown.startsWith('models: auto'), hintUnknown);
+}
+
 // ============================================================================
 console.log('\nlod-client — the wire half (an OWNED sequencer answers the loader\'s exact URLs)\n');
 
@@ -244,6 +303,12 @@ const cleanup = () => {
   for (const d of [LIB, NOWHERE]) try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
 };
 process.on('exit', cleanup);
+for (const sig of ['SIGINT', 'SIGTERM'] as const) process.on(sig, () => { cleanup(); process.exit(1); });
+// a run killed mid-way may have left last time's variants in OPT_DIR: a STALE
+// variant (older than the fixture written below) is exactly what the server
+// refuses to serve (#156 freshness), so clear before writing, and wait for a
+// variant NEWER than its source, never for a file that merely exists
+for (const rel of mine) try { rmSync(join(OPT, rel), { force: true }); } catch { /* best effort */ }
 
 async function gridGlb(tag: string, cells: number, extras: object | null): Promise<Uint8Array> {
   const { Document, NodeIO } = await import('@gltf-transform/core');
@@ -312,7 +377,9 @@ try {
   if (C.up) {
     const key = C.key as string, recipe = C.lod as string;
     check('it published a key and the recipe this client was built against', !!key && recipe === LOD_RECIPE, `${key} / ${recipe}`);
-    const landed = await until(() => existsSync(join(OPT, `${HEAVY}.lod.${recipe}.glb`)), 60_000);
+    const variant = join(OPT, `${HEAVY}.lod.${recipe}.glb`);
+    const fresh = () => existsSync(variant) && statSync(variant).mtimeMs > statSync(join(LIB, HEAVY)).mtimeMs;
+    const landed = await until(fresh, 60_000);
     check('the boot sweep baked the heavy fixture\'s LOD (untextured: no encoder needed)', landed,
       C.log().split('\n').filter((l) => l.includes('lod')).slice(-3).join(' | '));
     const served = async (url: string) => {
@@ -339,6 +406,50 @@ try {
     check('an authored `recipe` extra EQUAL to the running recipe, through the lod door: the sweep refused it typed (already light), the original answers, the loader reads FULL',
       refused && d.status === 200 && d.json.asset?.extras?.recipe === recipe && !d.json.asset?.extras?.lodOf && d.tier === 'full',
       JSON.stringify({ refused, extras: d.json.asset?.extras, cc: d.cc }));
+
+    // ---- the PRODUCTION loader (round three): real client/lib/assets.js, only a renderer and
+    // the frame conductors injected below it, its /version and /library fetches going to the
+    // owned child. A mutation at the decision seam (tier / url / glbKey / the stamps) fails here.
+    console.log('\n  the production loader — real assets.js against the owned child\n');
+    const probe = async (strip: string) => {
+      const p = Bun.spawn([process.execPath, join(ROOT, 'tools', 'lod-loader-probe.ts')], {
+        env: { ...process.env, LODC_BASE: C.base, LODC_STRIP: strip, LODC_HEAVY: HEAVY, LODC_AUTHORED: AUTHORED },
+        stdout: 'pipe', stderr: 'pipe',
+      });
+      const killer = setTimeout(() => { try { p.kill(); } catch { /* gone */ } }, 90_000);   // a wedged probe is a failure, not a hang
+      const [out, err] = await Promise.all([new Response(p.stdout).text(), new Response(p.stderr).text()]);
+      await p.exited;
+      clearTimeout(killer);
+      const line = out.split('\n').find((l) => l.startsWith('PROBE '));
+      const r = line ? JSON.parse(line.slice(6)) : {};
+      if (!line || r.error) r.error = (r.error ?? '') + (err + out).split('\n').filter(Boolean).slice(-8).join(' | ');
+      return r;
+    };
+    const P = await probe('');
+    check('the real loader came up against the child: its /version handshake read the real key and recipe, the transcoder is detected',
+      !P.error && P.negotiable === true && P.capable === true, P.error ?? JSON.stringify(P));
+    if (!P.error) {
+      check('resolveLoadRequest(HEAVY, lod): the URL carries the child\'s key and recipe, the tier is lod, the cache key is <lib>#lod',
+        P.resolve.url === `${HEAVY}?ktx2=${key}&lod=${encodeURIComponent(recipe)}` && P.resolve.tier === 'lod' && P.resolve.glbKey === `${HEAVY}#lod`,
+        JSON.stringify(P.resolve));
+      check('loadGLB(HEAVY, {tier: lod}) FETCHED that URL, keyed #lod, stamped asked lod, and read the REAL variant\'s stamp as served lod',
+        P.fetched.includes(`/library/${P.resolve.url}`) && P.lod.glbKey === `${HEAVY}#lod` && P.lod.asked === 'lod' && P.lod.served === 'lod',
+        JSON.stringify({ lod: P.lod, fetched: P.fetched }));
+      check('loadGLB(HEAVY, {tier: full}) fetched the plain ktx2 URL, keyed on the lib, asked and served full',
+        P.fetched.includes(`/library/${HEAVY}?ktx2=${key}`) && P.full.glbKey === HEAVY && P.full.asked === 'full' && P.full.served === 'full',
+        JSON.stringify(P.full));
+      check('loadGLB(AUTHORED, {tier: lod}) asked lod and, parsing the ORIGINAL the child fell through to, served full — the authored extra fooled the real loader no more than the pure one',
+        P.authored.asked === 'lod' && P.authored.served === 'full' && P.authored.glbKey === `${AUTHORED}#lod`, JSON.stringify(P.authored));
+    }
+    const older = await probe('lodRecipe');
+    check('an OLDER sequencer (no lodRecipe on /version): the real loader never asks — plain ktx2 URL, keyed on the lib, asked full, no lod= anywhere',
+      !older.error && older.negotiable === false && older.lod?.asked === 'full' && older.lod?.glbKey === HEAVY
+      && older.fetched?.includes(`/library/${HEAVY}?ktx2=${key}`) && !older.fetched?.some((u: string) => u.includes('lod=')),
+      older.error ?? JSON.stringify(older));
+    const keyless = await probe('ktx2Key');
+    check('no key on /version: nothing negotiates — the bare path, asked full',
+      !keyless.error && keyless.negotiable === false && keyless.lod?.asked === 'full' && keyless.fetched?.includes(`/library/${HEAVY}`)
+      && !keyless.fetched?.some((u: string) => u.includes('=')), keyless.error ?? JSON.stringify(keyless));
   }
 } finally { await C.stop(); }
 

--- a/tools/lod-loader-probe.ts
+++ b/tools/lod-loader-probe.ts
@@ -1,0 +1,86 @@
+// lod-loader-probe — runs the PRODUCTION loader (client/lib/assets.js,
+// unmodified) against an owned sequencer and reports what it did.
+//
+// Spawned by tools/lod-client-test.ts, once per /version shape:
+//   LODC_BASE      the owned child's base URL
+//   LODC_STRIP     '' | 'lodRecipe' | 'ktx2Key' — a field removed from the
+//                  child's /version answer at the network seam, so the same
+//                  real module is exercised as it would be against an older
+//                  sequencer (no recipe) or one that negotiates nothing (no key)
+//   LODC_HEAVY     a library rel the child has baked a LOD variant for
+//   LODC_AUTHORED  a light library rel whose SOURCE carries a `recipe` extra
+//
+// Only two things sit below the module: a renderer that never draws and
+// frame conductors that run at once (tools/lod-loader-stub.mjs), and a fetch
+// shim that resolves the loader's relative URLs against the child and
+// records every URL that crossed. Review of #170, round three: a mutation at
+// the loader's decision seam — `tier = req.tier` → `tier = 'full'`, the url,
+// the glbKey, the tierAsked / tierServed stamps — must FAIL the gate, so the
+// gate has to run the real seam. Output: one line, `PROBE {json}`.
+import { plugin } from 'bun';
+import { fileURLToPath } from 'node:url';
+
+const BASE = process.env.LODC_BASE!;
+const STRIP = process.env.LODC_STRIP ?? '';
+const HEAVY = process.env.LODC_HEAVY!;
+const AUTHORED = process.env.LODC_AUTHORED!;
+
+// a DOM event class three's FileLoader constructs for progress callbacks;
+// Bun has no DOM. Below the seam, like the renderer.
+if (!(globalThis as any).ProgressEvent) {
+  (globalThis as any).ProgressEvent = class ProgressEvent extends Event {
+    lengthComputable: boolean; loaded: number; total: number;
+    constructor(type: string, init: any = {}) { super(type); this.lengthComputable = !!init.lengthComputable; this.loaded = init.loaded ?? 0; this.total = init.total ?? 0; }
+  };
+}
+// whatever the module does in the background must not take the answer with
+// it: a rejection anywhere is reported, and the probe still prints its line
+const background: string[] = [];
+process.on('unhandledRejection', (e: any) => { background.push(String(e?.stack ?? e).split('\n').slice(0, 3).join(' | ')); });
+
+// the network seam: relative → the child; /version minus one field, when asked
+const fetched: string[] = [];
+const realFetch = globalThis.fetch;
+globalThis.fetch = (async (input: any, init?: any) => {
+  let url: string = typeof input === 'string' ? input : input.url;
+  if (url.startsWith('/')) url = BASE + url;
+  fetched.push(url.startsWith(BASE) ? url.slice(BASE.length) : url);
+  const r = await realFetch(url, init);
+  if (STRIP && url.endsWith('/version')) {
+    const j = await r.json();
+    delete j[STRIP];
+    return new Response(JSON.stringify(j), { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+  return r;
+}) as any;
+
+const STUB = fileURLToPath(new URL('./lod-loader-stub.mjs', import.meta.url));
+plugin({
+  name: 'lod-loader-stub',
+  setup(b) {
+    for (const f of ['^\\./core\\.js$', '^\\./loadwork\\.js$', '^\\./warmqueue\\.js$', '^\\./materials\\.js$', '^\\./draw_batches\\.js$']) {
+      b.onResolve({ filter: new RegExp(f) }, () => ({ path: STUB }));
+    }
+  },
+});
+
+const A: any = await import('../client/lib/assets.js');
+await A.negotiationReady;
+const identity = (o: any) => ({ glbKey: o.userData.glbKey, asked: o.userData.tierAsked, served: o.userData.tierServed });
+const out: any = {
+  strip: STRIP,
+  capable: A.ktx2Capable(),
+  negotiable: A.lodNegotiable(HEAVY),
+  resolve: A.resolveLoadRequest(HEAVY, 'lod'),
+};
+try {
+  out.lod = identity(await A.loadGLB(HEAVY, { tier: 'lod' }));
+  out.full = identity(await A.loadGLB(HEAVY, { tier: 'full' }));
+  out.authored = identity(await A.loadGLB(AUTHORED, { tier: 'lod' }));
+} catch (e: any) {
+  out.error = String(e?.stack ?? e);
+}
+out.fetched = fetched;
+out.background = background;
+console.log('PROBE ' + JSON.stringify(out));
+process.exit(0);

--- a/tools/lod-loader-stub.mjs
+++ b/tools/lod-loader-stub.mjs
@@ -1,0 +1,40 @@
+// tools/lod-loader-stub.mjs — what tools/lod-loader-probe.ts injects BELOW
+// the real client/lib/assets.js: a renderer that never draws, and the
+// frame-budget conductors (loadwork, warmqueue) that run their work at once.
+// Everything above — the /version handshake, resolveLoadRequest, fetchBytes,
+// the GLTF parse, the identity stamps, the proto cache and the clone — is
+// the production module, unmodified. The probe's fetch shim is the only
+// other seam, and it sits at the network.
+import * as THREE from '../client/node_modules/three/build/three.module.js';
+export { THREE };
+
+// ---- core.js ----------------------------------------------------------------
+export const scene = new THREE.Scene();
+export const camera = new THREE.PerspectiveCamera();
+// KTX2Loader.detectSupport reads the WebGPU feature set off this; assets.js
+// reads GPU memory for the pressure signal and uploads textures through it
+export const renderer = {
+  isWebGPURenderer: true,
+  hasFeature: () => false,
+  initTexture() {},
+  compileAsync: async () => {},
+  info: { memory: { total: 0 } },
+  domElement: null,
+};
+export const report = (where, e) => { console.error(`[report] ${where}`, e); };
+export const CONFIG = {};
+
+// ---- loadwork.js ------------------------------------------------------------
+export const beginWork = () => ({ phase() {}, async yield() {}, async tick() {}, end() {} });
+export const enqueue = (fn) => Promise.resolve().then(fn);
+export const nextFrame = () => Promise.resolve();
+export const loadNote = () => {};
+export const laneBusy = () => false;
+
+// ---- warmqueue.js -----------------------------------------------------------
+export const warm = (label, fn) => Promise.resolve().then(fn);
+export const warmStats = () => ({ pending: 0, running: false });
+
+// ---- materials.js / draw_batches.js ----------------------------------------
+export const prepareObject = () => {};
+export const markDrawBatchSource = () => {};

--- a/tools/lod-policy-test.ts
+++ b/tools/lod-policy-test.ts
@@ -1,0 +1,92 @@
+// client/lib/lod_policy.js — the tier chooser, tested headless.
+//
+//   bun tools/lod-policy-test.ts
+//
+// The contract under test (the #156 client half): the tier is chosen BEFORE
+// the fetch from the resident's dial, the distance against the entity's own
+// residency radius, and device pressure — and NEVER asked for unless the
+// running sequencer published a recipe (the split-brain gate, third time
+// applied). Hysteresis keeps a band-edge placement from flip-flopping; the
+// governor's shed and GPU pressure pull the reduce-at edge inward; the dial
+// pins full; 'eco' is the pressured band, always — near stays full on every
+// dial (the first field run's arm's-length slabs). The served tier is read
+// off the reducer's identity stamp, never assumed from the request.
+//
+// Negative control: on main this file dies at import (no lod_policy.js).
+
+import { MODEL_QUALITY, LOD_FRACTION, LOD_HYST, PRESSURE_EDGE, PRESSURE_AT,
+  makeModelQuality, chooseTier, tierOf } from "../client/lib/lod_policy.js";
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail?: string) => {
+  console.log(`  ${ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m"} ${label}${!ok && detail ? `\n      ${detail}` : ""}`);
+  if (!ok) failures++;
+};
+console.log("\nlod_policy — the tier chooser:\n");
+
+const R = 100;                       // a residency radius; edge = 45m at LOD_FRACTION 0.45
+const REC = "lod1-r25e01-texel1024";
+const edge = R * LOD_FRACTION;
+
+// ---- the gate: no recipe, no tier — ever
+check("no recipe published → 'full', however far", chooseTier({ dist: 1e6, radius: R, recipe: null }) === "full");
+check("…even on 'eco'", chooseTier({ dist: 1e6, radius: R, recipe: null, quality: "eco" }) === "full");
+check("…even under pressure and shed", chooseTier({ dist: 1e6, radius: R, recipe: null, pressure: 9, shed: true }) === "full");
+
+// ---- the dial's extremes ignore distance
+check("'full' never reduces", chooseTier({ dist: 1e6, radius: R, recipe: REC, quality: "full" }) === "full");
+check("'eco' is the pressured band, always — reduces past the HALVED edge",
+  chooseTier({ dist: edge * PRESSURE_EDGE * 1.2, radius: R, recipe: REC, quality: "eco" }) === "lod"
+  && chooseTier({ dist: edge * PRESSURE_EDGE * 1.2, radius: R, recipe: REC }) === "full");
+check("…and what you stand beside stays full on 'eco': no dial reduces near",
+  chooseTier({ dist: edge * PRESSURE_EDGE * 0.8, radius: R, recipe: REC, quality: "eco" }) === "full"
+  && chooseTier({ dist: 1, radius: R, recipe: REC, quality: "eco" }) === "full");
+
+// ---- 'auto': the distance band against the entity's OWN radius
+check("near → full", chooseTier({ dist: edge * 0.5, radius: R, recipe: REC }) === "full");
+check("far → lod", chooseTier({ dist: edge * 1.5, radius: R, recipe: REC }) === "lod");
+check("a bigger entity (bigger radius) goes reduced later", chooseTier({ dist: 60, radius: 100, recipe: REC }) === "lod"
+  && chooseTier({ dist: 60, radius: 200, recipe: REC }) === "full");
+check("a missing/zero radius falls back to the base radius, never divides by zero",
+  chooseTier({ dist: 1, radius: 0, recipe: REC }) === "full" && chooseTier({ dist: 1e6, radius: 0, recipe: REC }) === "lod");
+
+// ---- hysteresis: the edge you cross depends on what you wear
+const inner = edge * (1 - LOD_HYST), outer = edge * (1 + LOD_HYST);
+check("wearing full, just past the edge is still full (no flip at the line)", chooseTier({ dist: edge * 1.1, radius: R, recipe: REC, current: "full" }) === "full");
+check("wearing full, past the OUTER edge → lod", chooseTier({ dist: outer * 1.01, radius: R, recipe: REC, current: "full" }) === "lod");
+check("wearing lod, just inside the edge is still lod", chooseTier({ dist: edge * 0.9, radius: R, recipe: REC, current: "lod" }) === "lod");
+check("wearing lod, inside the INNER edge → full", chooseTier({ dist: inner * 0.99, radius: R, recipe: REC, current: "lod" }) === "full");
+{ // a walk across the band flips exactly once each way
+  let tier = "full"; let flips = 0;
+  for (let d = 0; d <= 2 * edge; d += edge / 50) { const t = chooseTier({ dist: d, radius: R, recipe: REC, current: tier }); if (t !== tier) { flips++; tier = t; } }
+  for (let d = 2 * edge; d >= 0; d -= edge / 50) { const t = chooseTier({ dist: d, radius: R, recipe: REC, current: tier }); if (t !== tier) { flips++; tier = t; } }
+  check("a walk out and back flips tier exactly twice (once each way), never chatters", flips === 2 && tier === "full", `${flips} flips, ends ${tier}`);
+}
+
+// ---- pressure and shed pull the edge inward
+const pressuredEdge = edge * PRESSURE_EDGE;
+check("under GPU pressure the edge halves (a mid-distance object goes reduced)",
+  chooseTier({ dist: pressuredEdge * 1.2, radius: R, recipe: REC, pressure: PRESSURE_AT }) === "lod"
+  && chooseTier({ dist: pressuredEdge * 1.2, radius: R, recipe: REC, pressure: PRESSURE_AT * 0.5 }) === "full");
+check("the governor's shed does the same, without pressure", chooseTier({ dist: pressuredEdge * 1.2, radius: R, recipe: REC, shed: true }) === "lod");
+check("but neither overrides the resident's 'full'", chooseTier({ dist: 1e6, radius: R, recipe: REC, quality: "full", pressure: 9, shed: true }) === "full");
+
+// ---- the dial: persisted, refuses unknowns, shed is session-only
+{
+  const store = new Map<string, string>();
+  const fake = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  const q = makeModelQuality(fake);
+  check("defaults to 'auto'", q.quality === "auto" && MODEL_QUALITY[0] === "auto");
+  check("a choice persists", q.setQuality("eco") === "eco" && store.get("ew-model-quality") === "eco");
+  check("…and comes back on the next boot", makeModelQuality(fake).quality === "eco");
+  check("an unknown level is refused, the current one stands", q.setQuality("ultra" as any) === "eco");
+  check("the governor's shed is a session dial — never written", q.setShed(true) === true && !store.has("shed") && makeModelQuality(fake).shed === false);
+  check("no store at all → session-only, still works", makeModelQuality(undefined).setQuality("full") === "full");
+}
+
+// ---- the served tier is the server's word
+check("a parsed GLB with the reducer's stamp is 'lod'", tierOf({ asset: { extras: { recipe: REC } } }) === "lod");
+check("without the stamp — the original chain answered — it is 'full', honestly", tierOf({ asset: { extras: {} } }) === "full" && tierOf({}) === "full" && tierOf(null) === "full");
+
+console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
+process.exit(failures ? 1 : 0);

--- a/tools/lod-policy-test.ts
+++ b/tools/lod-policy-test.ts
@@ -10,12 +10,15 @@
 // governor's shed and GPU pressure pull the reduce-at edge inward; the dial
 // pins full; 'eco' is the pressured band, always — near stays full on every
 // dial (the first field run's arm's-length slabs). The served tier is read
-// off the reducer's identity stamp, never assumed from the request.
+// off the reducer's identity stamp — lodOf plus the RUNNING recipe, never a
+// bare `recipe` extra an author may have written — and the tier a load IS
+// is what crossed the wire (askFor), never what the policy wished: no KTX2
+// transcoder, no key, no recipe, no .glb → no lod ask, reported as none.
 //
 // Negative control: on main this file dies at import (no lod_policy.js).
 
 import { MODEL_QUALITY, LOD_FRACTION, LOD_HYST, PRESSURE_EDGE, PRESSURE_AT,
-  makeModelQuality, chooseTier, tierOf } from "../client/lib/lod_policy.js";
+  makeModelQuality, chooseTier, tierOf, askFor } from "../client/lib/lod_policy.js";
 
 let failures = 0;
 const check = (label: string, ok: boolean, detail?: string) => {
@@ -84,9 +87,34 @@ check("but neither overrides the resident's 'full'", chooseTier({ dist: 1e6, rad
   check("no store at all → session-only, still works", makeModelQuality(undefined).setQuality("full") === "full");
 }
 
-// ---- the served tier is the server's word
-check("a parsed GLB with the reducer's stamp is 'lod'", tierOf({ asset: { extras: { recipe: REC } } }) === "lod");
-check("without the stamp — the original chain answered — it is 'full', honestly", tierOf({ asset: { extras: {} } }) === "full" && tierOf({}) === "full" && tierOf(null) === "full");
+// ---- the served tier is the REDUCER's stamp, bound to the running recipe (review of #170, point 1)
+const stamped = (recipe: string) => ({ asset: { extras: { lodOf: "9f2c…", recipe, tools: { meshoptimizer: "0.2x", encoder: "toktx" } } } });
+check("the reducer's stamp under the running recipe is 'lod'", tierOf(stamped(REC), REC) === "lod");
+check("an authored model's own `recipe` extra is NOT a lod — source extras survive the reducer, and a full model must keep its collider",
+  tierOf({ asset: { extras: { recipe: "chef-special" } } }, REC) === "full"
+  && tierOf({ asset: { extras: { recipe: REC } } }, REC) === "full");
+check("a WRONG-GENERATION stamp is 'full' — a stale variant is not this recipe's tier", tierOf(stamped("lod0-r50e05-texel2048"), REC) === "full");
+check("without the stamp — the original chain answered — 'full', honestly", tierOf({ asset: { extras: {} } }, REC) === "full" && tierOf({}, REC) === "full" && tierOf(null, REC) === "full");
+check("no running recipe → nothing is ever 'lod', stamp or not", tierOf(stamped(REC), null) === "full");
+
+// ---- the WIRE truth (review of #170, point 2): the tier a load IS is what the URL asks, never what the policy wished
+{
+  const lib = "eidoverse/assets/models/thing.glb";
+  const yes = askFor({ libPath: lib, key: "3", capable: true, recipe: REC, tier: "lod" });
+  check("transcoder + key + recipe: a lod ask crosses the wire, on top of the ktx2 negotiation",
+    yes.tier === "lod" && yes.url === `${lib}?ktx2=3&lod=${encodeURIComponent(REC)}`, yes.url);
+  const noTranscoder = askFor({ libPath: lib, key: "3", capable: true && false, recipe: REC, tier: "lod" });
+  check("no KTX2 transcoder: NO lod on the wire — the ask is honestly 'full', and not even ktx2 negotiates",
+    noTranscoder.tier === "full" && noTranscoder.url === lib, noTranscoder.url);
+  const noKey = askFor({ libPath: lib, key: null, capable: true, recipe: REC, tier: "lod" });
+  check("no key published: the same — an older sequencer is exactly today's behaviour", noKey.tier === "full" && noKey.url === lib);
+  const noRecipe = askFor({ libPath: lib, key: "3", capable: true, recipe: null, tier: "lod" });
+  check("no recipe published: ktx2 negotiates, lod does not", noRecipe.tier === "full" && noRecipe.url === `${lib}?ktx2=3`, noRecipe.url);
+  const body = askFor({ libPath: "eidoverse/assets/vrms/body.vrm", key: "3", capable: true, recipe: REC, tier: "lod" });
+  check("a non-.glb path never negotiates a tier (bodies are the server's refusal AND the client's silence)", body.tier === "full" && !body.url.includes("lod="));
+  const full = askFor({ libPath: lib, key: "3", capable: true, recipe: REC, tier: "full" });
+  check("a 'full' choice is a plain ktx2 fetch", full.tier === "full" && full.url === `${lib}?ktx2=3`);
+}
 
 console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m` : "\n\x1b[32m0 failed\x1b[0m");
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## What

The client half of #156. The sequencer has been baking `<rel>.lod.<recipe>.glb` since #156 went live; nothing asked for them. This makes the client **choose the tier before the fetch**, from local inputs only, and wear whatever the server honestly answers.

Against the v1 contract, point by point:

| contract | where |
|---|---|
| the client chooses the LOD **before** the fetch, from local policy / device pressure / distance | `client/lib/lod_policy.js` (pure) — `chooseTier({dist, radius, quality, recipe, pressure, shed, current})`; `models.js scheduleLoad` passes the tier into `loadGLB` |
| a missing / stale / failed variant falls back to the **original**, never half-valid | the request rides the existing negotiation (`askFor`: the ktx2 URL plus `lod=<recipe>`); the loader reads the **served** tier off the reducer's identity stamp — `asset.extras.lodOf` present **and** `recipe` equal to the running one (`tierOf`) — so a lod ask the server answered with the original, a wrong-generation variant, or an authored `recipe` extra all wear `full` |
| collision / support semantics preserved | a lod-tier placement is **visual only**: no collider, no support surface, no refit. Those come with the full tier on approach (`models.js` promote tail, `refreshModel`) |
| no tier asked unless the running sequencer published a recipe | `lodRecipeReady` from `/version` (`no-store`); `recipe: null → 'full'`, whatever the dial says. Third application of the split-brain gate |
| the resident decides, never the world | `models⚙` in the ☀ sky pane — `auto` / `full detail` / `eco (reduce sooner)`; persisted per browser like `clouds⚙` / `grass⚙`; the hint says "yours only" |

### The policy (auto)

- **Distance against the entity's own residency radius** (`R_BASE + bbox diagonal × 4`, already what residency uses): reduce past `0.45 × R`. A hand-sized organ goes reduced past ~36 m; the 66 m oil rig past ~155 m — the big thing you can actually see from afar keeps its detail longest.
- **Hysteresis** ±25 % around that edge, keyed on what the placement *asked* last time, so a walk along the band flips once each way (test: exactly two flips out and back, never chatter).
- **Pressure**: GPU memory ≥ 80 % of the proto budget, or the governor's new `lod` lever (sits before `pixels` in the ladder; toast "distant objects reduced to keep the frame rate"; restores silently) — either **halves the edge**. Neither overrides a resident's `full detail`.
- **eco** is that halved edge, always. It does not reduce what you stand beside: the first field run had eco reduce everything, and the 66 m rig's girders 1.4 m from the camera became slabs across the view (a raycast camera→avatar hit the reduced rig twice first). No dial reduces near; only `full detail` ignores distance.

### The realizer

- **The wire decides what a load is.** `askFor({libPath, key, capable, recipe, tier})` yields the URL and the tier that URL actually asks: a lod ask exists only with the KTX2 transcoder, a published key, a published recipe, and a `.glb` path — otherwise the load *is* full, keyed, fetched, stamped (`tierAsked`) and counted as one. In the loader this is one exported production function, `resolveLoadRequest(libPath, tier) → {url, tier, glbKey}` over the module's live state; `loadGLB` derives everything from it, `lodNegotiable` is its `'lod'` answer, the policy sees no recipe where none can cross the wire, and a first load chooses its tier at dequeue, once `/version` has answered.
- `loadGLB(lib, {tier})` keys protos / compiles / in-flight on `<lib>#lod`, so both tiers of one lib can be resident and evict independently.
- The residency sweep **re-tiers in place** when the policy flips (walked toward → full; walked away or pressure came → lod) under the same predicate as demotion (nothing riding, seated, or mid-edit) and a 5 s per-placement cooldown. The new tier loads first and replaces the old — no placeholder frame between.
- A swap over a real object is **re-authorized at application**: after the bytes land it re-runs the demote predicate against the current fold — a body that sat down, cargo that mounted, a part motion or socket that arrived, an edit hold — and when authority was lost the loaded clone is simply not worn (nothing was retained for it), the standing object keeps its collider, lamps and mounts, and `retiersRefused` counts it.
- It compares the want against what was **asked**, not what was served. The first field run re-asked an "already light" sphere every cooldown (21 re-tiers in 100 s, the server honestly answering the original each time) until that distinction existed.
- `EW.residency()` now reports `lod` (served), `lodAsked`, `quality`, `recipe`, `retiers`, `retiersRefused`.

## Receipts

`tools/lod-client-test.ts` — **the product door, headless and owned** (57 checks). Realizer part: the real `models.js`, policy, fold, scheduler and bus over a stub of the dependency cone (`tools/lod-client-stub.mjs`) — a loader whose tier is `askFor`'s, whose pretend sequencer answers a stamped variant for baked libs and the original otherwise, held open and released by hand; colliders recorded, never built. Covers: dial persistence in localStorage with a byte-identical world fold after dial flips and swaps; capable / incapable / no-key / no-recipe wires and what they report; asked vs served (`lod 1 / lodAsked 2` on join); the churn control (four beats, nothing re-asked); full↔lod re-tier in place with collider invariance (fitted for full only, never for lod); four held swaps each refused by its own dependency (rider, folded `mount`, folded `motion` with a part, edit hold) plus the landing control. The **real `governor.js`** runs over the same stub cone: three slow seconds shed the session dial with one toast, the next beat re-tiers a 25 m placement under the halved edge, smooth seconds restore silently, and `full detail` is never overridden. Wire part: a sequencer child owned by `WORLD_INSTANCE_NONCE` over a fixture library with no encoder on `PATH`; the boot sweep bakes the untextured heavy fixture; the loader's exact URLs go through it — capable → the stamped variant, read as lod by the loader's own `tierOf`; incapable → the original with neither `lod=` nor `ktx2=`, read as full; wrong generation → `no-cache`, read as full; an authored `recipe` extra equal to the running recipe → refused typed, the original, read as full. **Production-loader part**: `tools/lod-loader-probe.ts` runs the real, unmodified `client/lib/assets.js` against that same child — only a renderer that never draws and the frame conductors injected below it, relative fetches resolved to the child — once per `/version` shape (real; no `lodRecipe`; no `ktx2Key`) and asserts the URL it fetched, the cache key it chose, and the `tierAsked` / `tierServed` it stamped after parsing the real variant. Red controls, one-line mutations in the real `loadGLB`: `tier = 'full'`, a constant `tierServed`, the bare path — each fails the gate.

What the harness does **not** cross: the sky pane's `selectRow` binding itself. The row's whole behaviour is `dialModelQuality(v)` in `models.js` (set, persist, and say whether a reduced tier can be asked from this browser), which the harness gates; `skypanel.js` binds it and shows what it returns.

`tools/lod-policy-test.ts` — the pure policy, headless (35 checks): the gate (no recipe → full, even on eco, even under pressure), the dial's extremes, the band against the entity's own radius, hysteresis (a walk out and back flips exactly twice), pressure and shed halving the edge, persistence / refusal of unknown levels / shed never written, `tierOf` bound to `lodOf` + the running recipe (authored extras, wrong generations, no recipe → full), `askFor`'s wire truth. Negative control: dies at import on main.

Field, local sequencer at 99be0f7 + this branch, world of 7 placements at 10–110 m, a 6 GB card:

| placement | distance | radius (R) | asked | served |
|---|---|---|---|---|
| cyborg brain (diag 0.3 m) | 11 m | 81 m | full | full |
| oil rig (diag 66 m) | 15 m | 345 m | full | full |
| oil rig | 62 m | 345 m | full | full |
| cyborg heart (diag 0.2 m) | 75 m | 81 m | **lod** | **lod** (1.8 MB for a 46.5 MB original) |
| oil rig | 111 m | 345 m | full (edge is 155 m) | full |
| sci-fi orb (981 verts) | 111 m | 94 m | **lod** | full — the sweep's typed "already light" refusal, worn honestly |
| cyborg brain | 110 m | 81 m | demoted (beyond R + hysteresis) | — |

`EW.residency()` → `lod 1, lodAsked 2, quality 'auto', recipe 'lod1-r25e01-texel1024', retiers 2` and it stays there (the 2 are the geometry side-channel landing after the first ask: the rig's radius grows from the 128 m default to 345 m). Network: the lod asks go out as `?ktx2=3&lod=lod1-r25e01-texel1024`, the full ones as `?ktx2=3`.

Turning the dial to **eco (reduce sooner)** with the pane open: within one sweep the heart and the far rig wear lod (rig 111 m > 77 m halved edge), the mid rig at 62 m and everything near stay full, the orb asks and honestly gets the original. **full detail**: every placement back to full, `lod 0`, the reduced meshes gone. Avatar, colliders, frame rate (47–65 fps on a 6 GB card) unaffected through all three.

Regressions: `models-field-test` 18/18, `store-variants-test` 0 failed, `object-lod-test` green on top of the catalog fix (#169, the small PR alongside).

## Limitation, by construction

Geometry LOD rides the KTX2 negotiation because the reduced variant's textures **are** KTX2. A browser without the transcoder, or a sequencer that published no key or no recipe, never asks for a tier and is never reported as having asked; the `models⚙` hint says so ("reduced tiers cannot be asked from this browser; everything stays full detail"). The dial still persists there, so a later capable session honours it.

## Not in this PR

- Bodies (VRMs) never ask: the server refuses them typed, and `loadVRM` is untouched.
- A later bake is picked up on the next natural tier flip (or reload), not pushed — a provisional answer is worn until then.
- `LOD_MIN_VERTS` (12 k) is the yield limiter on the show box — 63 of 98 models are "already light" by it. A tuning question, not a client one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR2U8SynCcmYLYEvVTXAo
