### PR TITLE
Server hardening: pose fence, bounded client-log tee, upload/config/store fixes (VR alpha stack 1/4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,7 @@ House rules, learned the hard way (each one is a past incident):
 ```bash
 # scratch sequencer — NEVER develop against a port someone lives on
 WORLDS_DIR=$(mktemp -d) JOIN_TOKEN=test-door PORT=8993 bun run server/server.ts &
+# SKIP_OPT_SWEEP=1 — skip both boot optimize sweeps (encode pump + ktx2/lod) on a memory-tight host
 
 # the three matrices (each file's header has its exact recipe)
 WORLD_URL=ws://localhost:8993/ws JOIN_TOKEN=test-door bun run tools/comptest.ts    # components/mounts/motion/use

--- a/server/config.ts
+++ b/server/config.ts
@@ -4,8 +4,9 @@
 // server.ts's FIRST import, so everything here runs before any other
 // module's boot work — the same order the constants had inline.
 
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { totalmem } from "node:os";
 
 export const PORT = Number(process.env.PORT ?? 8940);
 // Show-night door policy. Empty = open (dev on a tailnet). On a public box you
@@ -17,6 +18,37 @@ export const UPLOAD_CAP = Number(process.env.UPLOAD_CAP_MB ?? 20) * 1_000_000;
 // enough to re-render the whole performance offline, at production quality,
 // forever. Clients are told at join — recording is never invisible.
 export const RECORD = process.env.RECORD_FRAMES === "1";
+// SKIP_OPT_SWEEP=1 skips both boot optimize sweeps (encode pump + ktx2/lod);
+// serving worlds must be startable without shouldering the optimizer.
+export const SKIP_OPT_SWEEP = process.env.SKIP_OPT_SWEEP === "1";
+// OPT_MEM_BUDGET_MB bounds the optimizer so serving a world never competes
+// with encoding one: each optimize child runs under RLIMIT_DATA of this
+// many MB (Linux only — XNU accepts the limit and ignores it), and an item
+// whose ESTIMATED cost exceeds it is deferred (a `.deferred` marker beside
+// the would-be variant, a count in /version for this boot) rather than
+// attempted — a bigger host does it later; the small one still optimizes
+// everything that fits. Default: half of the memory this process can
+// actually use — the cgroup limit when there is one (a 1GB container on a
+// 64GB box must not budget 32GB), else physical memory. 0 = no cap, no gate.
+function usableMemory(): number {
+  try { const m = Number(readFileSync("/sys/fs/cgroup/memory.max", "utf8").trim()); if (m > 0) return Math.min(m, totalmem()); } catch { /* no cgroup v2 */ }
+  return totalmem();
+}
+// Env values are VALIDATED: a budget that is not a finite number >= 0 ("banana", -1) falls back to the default
+// with a warning — NaN used to disable the cap silently and serialise as null; a negative one deferred everything.
+function envNumber(name: string, fallback: number, ok: (n: number) => boolean): number {
+  const raw = process.env[name]?.trim();   // " " is not a number either — Number(" ") is 0
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  if (Number.isFinite(n) && ok(n)) return n;
+  console.warn(`[config] ${name}=${JSON.stringify(raw)} is not valid — using ${fallback}`);
+  return fallback;
+}
+export const OPT_MEM_BUDGET_MB = envNumber("OPT_MEM_BUDGET_MB", Math.floor(usableMemory() / 2_000_000), (n) => n >= 0);
+// Peak RSS of an optimize pass as a multiple of the source bytes, for the
+// estimate above: measured 259MB for a 5.4MB store GLB (x48). The KTX2/LOD
+// arms were not measured separately and are assumed the same order.
+export const OPT_COST_FACTOR = envNumber("OPT_COST_FACTOR", 48, (n) => n > 0);
 export const ROOT = resolve(import.meta.dir, "..");
 // Dev instances point this elsewhere so a scratch sequencer can't append to the
 // live worlds' logs (they are append-only and forever — a stray dev spawn is
@@ -24,7 +56,10 @@ export const ROOT = resolve(import.meta.dir, "..");
 export const WORLDS_DIR = resolve(process.env.WORLDS_DIR ?? join(ROOT, "worlds"));
 // The eidoverse-video checkout = the asset library (models, VRMs, animations).
 export const LIBRARY_DIR = resolve(process.env.EIDOVERSE_DIR ?? join(ROOT, "..", "eidoverse-video"));
-export const OPT_DIR = join(ROOT, "assets", "opt");
+// Same doctrine as WORLDS_DIR: a dev or test instance points this elsewhere so it can never write derived
+// variants or markers into the live store (a harness once did — review of #172).
+export const OPT_DIR = resolve(process.env.OPT_DIR ?? join(ROOT, "assets", "opt"));
+try { mkdirSync(OPT_DIR, { recursive: true }); } catch { /* the first write will say why */ }   // an overridden OPT_DIR may not exist yet; the incarnation file lives here
 // Deliberate ASSET fixes over the library (versioned IN this repo —
 // patched/README.md carries the doctrine): /library serves these with TOP
 // precedence, so every machine gets the fix via ordinary git pull while

--- a/server/messages.ts
+++ b/server/messages.ts
@@ -16,6 +16,7 @@
 import { runVerb } from "./verbs.ts";
 import { coldLibs, warmBoxes, worldLibs } from "./boxes.ts";
 import { LIMITS } from "./limits.ts";
+import { sanePose } from "./posecheck.ts";
 import { currentIncarnation } from "./transport.ts";
 import { rightsOf, isAdminId } from "./rights.ts";
 import { ROLE_RANK } from "../shared/fold.js";
@@ -454,9 +455,17 @@ export const MESSAGES: Record<string, (ctx: MsgCtx, msg: any) => void> = {
   },
   "pose": ({ c, ws, now, expel }, msg) => {
     if (!c.world || c.spectator) return;
-    c.lastPose = msg.pose;
+    const pose = sanePose(msg.pose);
+    if (!pose) {                                  // non-finite / malformed: never relayed (posecheck.ts)
+      const cc = c as Client & { badPose?: number };
+      cc.badPose = (cc.badPose ?? 0) + 1;
+      if (cc.badPose === 1 || cc.badPose % 600 === 0)
+        console.log(`[world:${c.world.name}] dropped non-finite pose from ${c.id} (×${cc.badPose})`);
+      return;
+    }
+    c.lastPose = pose;
     // presence: batched into stage frames by the tick loop, never persisted
-    c.world.dirty.set(c.id, msg.pose);
+    c.world.dirty.set(c.id, pose);
   },
   "snap-result": ({ c, ws, now, expel }, msg) => {
     const pending = pendingSnaps.get(msg.id);

--- a/server/posecheck.ts
+++ b/server/posecheck.ts
@@ -1,0 +1,35 @@
+// A pose that reaches the wire reaches EVERY client. 2026-09-05 23:13: one NaN
+// from a waking stick made a presenter's pos/yaw NaN, and the server relayed
+// it — each receiver's lerp then held NaN until its own guard caught it. The
+// client guards remain (they fix the cause); this is the fence at the source:
+// a non-finite sample is dropped here, never batched into a frame.
+const fin = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v);
+const finArr = (a: unknown, n: number) => Array.isArray(a) && a.length === n && a.every(fin);
+
+export function sanePose(pose: unknown): Record<string, unknown> | null {
+  if (!pose || typeof pose !== "object") return null;
+  const p = pose as Record<string, unknown>;
+  if (!finArr(p.p, 3)) return null;
+  for (const k of ["yaw", "pitch", "speed"]) if (p[k] !== undefined && !fin(p[k])) return null;
+  if (p.xr !== undefined) {                       // C18: tracked head/hands (client/lib/xrbody.js)
+    const x = p.xr as Record<string, unknown> | null;
+    if (!x || typeof x !== "object" || !finArr(x.h, 4)) return null;
+    if (x.l !== undefined && !finArr(x.l, 7)) return null;
+    if (x.r !== undefined && !finArr(x.r, 7)) return null;
+    if (x.c !== undefined && !finArr(x.c, 4)) return null;
+  }
+  // held pose (bone quats), body pins and reach descriptors ride the same packet and are lerped by
+  // every receiver — a NaN anywhere inside them is the same fault. Deep finite-check, bounded depth.
+  for (const k of ["pose", "pins", "reach"]) if (p[k] != null && !finiteDeep(p[k], 0)) return null;
+  return p;
+}
+
+const MAX_DEPTH = 6, MAX_KEYS = 512;
+function finiteDeep(v: unknown, depth: number): boolean {
+  if (typeof v === "number") return Number.isFinite(v);
+  if (v === null || typeof v === "string" || typeof v === "boolean") return true;
+  if (depth > MAX_DEPTH) return false;
+  if (Array.isArray(v)) return v.length <= MAX_KEYS && v.every((x) => finiteDeep(x, depth + 1));
+  if (typeof v === "object") { const ks = Object.keys(v as object); return ks.length <= MAX_KEYS && ks.every((k) => finiteDeep((v as Record<string, unknown>)[k], depth + 1)); }
+  return false;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,11 +22,32 @@ import { verifyToken } from "./aid1.ts";
 import { resolveLibFile } from "./lint.ts";
 import { summarizeGlb } from "./geometry.ts";
 import { worlds, getWorld, type World } from "./world.ts";
-import { handleUpload } from "./upload.ts";
+import { handleUpload, optStatus } from "./upload.ts";
 import { defsPayload, avatarDefs, animationDefs } from "./defs.ts";
 import { tickStats } from "./tick.ts";
 import { entryBusStats } from "./events.ts";
 import { atomicWrite } from "./fsutil.ts";
+// client console tee (see the /clientlog route): a per-world bucket for every world this server KNOWS (loaded in
+// memory, or with a data dir on disk) plus one shared bucket for any other label, plus one global bucket — so a
+// busy world cannot starve the rest, a made-up label cannot buy quota or a file of its own, and the map is
+// bounded by the worlds that exist (review of #172: 64 invented labels once denied a real new world until restart).
+const clientLogRate = new Map<string, { at: number; n: number }>();
+const clientLogGlobal = { at: 0, n: 0 };
+const CLIENTLOG_DIR = process.env.CLIENTLOG_DIR ?? join(WORLDS_DIR, ".clientlogs");   // beside the worlds, like .perflogs — never a shared temp dir
+const CLIENTLOG_MAX_BODY = 4096, CLIENTLOG_MAX_FILE = 5_000_000, CLIENTLOG_PER_WORLD_MIN = 600, CLIENTLOG_GLOBAL_MIN = 2000;
+// EXACT-case match against the world directory listing (existsSync would say yes to every case variant on a
+// case-insensitive filesystem — each a fresh bucket and file); listed once per few seconds, never per request.
+let worldDirs: Set<string> = new Set(), worldDirsAt = 0;
+const knownWorld = (name: string) => {
+  if (worlds.has(name)) return true;
+  const now = Date.now();
+  const relist = () => { try { worldDirs = new Set(readdirSync(WORLDS_DIR)); } catch { worldDirs = new Set(); } worldDirsAt = now; };
+  if (now - worldDirsAt > 5000) relist();
+  if (!worldDirs.has(name) && now - worldDirsAt > 1000) relist();   // a miss re-lists (at most once a second): a new world is known at once
+  return worldDirs.has(name) && existsSync(join(WORLDS_DIR, name, "log.jsonl"));
+};
+const CLIENTLOG_UNKNOWN = "~unknown";   // '~' is outside the world-name alphabet, so no real world can share this file
+try { mkdirSync(CLIENTLOG_DIR, { recursive: true }); } catch (e) { console.warn(`[clientlog] cannot create ${CLIENTLOG_DIR}: ${(e as Error)?.message ?? e}`); }
 import { seatStore, announceProfileUpdate, MAX_PROPOSAL_BYTES } from "./seats.ts";
 import { agentTokens, aid1JoinIdentity } from "./auth.ts";
 
@@ -335,6 +356,54 @@ const ROUTES: Route[] = [
     ),
   },
   {
+    // client console tee — a visitor's errors and [xr] lines land in a file
+    // the operator can tail, because a headset shows an error for three
+    // seconds and a desk shows nothing. Diagnosis data, not surveillance: the
+    // line carries a timestamp and the client's text, no address. Bounded: 4 KB
+    // per body (refused above that by content-length), 600 lines/min/world and
+    // 2000/min overall, one file per KNOWN world plus one shared '~unknown' file
+    // for any other label, 5 MB per file, door-keyed by `Authorization: Bearer` (never the URL) — which means
+    // an OPEN door (JOIN_TOKEN empty, the tailnet dev posture) accepts these
+    // writes from anyone who can reach the port: do not run it open on a public
+    // box. A failed append answers 500, never a false 'ok'. Lands in
+    // $CLIENTLOG_DIR (default: WORLDS_DIR/.clientlogs).
+    match: (u, req) => u.pathname === "/clientlog" && req.method === "POST",
+    handler: async ({ req, url }) => {
+      const label = (url.searchParams.get("world") ?? "").replace(/[^a-z0-9_-]/gi, "").slice(0, 64);   // 64: the world-name limit (world.ts)
+      // a label the server does not know shares one bucket and one file. A brand-new world has no dir until its first
+      // join, so its pre-join boot lines land there too — a window, not a hole: nothing is lost, only shared.
+      // The door key rides in an Authorization header, NEVER the URL: query-carried join tokens have shown up in
+      // proxy/access diagnostics before (review of #172), and this route is called from every browser console.
+      // A key in the query is refused outright so the old client shape cannot ship by accident.
+      if (url.searchParams.has("key")) return new Response("key belongs in the Authorization header", { status: 400 });
+      const auth = req.headers.get("authorization") ?? "";
+      const key = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+      if (JOIN_TOKEN && key !== JOIN_TOKEN) return new Response("no", { status: 401 });   // the door is the first gate: no lookup for a stranger
+      const world = label && knownWorld(label) ? label : CLIENTLOG_UNKNOWN;
+      const cl = req.headers.get("content-length");
+      if (cl === null) return new Response("length required", { status: 411 });   // a chunked body would be buffered whole before the slice
+      const len = Number(cl);
+      if (!Number.isFinite(len) || len > CLIENTLOG_MAX_BODY) return new Response("too big", { status: 413 });
+      const now = Date.now();
+      if (now - clientLogGlobal.at > 60_000) { clientLogGlobal.at = now; clientLogGlobal.n = 0; }
+      if (++clientLogGlobal.n > CLIENTLOG_GLOBAL_MIN) return new Response("slow down", { status: 429 });
+      let bucket = clientLogRate.get(world);
+      if (!bucket) { bucket = { at: now, n: 0 }; clientLogRate.set(world, bucket); }   // bounded by the worlds that exist + 'unknown'
+      if (now - bucket.at > 60_000) { bucket.at = now; bucket.n = 0; }
+      if (++bucket.n > CLIENTLOG_PER_WORLD_MIN) return new Response("slow down", { status: 429 });
+      let body = "";
+      try { body = (await req.text()).slice(0, CLIENTLOG_MAX_BODY); } catch { return new Response("bad", { status: 400 }); }
+      const line = JSON.stringify({ t: new Date(now).toISOString(), line: body }) + "\n";
+      const dest = join(CLIENTLOG_DIR, `clientlog-${world}.log`);
+      try {
+        if (existsSync(dest) && Bun.file(dest).size > CLIENTLOG_MAX_FILE) return new Response("full", { status: 507 });
+        // appendFileSync, not Bun.write: Bun.write has no append and silently overwrote the file per line
+        appendFileSync(dest, line);
+      } catch (e) { console.warn(`[clientlog] append failed: ${(e as Error)?.message ?? e}`); return new Response("tee failed", { status: 500 }); }
+      return new Response("ok", { headers: { "cache-control": "no-store" } });
+    },
+  },
+  {
     match: (u) => u.pathname === "/whoami",
     handler: ({ req }) => {
       const s = sessionFromCookie(req.headers.get("cookie"));
@@ -578,6 +647,8 @@ const ROUTES: Route[] = [
         ...BUILD,
         ktx2Key: KTX2_KEY,
         lodRecipe: LOD_RECIPE,
+        // what the optimizer is doing / could not afford (config.ts OPT_MEM_BUDGET_MB)
+        opt: optStatus(),
         ...(process.env.WORLD_INSTANCE_NONCE ? { instance: process.env.WORLD_INSTANCE_NONCE } : {}),
       }),
       { headers: { "content-type": "application/json", "cache-control": "no-store" } }),

--- a/server/store-variants.ts
+++ b/server/store-variants.ts
@@ -129,11 +129,12 @@ export function isKtx2Variant(name: string): boolean {
 
 /** Anything the opt tree holds that is not an asset a client addresses by
  *  name: a KTX2 variant, a `.failed` marker (the pump's diagnostic verdict on
- *  a pass), a `.tmp` (a pass mid-write). None is a listing entry — the
+ *  a pass), a `.tmp` (a pass mid-write), a `.deferred` (a pass this host
+ *  could not afford — upload.ts). None is a listing entry — the
  *  prefetcher pushes every listed store path as a fetch, and a marker fetched
  *  as a model is a 404 on a good day. */
 export function isServingArtifact(name: string): boolean {
-  return isKtx2Variant(name) || isLodVariant(name) || /\.(failed|tmp)$/i.test(name);
+  return isKtx2Variant(name) || isLodVariant(name) || /\.(failed|tmp|deferred)$/i.test(name);
 }
 
 /** Is this store/ entry an upload, as opposed to a variant of one? The

--- a/server/upload.ts
+++ b/server/upload.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync, rmSync } from "node:fs";
 import { join, basename, dirname, relative } from "node:path";
-import { JOIN_TOKEN, UPLOAD_CAP, ROOT, OPT_DIR, STORE_MIN, LIBRARY_DIR } from "./config.ts";
+import { JOIN_TOKEN, UPLOAD_CAP, ROOT, OPT_DIR, STORE_MIN, LIBRARY_DIR, SKIP_OPT_SWEEP, OPT_MEM_BUDGET_MB, OPT_COST_FACTOR } from "./config.ts";
 // merge 2026-09-01 (anima a468cba, geometry LOD): upstream's LOD names ride
 // in; the door stays on R1's aid1JoinIdentity (the HN_*/verifyToken form is
 // what it replaced — the merged body references neither)
@@ -35,7 +35,26 @@ const optQueue: OptItem[] = [];
 let optRunning = false;
 let ktx2Skip = false; // set when a --ktx2 run exits 3 (no encoder) — stop queuing variants this boot
 let lodEncoderWarned = false; // the --lod arm's own once-per-boot note; it never sets ktx2Skip
-function queueOptimize(absPath: string) {
+// Items this host could not afford (estimate over budget, or the child died
+// under the cap). Informational: the marker never blocks a retry — the next
+// boot re-estimates against whatever budget it has — it exists so /version
+// can say how much is waiting on a bigger box. The count is this boot's;
+// the markers persist (and are never listing entries — store-variants.ts).
+const optDeferred = new Set<string>();
+if (process.env.OPT_CMD) console.warn(`[optimize] OPT_CMD=${process.env.OPT_CMD} — a stand-in optimizer is in charge of every variant this boot`);
+export function optStatus() {
+  return { budgetMB: OPT_MEM_BUDGET_MB, queued: optQueue.length, running: optRunning, deferred: optDeferred.size };
+}
+function undefer(dest: string) {
+  optDeferred.delete(dest);
+  if (existsSync(`${dest}.deferred`)) try { rmSync(`${dest}.deferred`); } catch { /* best effort */ }
+}
+function defer(dest: string, why: string) {
+  optDeferred.add(dest);
+  try { mkdirSync(dirname(dest), { recursive: true }); writeFileSync(`${dest}.deferred`, why); } catch { /* best effort */ }
+  console.log(`[optimize] deferred ${basename(dest)} — ${why}`);
+}
+export function queueOptimize(absPath: string) {
   let pushed = false;
   if (!optQueue.some((q) => q.src === absPath && !q.mode)) {
     optQueue.push({ src: absPath, dest: join(STORE_MIN, basename(absPath)) });
@@ -63,9 +82,13 @@ function queueOptimize(absPath: string) {
   }
   if (pushed) pumpOptimize();
 }
+let optPump: Promise<void> = Promise.resolve();
+/** Resolves when the pump has drained (a harness awaits this; the server never does). */
+export const optIdle = () => optPump;
 async function pumpOptimize() {
   if (optRunning) return;
   optRunning = true;
+  let done!: () => void; optPump = new Promise<void>((r) => { done = r; });
   try {
     while (optQueue.length) {
       const { src, dest, mode } = optQueue.shift()!;
@@ -79,14 +102,52 @@ async function pumpOptimize() {
       // KTX2 variants shadow MUTABLE library files, so a variant older than
       // its source rebuilds (the sweep filters too, but a file can change
       // while its item waits behind slow encodes).
-      if (existsSync(dest) && (!mode || statSync(dest).mtimeMs > statSync(src).mtimeMs)) continue;
+      if (existsSync(dest) && (!mode || statSync(dest).mtimeMs > statSync(src).mtimeMs)) { undefer(dest); continue; }   // done elsewhere: a stale .deferred must not outlive the variant
+      // Budget gate: an item this host cannot afford is deferred, not failed,
+      // and the rest of the queue keeps going (config.ts OPT_MEM_BUDGET_MB).
+      const estMB = Math.ceil(Bun.file(src).size * OPT_COST_FACTOR / 1_000_000);
+      if (OPT_MEM_BUDGET_MB && estMB > OPT_MEM_BUDGET_MB) { defer(dest, `estimated ${estMB}MB > budget ${OPT_MEM_BUDGET_MB}MB`); continue; }
       mkdirSync(dirname(dest), { recursive: true });
-      // process.execPath = the running bun binary — PATH under systemd has no bun
-      const proc = Bun.spawn([process.execPath, "run", join(ROOT, "server", "optimize.ts"), ...(mode ? [mode] : []), src, dest],
-        { stdout: "pipe", stderr: "pipe" });
+      // process.execPath = the running bun binary — PATH under systemd has no bun.
+      // Under a budget (Linux: the only kernel that enforces RLIMIT_DATA) the
+      // child runs beneath sh's `ulimit -d` (KB): an encode that outgrows it
+      // dies AS THE CHILD — a signal, SIGTRAP or SIGSEGV, exit ≥128, nothing
+      // on stderr (measured) — and the server serving worlds is never the
+      // casualty. RLIMIT_AS would be wrong here: bun reserves address space
+      // far beyond what it touches. The wrapper's OWN failures are made
+      // unmistakable (126: the limit could not be set — a hard limit below
+      // the budget; 127: exec failed) so they never read as a content verdict.
+      const capped = OPT_MEM_BUDGET_MB > 0 && process.platform === "linux";
+      // OPT_CMD: a harness may own the child (tools/optimize-pump-test.ts) — the real optimizer otherwise (logged at boot)
+      const cmd = [...(process.env.OPT_CMD ? [process.env.OPT_CMD] : [process.execPath, "run", join(ROOT, "server", "optimize.ts")]), ...(mode ? [mode] : []), src, dest];
+      let proc: ReturnType<typeof Bun.spawn>;
+      try {
+        // /bin/sh by absolute path: the pump may run under a PATH that has no
+        // shell at all (a harness pointing PATH at its fake encoder), and a
+        // spawn that cannot start throws HERE, synchronously — which would
+        // reject the un-awaited pump and drop the rest of the queue.
+        proc = Bun.spawn(capped
+          ? ["/bin/sh", "-c", 'ulimit -d "$0" || exit 126; exec "$@"', String(OPT_MEM_BUDGET_MB * 1024), ...cmd]
+          : cmd, { stdout: "pipe", stderr: "pipe" });
+      } catch (e) {
+        console.error(`[optimize] cannot spawn the optimizer (${String(e).split("\n")[0]}) — nothing marked; set OPT_MEM_BUDGET_MB=0 if /bin/sh is the problem`);
+        optQueue.length = 0; break;
+      }
       const code = await proc.exited;
       const err = (await new Response(proc.stderr).text()).trim();
+      if (capped && (code === 126 || code === 127)) {
+        // environmental, like a missing dep: no marker, and no point grinding on
+        console.error(`[optimize] cap wrapper failed (exit ${code}: ${err.split("\n").pop() || "sh"}) — set OPT_MEM_BUDGET_MB within this process's hard RLIMIT_DATA, or 0`);
+        optQueue.length = 0; break;
+      }
+      if (capped && (proc.signalCode || code >= 128)) {
+        // OOM under the cap and a crash on a corrupt file look the same from
+        // here; both are retried next boot (a signal is never a stuck verdict).
+        defer(dest, `child died (${proc.signalCode ?? `exit ${code}`}) under the ${OPT_MEM_BUDGET_MB}MB cap`);
+        continue;
+      }
       if (code === 0) {
+        undefer(dest);
         // a verdict that was re-measured and answered differently is history
         if (existsSync(failed)) try { rmSync(failed); } catch { /* best effort */ }
         // …and so is an older recipe generation's file: its URL is never
@@ -104,7 +165,7 @@ async function pumpOptimize() {
         // not suitable — bigger than source, or (--ktx2-img) non-POT dims /
         // conflicted consumers. Mark with the CLI's reason so the boot sweep
         // stops re-measuring it; the marker's CONTENT is diagnostic only.
-        writeFileSync(failed, err.slice(0, 2000) || "not-smaller");
+        writeFileSync(failed, err.slice(0, 2000) || "not-smaller"); undefer(dest);
         console.log(mode ? `[ktx2] ${base} — no variant (${err.split("\n").pop()?.replace(/^\[optimize\]\s*/, "") || "not smaller"})`
           : `[store] ${base} already lean — serving original`);
       } else if (code === 4) {
@@ -140,16 +201,20 @@ async function pumpOptimize() {
         // file — that would permanently skip every upload made before the
         // first successful `bun install`. Only content failures stick.
         const envFail = /cannot find module|cannot resolve|error: script not found/i.test(err);
-        if (!envFail) writeFileSync(failed, err.slice(0, 2000) || `exit ${code}`);
+        if (!envFail) { writeFileSync(failed, err.slice(0, 2000) || `exit ${code}`); undefer(dest); }
         console.error(`[${mode ? "ktx2" : "store"}] optimize ${envFail ? "unavailable (deps?)" : `FAILED ${base}`}: ${err.split("\n")[0] || `exit ${code}`}`);
         if (envFail) { optQueue.length = 0; break; } // no point grinding the rest
       }
     }
-  } finally { optRunning = false; }
+  } finally { optRunning = false; done(); }
 }
 // Boot sweep: whatever accumulated before this shipped (or failed mid-queue
 // last run) gets its shadow now. Deferred so boot stays about serving worlds.
-setTimeout(() => {
+// SKIP_OPT_SWEEP: see config.ts — a memory-tight host must be able to serve
+// worlds without shouldering the optimizer.
+/** The store sweep (named so a harness can drive it; the boot timer below calls it). */
+export function sweepStore() {
+  if (SKIP_OPT_SWEEP) return;
   const dir = join(OPT_DIR, "store");
   if (!existsSync(dir)) return;
   // isStoreOriginal, not endsWith(".glb"): the KTX2 variants live in this
@@ -164,7 +229,8 @@ setTimeout(() => {
   if (!pending.length) return;
   console.log(`[store] boot sweep: ${pending.length} upload(s) missing a shadow queued`);
   for (const f of pending) queueOptimize(join(dir, f));
-}, 5000);
+}
+setTimeout(sweepStore, 5000).unref?.();   // a harness that imports this must not be held open by the timer
 // Library KTX2 sweep (§20a, VRMs §20c, loose images §20d): every library
 // model gets a GPU-native-texture variant at OPT_DIR/<rel>.ktx2.glb, every
 // avatar a surgical-rewrite variant at OPT_DIR/<rel>.ktx2.vrm, and every
@@ -177,7 +243,9 @@ setTimeout(() => {
 // byte-preserved). Avatars live in TWO bases — Skye's library and the upload
 // overlay (assets/opt/...) — and serving prefers the overlay, so the sweep
 // sources each rel from the base that actually wins.
-setTimeout(() => {
+/** The library KTX2/LOD sweep — same seam. */
+export function sweepLibrary() {
+  if (SKIP_OPT_SWEEP) return;
   if (ktx2Skip) return;
   const items: OptItem[] = [];
   const seen = new Set<string>();
@@ -231,7 +299,8 @@ setTimeout(() => {
   console.log(`[ktx2] boot sweep: ${items.length} library asset(s) queued for variants`);
   optQueue.push(...items);
   pumpOptimize();
-}, 15_000);
+}
+setTimeout(sweepLibrary, 15_000).unref?.();
 
 // ---- the endpoint -----------------------------------------------------------
 

--- a/tools/clientlog-test.ts
+++ b/tools/clientlog-test.ts
@@ -1,0 +1,42 @@
+// bun tools/clientlog-test.ts — the /clientlog tee through the REAL route(): auth, length gates, a known world
+// gets its own file, an unknown label shares one, rate buckets answer 429, and a failed append answers 500 —
+// never a false ok.
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, chmodSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+const wd = mkdtempSync(join(tmpdir(), "clientlog-worlds-")); const ld = join(wd, ".clientlogs");
+process.env.WORLDS_DIR = wd; process.env.CLIENTLOG_DIR = ld; process.env.JOIN_TOKEN = "test-door";
+mkdirSync(join(wd, "known"), { recursive: true }); writeFileSync(join(wd, "known", "log.jsonl"), "");   // a world with a data dir = known
+const { route } = await import("../server/routes.ts");
+const ok = (v: unknown, why: string) => { if (!v) { console.error("FAIL", why); process.exit(1); } };
+const srv: any = { requestIP: () => ({ address: "127.0.0.1" }), upgrade: () => false };
+const post = (q: string, body = "hello", headers: Record<string, string> = { authorization: "Bearer test-door" }) =>
+  route(new Request(`http://x/clientlog?${q}`, { method: "POST", body, headers: { "content-length": String(Buffer.byteLength(body)), ...headers } }), srv);
+const st = async (r: Response | Promise<Response>) => (await r).status;
+ok(await st(post("world=known", "hello", {})) === 401, "no Authorization → 401");
+ok(await st(post("world=known", "hello", { authorization: "Bearer wrong" })) === 401, "wrong key → 401");
+ok(await st(post("world=known&key=test-door")) === 400, "a key in the URL is refused (400) even when correct — the record path never carries the door");
+const streamed = new Request("http://x/clientlog?world=known", { method: "POST", body: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("x")); c.close(); } }), duplex: "half", headers: { authorization: "Bearer test-door" } } as RequestInit);
+ok(streamed.headers.get("content-length") === null && await st(route(streamed, srv)) === 411, "a streamed body (no content-length) → 411");
+ok(await st(post("world=known", "y".repeat(5000))) === 413, "4 KB+ → 413");
+ok(await st(post("world=known", "line one")) === 200, "known world → 200");
+ok(existsSync(join(ld, "clientlog-known.log")), "known world gets its own file");
+ok(await st(post("world=madeup-9x", "from nowhere")) === 200, "unknown label → accepted");
+ok(!existsSync(join(ld, "clientlog-madeup-9x.log")) && existsSync(join(ld, "clientlog-~unknown.log")), "unknown label shares the '~unknown' file, never its own");
+ok(await st(post("world=KNOWN", "case variant")) === 200 && readFileSync(join(ld, "clientlog-~unknown.log"), "utf8").includes("case variant") && !readFileSync(join(ld, "clientlog-known.log"), "utf8").includes("case variant"), "a case variant of a real world routes to ~unknown, not the known stream (asserted on content — path case aliases on macOS)");
+const long = "w".repeat(50); mkdirSync(join(wd, long), { recursive: true }); writeFileSync(join(wd, long, "log.jsonl"), ""); await new Promise((r) => setTimeout(r, 1100));   // past the miss-relist rate limit
+ok(await st(post(`world=${long}`, "long name")) === 200 && existsSync(join(ld, `clientlog-${long}.log`)), "a 50-char world name (under the 64 limit) keeps its own file");
+ok(readFileSync(join(ld, "clientlog-~unknown.log"), "utf8").includes("from nowhere") && !readFileSync(join(ld, "clientlog-~unknown.log"), "utf8").includes('"ip"'), "line written, no address recorded");
+for (let i = 0; i < 64; i++) await post(`world=label${i}`, "z");
+ok(await st(post("world=known", "still fine")) === 200, "64 invented labels do not deny a real world (they all shared one bucket)");
+let last = 200; for (let i = 0; i < 700; i++) last = await st(post("world=known", "spam"));
+ok(last === 429, "per-world minute bucket → 429 after 600");
+if (process.getuid?.() !== 0) {
+  mkdirSync(join(wd, "fresh"), { recursive: true }); writeFileSync(join(wd, "fresh", "log.jsonl"), "");   // a known world with NO log file yet
+  await new Promise((r) => setTimeout(r, 1100));                                                          // past the miss-relist rate limit
+  chmodSync(ld, 0o500);                                                                                  // a read-only dir blocks creating one
+  ok(await st(post("world=fresh", "into a wall")) === 500, "unwritable log dir → 500, not a false ok");
+  chmodSync(ld, 0o700);
+} else console.log("(root: skipping the unwritable-dir case)");
+console.log("clientlog: 15 ok");
+import("node:fs").then((fs) => { try { fs.rmSync(process.env.WORLDS_DIR!, { recursive: true, force: true }); } catch {} });

--- a/tools/config-env-test.ts
+++ b/tools/config-env-test.ts
@@ -1,0 +1,21 @@
+// bun tools/config-env-test.ts — env numbers are validated (config.ts envNumber): a nonsense or negative
+// OPT_MEM_BUDGET_MB falls back to the default with a warning; 0 stays 0 (no cap); a cost factor must be > 0.
+import { spawnSync } from "node:child_process";
+const ok = (v: unknown, why: string) => { if (!v) { console.error("FAIL", why); process.exit(1); } };
+const read = (env: Record<string, string>) => {
+  const r = spawnSync(process.execPath, ["-e", 'import { OPT_MEM_BUDGET_MB, OPT_COST_FACTOR } from "./server/config.ts"; console.log(JSON.stringify({ b: OPT_MEM_BUDGET_MB, f: OPT_COST_FACTOR }))'],
+    { env: { ...process.env, WORLDS_DIR: process.env.WORLDS_DIR ?? "/tmp/config-env-test-worlds", ...env }, encoding: "utf8", cwd: import.meta.dir + "/.." });
+  const line = r.stdout.trim().split("\n").pop() ?? "";
+  return { v: JSON.parse(line), warn: r.stderr + r.stdout };
+};
+const base = read({});
+ok(Number.isFinite(base.v.b) && base.v.b >= 0 && base.v.f === 48, "defaults: finite budget, factor 48");
+const banana = read({ OPT_MEM_BUDGET_MB: "banana" });
+ok(banana.v.b === base.v.b && /not valid/.test(banana.warn), "'banana' → default, with a warning");
+const neg = read({ OPT_MEM_BUDGET_MB: "-1" });
+ok(neg.v.b === base.v.b && /not valid/.test(neg.warn), "-1 → default, with a warning");
+ok(read({ OPT_MEM_BUDGET_MB: "0" }).v.b === 0, "0 → 0 (no cap, documented)");
+ok(read({ OPT_MEM_BUDGET_MB: "512" }).v.b === 512, "512 → 512");
+ok(read({ OPT_COST_FACTOR: "0" }).v.f === 48 && read({ OPT_COST_FACTOR: "abc" }).v.f === 48, "cost factor 0 / 'abc' → 48");
+ok(read({ OPT_COST_FACTOR: "12" }).v.f === 12, "cost factor 12 → 12");
+console.log("config-env: 7 ok");

--- a/tools/optimize-pump-test.ts
+++ b/tools/optimize-pump-test.ts
@@ -1,0 +1,88 @@
+// bun tools/optimize-pump-test.ts — the optimizer pump with a FAKE child (OPT_CMD): estimate defer with queue
+// continuation, success (+ stale .deferred retired), 'not smaller' marker, capped child death → .deferred and
+// retried, wrapper 126 → environmental (no marker, queue dropped), stale-marker retirement when the variant
+// exists already, and both boot sweeps skipped under SKIP_OPT_SWEEP (subprocess). Each case owns its store.
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, chmodSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+const ok = (v: unknown, why: string) => { if (!v) { console.error("FAIL", why); process.exit(1); } };
+const root = mkdtempSync(join(tmpdir(), "optpump-"));
+const fake = join(root, "fake-optimizer.sh");
+// the fake child reads its verdict from a file beside the source: "0" writes dest, "2" exits 2, "sig" dies by SIGSEGV
+writeFileSync(fake, `#!/bin/sh
+src=""; dest=""
+for a in "$@"; do case "$a" in --*) ;; *) if [ -z "$src" ]; then src="$a"; else dest="$a"; fi;; esac; done
+v=$(cat "$src.verdict" 2>/dev/null || echo 0)
+[ -n "$OPT_RECEIPTS" ] && echo "$dest" >> "$OPT_RECEIPTS"   # every invocation leaves a receipt the harness can count
+case "$v" in
+  0) mkdir -p "$(dirname "$dest")"; printf 'tiny' > "$dest"; exit 0;;
+  sig) kill -SEGV $$;;
+  *) echo "fake verdict $v" >&2; exit "$v";;
+esac
+`); chmodSync(fake, 0o755);
+process.env.SKIP_OPT_SWEEP = "1";   // the parent's own boot timers must not sweep the real library through the fake
+process.env.WORLDS_DIR = join(root, "worlds"); process.env.OPT_DIR = join(root, "opt"); process.env.JOIN_TOKEN = "t"; process.env.OPT_CMD = fake;   // OPT_DIR: NEVER the checkout's store
+process.env.OPT_MEM_BUDGET_MB = "10"; process.env.OPT_COST_FACTOR = "1"; process.env.KTX2_TOKTX = "";
+const { queueOptimize, optIdle } = await import("../server/upload.ts");
+const { STORE_MIN } = await import("../server/config.ts");
+const src = (name: string, bytes: number, verdict: string) => {
+  const dir = join(root, "src"); mkdirSync(dir, { recursive: true });
+  const p = join(dir, name); writeFileSync(p, Buffer.alloc(bytes, 1)); writeFileSync(p + ".verdict", verdict); return p;
+};
+const storeDest = (p: string) => join(STORE_MIN, p.split("/").pop()!);
+// 1. estimate defer: 20 MB × factor 1 > 10 MB budget → .deferred, and the NEXT item still runs
+const big = src("big.glb", 20_000_000, "0"), small = src("small.glb", 1000, "0");
+queueOptimize(big); queueOptimize(small); await optIdle();
+ok(existsSync(storeDest(big) + ".deferred") && /budget/.test(readFileSync(storeDest(big) + ".deferred", "utf8")), "over-budget item deferred with the reason");
+ok(existsSync(storeDest(small)) && readFileSync(storeDest(small), "utf8") === "tiny", "queue continued: the small item after it succeeded");
+// 2. success retires a stale .deferred
+const s2 = src("s2.glb", 1000, "0"); writeFileSync(storeDest(s2) + ".deferred", "old");
+queueOptimize(s2); await optIdle();
+ok(existsSync(storeDest(s2)) && !existsSync(storeDest(s2) + ".deferred"), "success removed the stale .deferred");
+// 3. exit 2 = not smaller → .failed marker, no .deferred
+const s3 = src("s3.glb", 1000, "2"); queueOptimize(s3); await optIdle();
+ok(existsSync(storeDest(s3) + ".failed") && !existsSync(storeDest(s3)), "exit 2 → .failed marker, no variant");
+// 4. a variant that exists already (done elsewhere) retires a stale .deferred without spawning
+const s4 = src("s4.glb", 1000, "0"); mkdirSync(STORE_MIN, { recursive: true }); writeFileSync(storeDest(s4), "done-elsewhere"); writeFileSync(storeDest(s4) + ".deferred", "stale");
+queueOptimize(s4); await optIdle();
+ok(!existsSync(storeDest(s4) + ".deferred") && readFileSync(storeDest(s4), "utf8") === "done-elsewhere", "existing variant: stale .deferred retired, variant untouched");
+// 5. capped child death (Linux only: the cap wrapper) → .deferred with 'child died', queue continues
+if (process.platform === "linux") {
+  const s5 = src("s5.glb", 1000, "sig"), s6 = src("s6.glb", 1000, "0"); queueOptimize(s5); queueOptimize(s6); await optIdle();
+  ok(existsSync(storeDest(s5) + ".deferred") && /died/.test(readFileSync(storeDest(s5) + ".deferred", "utf8")), "signalled child under the cap → .deferred 'child died'");
+  ok(existsSync(storeDest(s6)), "queue continued after the death");
+  // 6. wrapper 126 (a hard RLIMIT_DATA below the budget) → environmental: no marker, queue dropped
+  // a 1 MB HARD data limit (soft first — dash refuses to drop the hard limit below the soft one) makes the wrapper's
+  // `ulimit -d 20480` fail: the 126 path. bun itself must still start under it, or the case is skipped.
+  const canLimit = spawnSync("/bin/sh", ["-c", "ulimit -S -d 2000000 && ulimit -H -d 2000000 && /bin/sh -c 'ulimit -d 4000000000' 2>/dev/null; echo $?"], { encoding: "utf8" }).stdout.trim();   // a 2 GB hard limit (bun starts) that a 4 TB budget cannot raise
+  if (canLimit !== "0") {
+    const sh = spawnSync("/bin/sh", ["-c", `ulimit -S -d 2000000 && ulimit -H -d 2000000; exec "${process.execPath}" -e 'process.env.OPT_MEM_BUDGET_MB="4000000000"; const {queueOptimize,optIdle}=await import("./server/upload.ts"); const {STORE_MIN}=await import("./server/config.ts"); const fs=await import("node:fs"); const p=${JSON.stringify(join(root, "src", "s8.glb"))}; fs.writeFileSync(p, Buffer.alloc(1000,1)); fs.writeFileSync(p+".verdict","0"); queueOptimize(p); await optIdle(); console.log(JSON.stringify({variant:fs.existsSync(STORE_MIN+"/s8.glb"), deferred:fs.existsSync(STORE_MIN+"/s8.glb.deferred"), failed:fs.existsSync(STORE_MIN+"/s8.glb.failed")}))'`],
+      { env: { ...process.env, OPT_MEM_BUDGET_MB: "4000000000" }, cwd: import.meta.dir + "/..", encoding: "utf8" });
+    const line = sh.stdout.split("\n").find((l) => l.startsWith("{")) ?? "{}";   // the boot-sweep timers log after the JSON
+    try { const v = JSON.parse(line); const loud = /cap wrapper failed/.test(sh.stderr + sh.stdout);
+      if (v.variant || v.deferred || v.failed || !loud) console.error("126 case saw", JSON.stringify(v), "loud=" + loud, "| tail:", (sh.stderr + sh.stdout).trim().split("\n").slice(-3).join(" // ").slice(0, 400));
+      ok(!v.variant && !v.deferred && !v.failed && loud, "wrapper 126: no variant, no marker, loud"); console.log("(126 case ran: wrapper refused under the hard limit, nothing marked)"); }
+    catch { console.log("(126 case: bun could not start under the hard limit — skipped: " + (sh.stderr + sh.stdout).split("\n").pop() + ")"); }
+  } else console.log("(126 case: cannot set a hard data limit here — skipped)");
+} else console.log("(non-Linux: capped-death and 126 cases skipped)");
+// 7. SKIP_OPT_SWEEP: with it set, both sweeps queue NOTHING even with a GLB planted in the store; without it,
+//    the same store queues the planted GLB (the positive control). Each direction is its own subprocess: the
+//    flag is a config constant read at import.
+const { OPT_DIR } = await import("../server/config.ts");
+mkdirSync(join(OPT_DIR, "store"), { recursive: true }); writeFileSync(join(OPT_DIR, "store", "planted.glb"), Buffer.alloc(500, 1));
+const receipts = join(root, "sweep-receipts");
+const sweep = (skip: boolean) => {
+  const rf = join(receipts, skip ? "skip.txt" : "run.txt"); mkdirSync(receipts, { recursive: true }); writeFileSync(rf, "");
+  const r = spawnSync(process.execPath, ["-e", 'const u = await import("./server/upload.ts"); u.sweepStore(); u.sweepLibrary(); await u.optIdle(); console.log(JSON.stringify(u.optStatus()))'],
+    { env: { ...process.env, SKIP_OPT_SWEEP: skip ? "1" : "0", OPT_RECEIPTS: rf }, cwd: import.meta.dir + "/..", encoding: "utf8" });
+  const status = JSON.parse(r.stdout.split("\n").find((l) => l.startsWith("{")) || "{}");
+  const invoked = readFileSync(rf, "utf8").split("\n").filter(Boolean);
+  return { status, invoked };
+};
+// deterministic: the subprocess awaits optIdle() and the proof is the fake child's own receipts, not a queue snapshot
+const skipped = sweep(true), ran = sweep(false);
+ok(skipped.invoked.length === 0 && skipped.status.queued === 0, `SKIP_OPT_SWEEP=1: the child was never invoked (${skipped.invoked.length} receipts)`);
+ok(ran.invoked.some((d) => d.includes("planted.glb")), `SKIP_OPT_SWEEP unset: the planted GLB reached the child (${ran.invoked.length} receipts)`);
+import("node:fs").then((fs) => fs.rmSync(root, { recursive: true, force: true }));
+console.log("optimize-pump: cases passed");

--- a/tools/pose-handler-test.ts
+++ b/tools/pose-handler-test.ts
@@ -1,0 +1,24 @@
+// bun tools/pose-handler-test.ts — the pose fence is PRODUCT-BOUND: the real "pose" message handler
+// (server/messages.ts) neither updates lastPose nor stages a frame for a malformed sample, and does both
+// for a finite one. Deleting sanePose() from the handler turns this red; so does deleting posecheck.ts.
+process.env.WORLDS_DIR ??= require("node:fs").mkdtempSync(require("node:os").tmpdir() + "/pose-handler-");
+process.env.JOIN_TOKEN ??= "test-door";
+const { MESSAGES } = await import("../server/messages.ts");
+const ok = (v: unknown, why: string) => { if (!v) { console.error("FAIL", why); process.exit(1); } };
+const sent: string[] = [];
+const dirty = new Map<string, unknown>();
+const c: any = { id: "c1", world: { name: "w", dirty }, lastPose: { p: [9, 9, 9] } };
+const ctx: any = { c, ws: { send: (d: string) => sent.push(d) }, now: Date.now(), expel: () => {} };
+const before = c.lastPose;
+MESSAGES["pose"](ctx, { type: "pose", pose: { p: [NaN, 0, 0], yaw: 0 } });
+ok(c.lastPose === before, "malformed pose: lastPose untouched");
+ok(dirty.size === 0, "malformed pose: nothing staged for broadcast");
+MESSAGES["pose"](ctx, { type: "pose", pose: { p: [1, 0, 2], yaw: 0.5, pose: { hips: [0, 0, 0, NaN] } } });
+ok(c.lastPose === before && dirty.size === 0, "NaN buried in a bone quat: still nothing staged");
+const fine = { p: [1, 0, 2], yaw: 0.5, speed: 0 };
+MESSAGES["pose"](ctx, { type: "pose", pose: fine });
+ok(c.lastPose === fine, "finite pose: lastPose updated");
+ok(dirty.get("c1") === fine, "finite pose: staged for the next frame");
+ok(sent.length === 0, "the pose handler answers nothing on the socket");
+console.log("pose-handler: 6 ok");
+import("node:fs").then((fs) => { try { fs.rmSync(process.env.WORLDS_DIR!, { recursive: true, force: true }); } catch {} });

--- a/tools/posecheck-test.ts
+++ b/tools/posecheck-test.ts
@@ -1,0 +1,30 @@
+// bun tools/posecheck-test.ts — the pose fence (server/posecheck.ts)
+import { sanePose } from "../server/posecheck.ts";
+const ok = (v: unknown, why: string) => { if (!v) { console.error("FAIL", why); process.exit(1); } };
+const good = { p: [1, 0, 2], yaw: 0.3, speed: 0, clip: "idle", pitch: 0 };
+ok(sanePose(good) === good, "a finite pose passes through untouched");
+ok(sanePose({ ...good, p: [NaN, 0, 2] }) === null, "NaN position dropped");
+ok(sanePose({ ...good, yaw: NaN }) === null, "NaN yaw dropped");
+ok(sanePose({ ...good, yaw: Infinity }) === null, "Infinity yaw dropped");
+ok(sanePose({ ...good, p: [1, 0] }) === null, "short position dropped");
+ok(sanePose({ ...good, p: ["1", 0, 2] }) === null, "string position dropped");
+ok(sanePose(null) === null && sanePose("x") === null, "non-object dropped");
+ok(sanePose({ p: [0, 0, 0] }) !== null, "minimal pose (no yaw) passes");
+const xr = { h: [0, 0, 0, 1], r: [0.1, 1.1, 0.3, 0, 0, 0, 1], c: [0, 0, 1, 0] };
+ok(sanePose({ ...good, xr }) !== null, "C18 xr passes");
+ok(sanePose({ ...good, xr: { ...xr, h: [NaN, 0, 0, 1] } }) === null, "NaN head quat dropped");
+ok(sanePose({ ...good, xr: { ...xr, r: [0, 1, 2] } }) === null, "short grip dropped");
+ok(sanePose({ ...good, xr: { h: [0, 0, 0, 1] } }) !== null, "xr with head only passes");
+ok(sanePose({ ...good, xr: null }) === null, "null xr dropped");
+// the deep fence: held pose (bone quats), pins, reach — a NaN anywhere inside is the same fault
+const deep = { ...good, pose: { hips: [0, 0, 0, 1], head: [0.1, 0, 0, 0.99] }, pins: [{ bone: "leftHand", p: [1, 2, 3] }], reach: { right: { t: { p: [0, 1, 0] }, palm: 0.5 } } };
+ok(sanePose(deep) !== null, "deep pose/pins/reach pass");
+ok(sanePose({ ...deep, pose: { hips: [0, NaN, 0, 1] } }) === null, "NaN buried in a bone quat dropped");
+ok(sanePose({ ...deep, pins: [{ bone: "x", p: [1, Infinity, 3] }] }) === null, "Infinity buried in a pin dropped");
+ok(sanePose({ ...deep, reach: { right: { t: { p: [0, 1, NaN] } } } }) === null, "NaN buried in reach dropped");
+ok(sanePose({ ...good, pose: null, pins: null, reach: null }) !== null, "null clears pass (the client's 'let go' contract)");
+let nest: unknown = 1; for (let i = 0; i < 8; i++) nest = { a: nest };
+ok(sanePose({ ...good, pose: nest }) === null, "a container nested past MAX_DEPTH dropped");
+const wide: Record<string, number> = {}; for (let i = 0; i < 600; i++) wide["k" + i] = 0;
+ok(sanePose({ ...good, pins: wide }) === null, "a container wider than MAX_KEYS dropped");
+console.log("posecheck: 20 ok");

--- a/tools/store-variants-test.ts
+++ b/tools/store-variants-test.ts
@@ -179,7 +179,7 @@ console.log("\nthe store's KTX2 shadow (store-variants.ts, shared/ktx2.js):\n");
   for (const o of ["x.glb", "aletheia.vrm", "moon_color_1k.jpg", "manifest.json", "sky_system.js"])
     check(`${o} is not`, !isKtx2Variant(o) && !isServingArtifact(o));
   // …nor fetches a marker as a model (review of #142, P2)
-  for (const a of ["x.glb.ktx2.glb.failed", "x.glb.failed", "x.glb.tmp", "manifest.json.tmp", "x.glb.ktx2.glb.tmp"])
+  for (const a of ["x.glb.ktx2.glb.failed", "x.glb.failed", "x.glb.tmp", "manifest.json.tmp", "x.glb.ktx2.glb.tmp", "x.glb.ktx2.glb.deferred", "x.glb.lod.lod1-r25e01-texel1024.glb.deferred"])
     check(`${a} is a serving artifact, never a listing entry`, isServingArtifact(a));
   check("the listing the prefetcher sees is originals + the manifest only",
     listing.filter((f) => !isServingArtifact(f)).join(",") === "305ea80018ad4dbf.glb,a1b2c3d4e5f60718.glb,manifest.json,scripts");


### PR DESCRIPTION
# Server hardening: pose fence, bounded client-log tee, upload/config/store fixes (1 of 4)

Part 1 of a 4-rung stacked series that brings headset presence (VR alpha) to eidoverse-worlds. Server only — no client files — so it stands entirely on its own. (The related kv doc note lives in #153.)

## What's in it
- **`server/posecheck.ts` (+ `tools/posecheck-test.ts`)** — the fence at the source: a pose with a non-finite number anywhere in it (`p`, `yaw/pitch/speed`, tracked `xr` head/hands, and now the held `pose`, `pins` and `reach` descriptors) is dropped at the server, never batched into a frame. One waking controller used to make every receiver's IK hold NaN until its own guard caught it. Wired in `messages.ts`, with a throttled log.
- **`/clientlog` (`routes.ts`)** — the console tee an operator can tail (a headset shows an error for three seconds; a desk shows nothing). The client that posts to it arrives in part 2 (`base.js`), so at this rung the endpoint is inert. Diagnosis data, not surveillance: timestamp + the client's text, no address. Bounded: 4 KB per body refused by `content-length` (411 without the header), 600 lines/min/world and 2000/min overall, at most 64 world files (no eviction — a fresh name buys no fresh quota), 5 MB per file, key-gated like the door; lands beside the worlds in `WORLDS_DIR/.clientlogs` (`CLIENTLOG_DIR` overrides) and warns instead of swallowing when the append fails.
- **`upload.ts`** — the boot optimize sweeps (encode pump + ktx2/lod) are skippable with `SKIP_OPT_SWEEP=1` on a memory-tight host (documented in `AGENTS.md`); deferred items are excluded from listings.
- **`config.ts`, `store-variants.ts` (+ test)** — small hardenings.

## Auth shape
`/clientlog` is door-keyed by `Authorization: Bearer <JOIN_TOKEN>` — never a query parameter (query-carried join tokens have appeared in proxy/access diagnostics). A `?key=` in the URL is refused with 400 so the older client shape cannot ship by accident; the browser tee (part 2, `client/lib/base.js`) sends the header.

## Tests (each goes red if its fix is reverted)
- `bun tools/posecheck-test.ts` — 20 ok (flat fields, `xr`, deep `pose`/`pins`/`reach`, `MAX_DEPTH`, `MAX_KEYS`)
- `bun tools/pose-handler-test.ts` — 6 ok: drives the real `MESSAGES.pose` handler with a fake client; a malformed sample leaves `lastPose` and the stage map untouched, a finite one updates both; deleting `sanePose()` turns it red
- `bun tools/clientlog-test.ts` — 15 ok, through the real `route()`: no `Authorization` → 401, wrong key → 401, **a key in the URL → 400 even when correct** (the record path never carries the door), 413, 411 (a streamed body), 200; a known world gets its own file; an unknown label shares `clientlog-~unknown.log` and one bucket (64 invented labels do not deny a real world); a case variant of a real name routes to `~unknown` (asserted on file content — paths alias on macOS); a 50-char name keeps its own file; 429 after the per-world minute; a read-only log dir answers **500**, never a false ok
- `bun tools/config-env-test.ts` — 7 ok: `OPT_MEM_BUDGET_MB=banana` / `-1` → default with a warning; `0` → 0; cost factor must be > 0
- `bun tools/optimize-pump-test.ts` — the pump with a fake child (`OPT_CMD`, `OPT_DIR` isolated to a temp root; the child leaves a receipt per invocation): estimate defer with queue continuation; success retiring a stale `.deferred`; exit 2 → `.failed`; a variant done elsewhere retires its stale `.deferred` without spawning; a signalled child under the cap → `.deferred` and the queue continues; wrapper **126** under a real hard `RLIMIT_DATA` → no variant, no marker, loud, queue dropped; `SKIP_OPT_SWEEP` both ways, deterministic (the subprocess awaits `optIdle()`; set: zero child invocations; unset: `planted.glb` reached the child)
- `bun tools/store-variants-test.ts` — 0 failed on a `toktx` box; on a box with only the newer `ktx` CLI one pre-existing real-encode case (2048² → 1024² header) fails on `main` too — environmental, not this PR

Also: `bun build server/server.ts` clean; a headless desktop boot + walk against this tree (body loads, moves, turns, jumps; zero page errors).

## Env seams (documented, default = production behaviour)
`CLIENTLOG_DIR` (default `WORLDS_DIR/.clientlogs`), `OPT_DIR` (default `assets/opt` — a test instance must never write into the live store), `OPT_CMD` (the optimizer command; a harness owns the child), `SKIP_OPT_SWEEP`, `OPT_MEM_BUDGET_MB`, `OPT_COST_FACTOR`.

## Part of a stack
**1** → 2 rendering + boot → 3 desktop UI → 4 VR alpha. Each rung boots and runs on its own (proven headless per rung), so the series can stop at any point. Merge in order.
