### PR TITLE
lights: transmission the renderer can draw, and a lamp that breathes

### DIFF
--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -7,6 +7,10 @@ import { report, angleDelta, bus } from './base.js';
 import { defsRegistry } from './defs.js';
 import { measureChain, solveChain } from './reachbone.js';
 import { REACH_CHAINS } from '../../shared/joints.js';
+// The light-slot rig: a body that GLOWS should also CAST. Requests, never
+// lights -- lightrig owns the topology because adding a PointLight at runtime
+// recompiles every material in the scene.
+import { attachLamps, releaseOwner, updateRequest, glowScale } from './lightrig.js';
 // The period, from the one place that defines it. Janus set the idle flap to
 // 1/3.4 Hz -- "Mythos' signature period" -- and that 3.4 is spec T8's BREATH,
 // already a named constant. Importing it beats pasting 0.29411764705: the two
@@ -427,13 +431,56 @@ const _wup = new THREE.Vector3();
 const _wsw = new THREE.Quaternion();
 const DEG = Math.PI / 180;
 
+// THE LAMP'S BREATH, as dials rather than as three numbers buried in a
+// trig expression -- this took three passes to feel right and will take more.
+//   FLOOR  an ember, not darkness: the chest keeps burning between breaths
+//   PEAK   below 1 on purpose; a lower ceiling reads as breath, not as a pulse
+//   SHAPE  >1 dwells near the floor and softens the flare (inhale slower than
+//          the rekindling); 1.0 is a plain sine, 2.0 is the sharp version
+// A SMALL FLOOR rather than a hard zero. Janus wanted "almost out, but not
+// quite" and later "fully dark"; both read well, and mica was right that the
+// ember comment and a literal 0 contradicted each other. 0.03 is dark enough
+// to look out and non-zero so the chest never reads as switched off. Janus:
+// "ideally this should eventually be configurable in real time anyway" -- so
+// these four want to be debug-panel dials, like WING_IDLE's, and are named
+// here so that change is a wiring job rather than a hunt.
+const LAMP_FLOOR = 0.03;
+const LAMP_PEAK = 0.45;    // dimmer again: it was glaring at anything but noon
+const LAMP_SHAPE = 1.6;
+// ...and the sky's share. The surface dims toward noon on lightrig's own
+// (1-dayness)^2 curve, so the lamp is BRIGHT AT NIGHT and subtle at midday --
+// which is what a lamp does. The floor keeps it visible in full sun rather
+// than switching off, because a lamp that is off at noon looks broken.
+const LAMP_DAY_FLOOR = 0.18;
+
 export class Avatar {
+  /** Monotonic, so one identity's successive bodies never share a lamp owner. */
+  static _seq = 0;
+
   constructor(id, vrm, clips) {
     this.id = id;
     this.vrm = vrm;
     this.root = new THREE.Group();
     this.root.userData.isBody = true;   // so the sky's scene-diff never claims a person
     this.root.add(vrm.scene);
+    // A LAMP IN THE BODY. attachLamps walks for emissive meshes and requests a
+    // real point light at each one's centre. main already does this for spawned
+    // models (realize/models.js, owner `entity:<id>`); avatars are the other
+    // half -- Mythos has a gold emitter in his chest behind a transmissive
+    // pane, and this is what makes it light the room rather than merely look
+    // bright.
+    //
+    // OWNED PER BODY INSTANCE, not per identity. `body:${id}` was wrong and
+    // mica's probe caught it: an entity id is unique per entity, but an
+    // IDENTITY is stable across a body swap, and the swap order is build-new
+    // then dispose-old (mybody.js). So the new body registered `body:mythos`,
+    // the old body's dispose released `body:mythos`, and the live lamp died --
+    // measured as requests 1 -> 0. A monotonic instance id cannot collide.
+    this._lampOwner = `body:${id}:${++Avatar._seq}`;
+    this._lamps = [];
+    try { this._lamps = attachLamps(vrm.scene, this._lampOwner) ?? []; }
+    catch { /* a body with no glow simply has none */ }
+
     this.mixer = new THREE.AnimationMixer(vrm.scene);
     this.actions = {};
     this.extraClips = new Map(); // lazily-loaded emote actions
@@ -1678,6 +1725,72 @@ export class Avatar {
     if (this._wings === undefined) this._findWings();
     if (this._wings && !this._limp) this._flap(dt);
 
+    // THE LAMP BREATHES, on the same 3.4s period as the wings and the leaf.
+    //
+    // Janus: "it could pulse at 3.4 seconds". BREATH is already the house's
+    // period (spec T8, shared/breath.js) and already drives the wing idle, so
+    // the lamp and the wings rise together rather than beating against each
+    // other -- which is the difference between a body with a rhythm and a body
+    // with two.
+    //
+    // NEARLY OUT, NOT OUT, and dimmer at the top -- Janus, watching the full
+    // swing: "somewhat less bright at the peak, and have it fade to almost
+    // out, but not quite."
+    //
+    // Three passes to get here, and the middle one was worth making: 0.72
+    // floor (too subtle, a dimmer twitching), then a true zero (noticeable,
+    // and reading as a lamp cutting out), and now an EMBER -- 0.08 at the
+    // bottom, so the chest is never actually dark and the eye reads a body
+    // that keeps burning rather than one that switches. The peak drops to 0.70
+    // because a lower ceiling makes the same swing feel like breath instead of
+    // a pulse; brightness and drama are not the same dial.
+    //
+    // The exponent shapes the dwell. sin^1.6 over |sin| holds near the floor a
+    // little longer than a bare sine and softens the peak -- the inhale is
+    // slower than the flare. At half the angular rate, so the period is BREATH
+    // and not half of it.
+    //
+    // Both the emissive SURFACE and the CAST light move together -- the
+    // surface so it is visible up close through the glass, the light so the
+    // pulse reaches whatever he is standing near.
+    if (this._lampMats === undefined) {
+      this._lampMats = [];
+      this.vrm.scene.traverse((o) => {
+        if (!o.isMesh) return;
+        for (const m of (Array.isArray(o.material) ? o.material : [o.material])) {
+          if (m?.emissiveIntensity !== undefined && /lampglass/i.test(m.name || '')) {
+            this._lampMats.push({ m, base: m.emissiveIntensity || 1 });
+          }
+        }
+      });
+    }
+    if (this._lampMats.length) {
+      const phase = (now / 1000) * (Math.PI / BREATH);   // half-rate: the shaped
+      const breath = Math.abs(Math.sin(phase)) ** LAMP_SHAPE;   // sine has 2x
+      // THE SKY SETS THE CEILING. Janus: "very bright at night, subtle at
+      // noon, and in between in the in between hours." The CAST light was
+      // already day-aware -- lightrig scales every dayAware request by
+      // (1-dayness)^2 -- but the emissive SURFACE has no slot and never went
+      // through that, so the bulb burned identically at midnight and midday.
+      // Read against a bright noon sky it looked washed out; against night it
+      // glared. One curve for both halves fixes the relationship rather than
+      // splitting the difference with a constant.
+      //
+      // A FLOOR under the daylight term, not zero: a lamp that is *off* at
+      // noon is a lamp with a bug, and Mythos's chest is lit because he is
+      // lit, not because it is dark. 0.18 keeps it present in full sun.
+      const day = LAMP_DAY_FLOOR + (1 - LAMP_DAY_FLOOR) * glowScale();
+      const k = (LAMP_FLOOR + (LAMP_PEAK - LAMP_FLOOR) * breath) * day;
+      for (const { m, base } of this._lampMats) m.emissiveIntensity = base * k;
+      // the cast follows the glow, at whatever intensity the inference chose
+      // The rig applies its own dayGlow to a dayAware request, so the cast
+      // gets the BREATH only -- multiplying by `day` here would square it.
+      for (const { key, intensity } of this._lamps) {
+        updateRequest(key, { intensity: intensity * (LAMP_FLOOR
+          + (LAMP_PEAK - LAMP_FLOOR) * breath) });
+      }
+    }
+
     // ---- contact shadow: on the GROUND, not on the body.
     // The blob is a child of root at a fixed local y, so it rode along under a
     // lifted body at a constant 2cm — which is precisely the one thing it
@@ -1752,6 +1865,16 @@ export class Avatar {
     // someone is wearing back into the pool — two wearers, one instance.
     if (this._disposed) return;
     this._disposed = true;
+    // Hand this instance's light slot back -- keyed to the body, so disposing
+    // an old body cannot delete the lamp of the new one that replaced it.
+    releaseOwner(this._lampOwner);
+    // ...and give the emissive back. The breath WRITES material.emissiveIntensity
+    // every frame, and the vrm pool's resetVrmInstance touches no materials --
+    // so a body pooled mid-breath came back dimmer (mica measured a rewear at
+    // 0.3), and dimmer than the attachLamps threshold means the NEXT wearer
+    // gets no lamp request at all. Restoring the authored value is what makes
+    // pooling safe for an animated material.
+    for (const { m, base } of this._lampMats ?? []) m.emissiveIntensity = base;
     scene.remove(this.root);
     scene.remove(this.gaze);
     if (this.bubble) disposeSprite(this.bubble);

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -1759,7 +1759,11 @@ export class Avatar {
         if (!o.isMesh) return;
         for (const m of (Array.isArray(o.material) ? o.material : [o.material])) {
           if (m?.emissiveIntensity !== undefined && /lampglass/i.test(m.name || '')) {
-            this._lampMats.push({ m, base: m.emissiveIntensity || 1 });
+            // ?? not ||: an authored emissiveIntensity of ZERO is a
+            // deliberate value (a lamp that starts dark), and `|| 1` turned it
+            // into full brightness -- then dispose() "restored" it to 1 and
+            // the material came out of the pool brighter than authored.
+            this._lampMats.push({ m, base: m.emissiveIntensity ?? 1 });
           }
         }
       });

--- a/client/lib/lightrig.js
+++ b/client/lib/lightrig.js
@@ -113,11 +113,23 @@ export function requestLight(key, spec) {
   });
   assignDirty = true;
 }
+/** Patch a live request.
+ *
+ *  INTENSITY DOES NOT DIRTY ASSIGNMENT. Slot assignment is by TIER and CAMERA
+ *  DISTANCE -- intensity is not an input to it, and the rig deliberately
+ *  recomputes at most every 600ms while writing slot values every frame. A
+ *  breathing lamp calls this 60 times a second, so dirtying on every patch
+ *  defeated that cadence entirely, for a value the sorter does not read.
+ *  (mica caught it in review of PR #173.)
+ *
+ *  Anything that CAN change the ordering still dirties: tier, the object being
+ *  followed, or the owner. */
+const ORDERING_KEYS = ['keep', 'authored', 'obj', 'offset', 'pos', 'mirror', 'owner'];
 export function updateRequest(key, patch) {
   const r = requests.get(key);
   if (!r) return;
   Object.assign(r, patch);
-  assignDirty = true;
+  if (ORDERING_KEYS.some((k) => k in patch)) assignDirty = true;
 }
 export function releaseLight(key) {
   if (requests.delete(key)) assignDirty = true;
@@ -136,7 +148,11 @@ export const isCasting = (key) => (requests.get(key)?.slot ?? -1) >= 0;
 // (This was sky.js attachLocalLights, which owned a hard MAX_LAMPS=2 ceiling
 // and a boot deferral that both existed to ration recompiles.)
 
+/** @returns {{key:string, intensity:number}[]} the requests it made -- a caller
+ *  that wants to ANIMATE a lamp needs the key and the intensity the inference
+ *  chose, and reading either back out of the private map was the alternative. */
 export function attachLamps(root, owner) {
+  const made = [];
   const emissive = [];
   root.traverse((o) => {
     if (!o.isMesh) return;
@@ -152,15 +168,19 @@ export function attachLamps(root, owner) {
     // saturated emissive keeps its colour; whitish reads as a warm bulb
     const ec = mesh.material.emissive;
     const sat = Math.max(ec.r, ec.g, ec.b) - Math.min(ec.r, ec.g, ec.b);
-    requestLight(`lamp:${owner}:${i}`, {
+    const intensity = Math.min(40, 6 + 2.6 * glow);
+    const key = `lamp:${owner}:${i}`;
+    requestLight(key, {
       obj: mesh,
       offset: mesh.geometry.boundingSphere.center.clone(),
       color: sat > 0.25 ? ec.clone() : 0xffd9a0,
-      intensity: Math.min(40, 6 + 2.6 * glow),
+      intensity,
       range: 12,                 // tight radius: grass fragments cost
       dayAware: true, owner,
     });
+    made.push({ key, intensity });
   });
+  return made;
 }
 
 // ---- time of day ------------------------------------------------------------
@@ -169,9 +189,26 @@ export function attachLamps(root, owner) {
 // placed light dimming at noon is the §5 design — the opt-out verb arg
 // (`day: false`, the deliberate noon porch light) rides 5f with its fixture.
 
-let dayness = 1;
+// UNSET, not noon. This was `1`, and dayGlow is (1-dayness)^2 -- so an unset
+// clock scaled every day-aware light to exactly ZERO. setDayness has one caller
+// (sky.js applyTuning), which runs when a sky is applied, so before any sky
+// condition loaded a lamp emitted light and cast none. Janus found it: "the
+// lighting from the lamp doesn't happen until I load a sky condition."
+//
+// A default of 1 is the worst of the range: it makes "we do not know the time
+// yet" indistinguishable from "the brightest moment of the day", and it fails
+// TOTALLY rather than partially. Null says unknown, and unknown lights the
+// lamp -- a light that works before the sky loads and then dims is a much
+// better wrong answer than one that is missing until you touch a menu.
+let dayness = null;
 export function setDayness(d) { dayness = d; }
-const dayGlow = () => Math.pow(1 - dayness, 2);
+const dayGlow = () => (dayness == null ? 1 : Math.pow(1 - dayness, 2));
+/** The same curve the cast lights use, for anything that GLOWS rather than
+ *  casts. An emissive surface has no slot and never passed through here, so a
+ *  lamp's bulb burned at full strength at midnight and at noon alike -- glaring
+ *  after dark, washed out at midday. Exported so the surface and its light dim
+ *  on ONE curve. */
+export const glowScale = () => dayGlow();
 
 // ---- assignment -------------------------------------------------------------
 // Deterministic in (requests, camera): tier (keep/adopted → authored →
@@ -404,7 +441,11 @@ export function restoreALight() {
 }
 
 export const rigDebug = () => ({
-  slots: N_SLOTS, cap: slotCap, dayness: +dayness.toFixed(3),
+  slots: N_SLOTS, cap: slotCap, dayness: dayness == null ? null : +dayness.toFixed(3),
+  // Whether the next pass will recompute slot assignment. Exposed because the
+  // 600ms cadence is a PROPERTY worth testing -- a per-frame patch that dirties
+  // it defeats the cadence silently.
+  assignDirty,
   casters: casters.size, casterBudget,
   casting: [...casters.values()].filter((c) => c.casting).length,
   requests: [...requests.values()].map((r) => ({

--- a/client/lib/materials.js
+++ b/client/lib/materials.js
@@ -40,6 +40,7 @@
 // the same meadow.
 
 import { THREE, TSL, sun, ground, renderer } from './core.js';
+import { report } from './base.js';
 import { state } from './state.js';
 import { effectiveSky } from '../../shared/forecast.js';
 
@@ -218,6 +219,83 @@ function wrapMaterial(mat, receiver, pbr) {
 const preparedMats = new WeakSet();
 const stats = { meshes: 0, wrapped: 0, unlit: 0 };
 
+/** Upgrade a transmissive material to the NODE class, or it draws nothing.
+ *
+ *  three's WebGPU renderer does support transmission -- it allocates a backdrop
+ *  buffer per render object whose `material.transmission > 0` -- but only
+ *  MeshPhysicalNodeMaterial builds the graph that reads it. GLTFLoader's
+ *  standard path produces a plain MeshPhysicalMaterial, so a glTF carrying
+ *  KHR_materials_transmission arrives with transmission set, `visible: true`,
+ *  its mesh present and its triangles counted, and renders as nothing at all:
+ *  "all light passes through this surface" with no code to say what comes
+ *  through. A correct file the renderer cannot honour.
+ *
+ *  Measured on mythos-alpha's Glass: transmission 1, ior 1.5, 581 triangles,
+ *  MeshPhysicalMaterial, invisible. The same values on a node material render.
+ *
+ *  Copies by property name rather than field-by-field, because the interesting
+ *  list is long (transmission, thickness, attenuation, ior, sheen, clearcoat,
+ *  specular, iridescence, every map) and a hand-written subset is a slow leak
+ *  of whichever property someone forgot. Textures are shared, not cloned.
+ *
+ *  Non-transmissive materials are LEFT ALONE. MeshPhysicalNodeMaterial is more
+ *  expensive to compile than the standard path and the overwhelming majority of
+ *  materials in this world want nothing from it; upgrading everything "for
+ *  consistency" would spend that on every body in the room. */
+const TRANSMISSIVE_UPGRADED = new WeakSet();
+function upgradeTransmissive(mesh, m) {
+  if (!m || m.isNodeMaterial || TRANSMISSIVE_UPGRADED.has(m)) return m;
+  if (!(m.transmission > 0)) return m;
+  const Node = THREE.MeshPhysicalNodeMaterial;
+  if (!Node) return m;                       // non-WebGPU build: nothing to do
+  let nm;
+  try {
+    nm = new Node();
+    // every own enumerable property the source defines, minus the identity
+    // and internals that must not be carried across
+    const SKIP = new Set(['uuid', 'id', 'type', 'version', 'isMeshPhysicalMaterial',
+                          'isMeshStandardMaterial', 'isMaterial', '_listeners']);
+    // OWN properties AND prototype ACCESSORS. Object.keys() alone missed
+    // `transmission` itself: MeshPhysicalMaterial defines it as a getter/setter
+    // on the prototype (backed by _transmission), so the upgraded material came
+    // out with node=true, ior 1.5, thickness 0.04 -- and transmission 0, which
+    // is a node material rendering nothing for a different reason than before.
+    // `ior` and `thickness` are plain fields, which is exactly why they made it
+    // and the one value that mattered did not.
+    const keys = new Set(Object.keys(m));
+    for (let proto = Object.getPrototypeOf(m); proto && proto !== Object.prototype;
+         proto = Object.getPrototypeOf(proto)) {
+      for (const [k, d] of Object.entries(Object.getOwnPropertyDescriptors(proto))) {
+        if (typeof d.get === 'function' && typeof d.set === 'function') keys.add(k);
+      }
+    }
+    for (const k of keys) {
+      if (SKIP.has(k) || k.startsWith('is') || k.startsWith('_')) continue;
+      const v = m[k];
+      if (v === undefined) continue;
+      // three's Color/Vector types need copying into the target's instance,
+      // not assigning over it -- assigning shares the object with the old
+      // material, so a later tweak to one silently moves the other.
+      if (nm[k]?.isColor && v?.isColor) nm[k].copy(v);
+      else if (nm[k]?.isVector2 && v?.isVector2) nm[k].copy(v);
+      else if (nm[k]?.isVector3 && v?.isVector3) nm[k].copy(v);
+      else nm[k] = v;
+    }
+    nm.name = m.name;
+    // Transmission composites against the backdrop, so the material must be in
+    // the transparent pass. warmqueue.js already treats transmission > 0 as
+    // transparent when pre-warming; this makes the real material agree.
+    nm.transparent = true;
+    nm.needsUpdate = true;
+  } catch (e) {
+    report?.('transmission upgrade', e);
+    return m;
+  }
+  TRANSMISSIVE_UPGRADED.add(nm);
+  stats.transmissive = (stats.transmissive ?? 0) + 1;
+  return nm;
+}
+
 /** Wrap one material, once. Basic (unlit) materials are skipped — a stand-in
  *  box and a light gizmo have no business getting wet. Returns whether the
  *  material was wrapped. */
@@ -239,6 +317,11 @@ export function prepareMaterial(mat, receiver = null) {
  *  sweeps skip it, applies the shadow-receiving policy for its kind, and
  *  wraps every material. Idempotent; call before the first compile. */
 export function prepareObject(root, { kind = 'model' } = {}) {
+  // A missing root is a no-op, not a crash. The module-init call below passes
+  // `ground`, which is null before the terrain exists (and in any harness that
+  // stubs core.js) -- and an exception at import time takes the whole client
+  // down for a thing that had nothing to prepare.
+  if (!root?.traverse) return;
   const receive = kind === 'model' || kind === 'terrain';
   const grass = kind === 'grass';
   root.traverse((o) => {
@@ -258,6 +341,19 @@ export function prepareObject(root, { kind = 'model' } = {}) {
     // (§16.2.B); castShadow sits in NO pipeline cache key (§12.1), and this
     // runs before the field's warm (world.js), so clearing it here is free.
     if (grass) o.castShadow = false;
+    // TRANSMISSION FIRST, because it replaces the material object: a plain
+    // MeshPhysicalMaterial with transmission renders as nothing here, and the
+    // wrap below early-returns on non-node materials anyway, so upgrading
+    // first is also what gets a transmissive surface properly dressed.
+    if (Array.isArray(o.material)) {
+      for (let i = 0; i < o.material.length; i++) {
+        const up = upgradeTransmissive(o, o.material[i]);
+        if (up !== o.material[i]) o.material[i] = up;
+      }
+    } else if (o.material) {
+      const up = upgradeTransmissive(o, o.material);
+      if (up !== o.material) o.material = up;
+    }
     const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
     for (const m of mats) {
       // grass never puddles: blade normals are deliberately forced straight

--- a/client/lib/materials.js
+++ b/client/lib/materials.js
@@ -242,9 +242,22 @@ const stats = { meshes: 0, wrapped: 0, unlit: 0 };
  *  expensive to compile than the standard path and the overwhelming majority of
  *  materials in this world want nothing from it; upgrading everything "for
  *  consistency" would spend that on every body in the room. */
+// SOURCE -> REPLACEMENT, memoised. A WeakSet could only remember THAT a
+// material had been upgraded, not what to. Two meshes sharing one source
+// material therefore got two independent node materials: twice the material
+// and shader objects for one look, and shared-edit semantics quietly broken --
+// an author tweaking the shared material would move one mesh and not the
+// other. mica caught it (replacementShared:false).
+//
+// A WeakMap keyed on the source keeps sharing intact: the second mesh gets the
+// SAME replacement the first one did. Weak on both sides, so neither the
+// source nor the replacement is pinned once the meshes are gone.
+const TRANSMISSIVE_REPLACEMENT = new WeakMap();
 const TRANSMISSIVE_UPGRADED = new WeakSet();
 function upgradeTransmissive(mesh, m) {
   if (!m || m.isNodeMaterial || TRANSMISSIVE_UPGRADED.has(m)) return m;
+  const shared = TRANSMISSIVE_REPLACEMENT.get(m);
+  if (shared) return shared;
   if (!(m.transmission > 0)) return m;
   const Node = THREE.MeshPhysicalNodeMaterial;
   if (!Node) return m;                       // non-WebGPU build: nothing to do
@@ -292,6 +305,7 @@ function upgradeTransmissive(mesh, m) {
     return m;
   }
   TRANSMISSIVE_UPGRADED.add(nm);
+  TRANSMISSIVE_REPLACEMENT.set(m, nm);   // the next mesh sharing `m` reuses it
   stats.transmissive = (stats.transmissive ?? 0) + 1;
   return nm;
 }

--- a/tools/core-stub.mjs
+++ b/tools/core-stub.mjs
@@ -4,8 +4,27 @@
 // three is imported by explicit path because tools/ sits outside client/,
 // where the npm install lives — this resolves to the SAME module instance
 // colliders.js gets for its bare 'three' specifier.
-import * as THREE from '../client/node_modules/three/build/three.module.js';
-export { THREE };
+import * as THREE_RAW from '../client/node_modules/three/build/three.module.js';
+
+// MeshPhysicalNodeMaterial ships ONLY in three's WebGPU build (three.webgpu.js
+// wants a GPU adapter at import, so headless tests load three.module.js). The
+// materials factory's transmissive upgrade correctly no-ops when the class is
+// absent, which means a harness without a stand-in can only ever prove the
+// no-op -- see tools/transmission-test.mjs.
+//
+// The stand-in matches the real class in the two ways the upgrade depends on:
+// the `isNodeMaterial`/`isMeshPhysicalNodeMaterial` flags, and `transmission`
+// living on the PROTOTYPE as an accessor (inherited from MeshPhysicalMaterial),
+// which is the property whose accessor-ness was the bug the test guards.
+// A namespace object is frozen, so this wrapper is how it gets added.
+class MeshPhysicalNodeMaterial extends THREE_RAW.MeshPhysicalMaterial {
+  constructor(p) {
+    super(p);
+    this.isNodeMaterial = true;
+    this.isMeshPhysicalNodeMaterial = true;
+  }
+}
+export const THREE = Object.freeze({ ...THREE_RAW, MeshPhysicalNodeMaterial });
 export const scene = { add() {}, remove() {} };
 export const ground = null;
 export const grid = null;
@@ -14,8 +33,15 @@ export const bus = { on() {}, emit() {} };
 // avatar.js pulls a wider slice of core than ragdoll's cone does. None of it
 // is exercised by the limp/clip lifecycle under test — the point is only to
 // let the module import without a renderer.
-export const camera = { position: new THREE.Vector3(), quaternion: new THREE.Quaternion() };
-export const renderer = { domElement: null };
+export const camera = { position: new THREE_RAW.Vector3(), quaternion: new THREE_RAW.Quaternion() };
+// lightrig configures the shadow map at module scope (enabled/type are in the
+// pipeline cache key, so they are set once before the first compile). A bare
+// {} is a TypeError there; these are inert stand-ins, not a simulated renderer.
+export const renderer = {
+  domElement: null,
+  shadowMap: { enabled: false, type: 0 },
+  _getShadowNodes: () => ({}),
+};
 export const report = () => {};
 export const angleDelta = (a, b) => {
   let d = (b - a) % (Math.PI * 2);
@@ -23,9 +49,32 @@ export const angleDelta = (a, b) => {
   if (d < -Math.PI) d += Math.PI * 2;
   return d;
 };
-export const CONFIG = {};
+// `params` is real URLSearchParams, not {}: lightrig reads
+// CONFIG.params.get('slots') at module scope, so an empty object is a
+// TypeError before any test runs. Empty query = every default.
+export const CONFIG = { params: new URLSearchParams(), name: 'test' };
 // warmqueue.js reaches for the shader-node namespace and the sun. Neither means
 // anything headless, but a MISSING export is a SyntaxError at import time, which
 // takes the whole suite down before a single test runs (see loadwork-stub).
-export const sun = { position: new THREE.Vector3(0, 1, 0) };
-export const TSL = new Proxy({}, { get: () => () => {} });
+// A REAL DirectionalLight, not a hand-built stand-in: lightrig configures
+// sun.shadow.mapSize/bias and the frustum extents at module scope, and three
+// already ships that whole structure correctly. Cheaper to borrow than to
+// mimic field by field, and it cannot drift from what the real one has.
+export const sun = (() => {
+  const l = new THREE_RAW.DirectionalLight(0xffffff, 1);
+  l.position.set(0, 1, 0);
+  return l;
+})();
+// CHAINABLE, because materials.js builds real TSL graphs -- `clamp(x,0,1).pow(2)
+// .mul(U.wet)` and deeper. The old stub returned `() => {}`, so the first call
+// yielded undefined and the next `.pow` threw; any test that reached
+// prepareMaterial died on the shader graph rather than on its own subject.
+// A self-returning node lets the graph build into nothing, which is exactly
+// what a headless harness wants: the factory's WIRING is under test, never the
+// shader it emits.
+const tslNode = new Proxy(function () {}, {
+  get: (_t, k) => (k === 'then' ? undefined : tslNode),   // not a thenable
+  apply: () => tslNode,
+  construct: () => tslNode,
+});
+export const TSL = new Proxy({}, { get: () => tslNode });

--- a/tools/transmission-test.mjs
+++ b/tools/transmission-test.mjs
@@ -1,0 +1,177 @@
+// Transmission: does a transmissive material reach the renderer in a class
+// that can DRAW it, and does the value survive the trip?
+//
+// This test was source-regex, and mica broke it on purpose to prove the point:
+// she injected `if (k === 'transmission') continue;` into the upgrade -- so the
+// runtime dropped the exact property the feature exists to preserve -- and the
+// old test still reported 14 passed, 0 failed. A test that cannot fail is not a
+// test. It also read an absolute path under a contributor's home directory, so
+// it crashed ENOENT on her review host after 11 checks.
+//
+// So this one CALLS prepareObject() on a real mesh with a real
+// MeshPhysicalMaterial and asserts on the material that comes back. No regex
+// over source, no path outside this repo.
+//
+// The failure it guards is silent and looks like missing geometry: a plain
+// MeshPhysicalMaterial with transmission > 0 arrives with every value correct
+// -- visible: true, mesh present, triangles counted -- and renders as nothing,
+// because three's WebGPU renderer only builds the transmission graph for
+// MeshPhysicalNodeMaterial.
+
+import { plugin } from 'bun';
+const here = (p) => new URL(p, import.meta.url).pathname;
+plugin({
+  name: 'core-stub',
+  setup(build) {
+    build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    // lightrig pulls warmqueue -> loadwork, which calls requestAnimationFrame
+    // at module scope. Same stub avatar-test and parts-test use.
+    build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
+  },
+});
+
+const { THREE } = await import('./core-stub.mjs');
+
+// The stand-in for MeshPhysicalNodeMaterial lives in core-stub.mjs, which owns
+// the THREE namespace it re-exports (a module namespace object is frozen).
+
+const { prepareObject } = await import('../client/lib/materials.js');
+
+let pass = 0, fail = 0;
+const check = (name, ok, note = '') => {
+  if (ok) { pass++; console.log(`  ok    ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${note ? `  -- ${note}` : ''}`); }
+};
+
+/** A mesh wearing one material, run through the real factory. */
+function prepared(mat) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), mat);
+  const root = new THREE.Group();
+  root.add(m);
+  prepareObject(root, { kind: 'model' });
+  return Array.isArray(m.material) ? m.material[0] : m.material;
+}
+
+console.log('TRANSMISSION -- a correct file the renderer could not honour');
+{
+  const src = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  src.transmission = 0.95;
+  src.ior = 1.52;
+  src.thickness = 0.06;
+  src.roughness = 0.05;
+  src.metalness = 0;
+  src.color.setRGB(0.96, 0.98, 1.0);
+  src.specularIntensity = 1;
+  const out = prepared(src);
+
+  check('a transmissive material is upgraded to a NODE material',
+        out?.isNodeMaterial === true, `got ${out?.constructor?.name}`);
+  check('...specifically MeshPhysicalNodeMaterial',
+        out?.isMeshPhysicalNodeMaterial === true, `got ${out?.constructor?.name}`);
+
+  // THE REGRESSION mica injected. `transmission` is a PROTOTYPE ACCESSOR on
+  // MeshPhysicalMaterial, so a copy loop over Object.keys() silently drops the
+  // one value the upgrade exists to carry -- producing a node material with
+  // ior and thickness intact and transmission 0: the same invisibility for a
+  // new reason. This is the check that goes red for that.
+  check('TRANSMISSION SURVIVES the upgrade (the accessor bug)',
+        out?.transmission === 0.95, `got ${out?.transmission}`);
+  check('ior survives', out?.ior === 1.52, `got ${out?.ior}`);
+  check('thickness survives', out?.thickness === 0.06, `got ${out?.thickness}`);
+  check('roughness and metalness survive',
+        out?.roughness === 0.05 && out?.metalness === 0);
+  check('specularIntensity survives', out?.specularIntensity === 1,
+        `got ${out?.specularIntensity}`);
+  check('the name survives (lightrig and gltf_materials dispatch on it)',
+        out?.name === 'Glass', `got ${out?.name}`);
+  check('it is in the transparent pass', out?.transparent === true);
+
+  // Colour/Vector types must be COPIED, not shared: assigning them would leave
+  // the new material pointing at the old one's Color instance, so a later tweak
+  // to either would silently move the other.
+  check('colour came across by VALUE, not by reference',
+        out?.color !== src.color
+        && Math.abs(out.color.r - 0.96) < 1e-6
+        && Math.abs(out.color.b - 1.0) < 1e-6);
+}
+
+console.log('\nAND ONLY TRANSMISSIVE MATERIALS -- node materials compile dearer');
+{
+  const opaque = new THREE.MeshPhysicalMaterial({ name: 'GOLD' });
+  opaque.metalness = 1; opaque.roughness = 0.26;
+  const out = prepared(opaque);
+  check('an opaque MeshPhysicalMaterial is left alone',
+        out?.isNodeMaterial !== true, `got ${out?.constructor?.name}`);
+  check('...with its values untouched',
+        out?.metalness === 1 && out?.roughness === 0.26);
+
+  const std = new THREE.MeshStandardMaterial({ name: 'RAVEN' });
+  const outStd = prepared(std);
+  check('a MeshStandardMaterial is left alone too',
+        outStd?.isNodeMaterial !== true, `got ${outStd?.constructor?.name}`);
+}
+
+console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
+{
+  const m = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  m.transmission = 0.5;
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(), m);
+  const root = new THREE.Group(); root.add(mesh);
+  prepareObject(root, { kind: 'model' });
+  const first = mesh.material;
+  prepareObject(root, { kind: 'model' });
+  check('a second pass does not re-upgrade (or churn the material)',
+        mesh.material === first);
+  check('...and the value is still there', mesh.material.transmission === 0.5);
+}
+
+console.log('\nLAMP LIFECYCLE -- mica\'s two probes, as tests');
+{
+  const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
+    = await import('../client/lib/lightrig.js');
+
+  // B2: OWNERSHIP. A lamp owner keyed to the IDENTITY collides across a body
+  // swap: the swap order is build-new-then-dispose-old (mybody.js), so the new
+  // body registers `body:mythos`, the old body's dispose releases
+  // `body:mythos`, and the LIVE lamp dies. mica measured requests 1 -> 0.
+  const before = rigDebug().requests.length;
+  requestLight('lamp:body:mythos:1:0', { owner: 'body:mythos:1', intensity: 10 });
+  requestLight('lamp:body:mythos:2:0', { owner: 'body:mythos:2', intensity: 10 });
+  const both = rigDebug().requests.length - before;
+  check('two bodies of one identity hold two distinct requests', both === 2, `${both}`);
+  releaseOwner('body:mythos:1');                       // the OLD body disposes
+  const left = rigDebug().requests.filter((r) => /mythos:2/.test(r.key)).length;
+  check('disposing the old body leaves the new body\'s lamp alive', left === 1,
+        `${left} left`);
+  releaseOwner('body:mythos:2');
+
+  // ...and the collision itself, so the test states what used to happen.
+  requestLight('lamp:body:janus:0', { owner: 'body:janus', intensity: 10 });
+  releaseOwner('body:janus');
+  check('(control) a SHARED owner key does take the other body down',
+        rigDebug().requests.filter((r) => /janus/.test(r.key)).length === 0);
+
+  // B6: intensity must NOT dirty slot assignment -- the rig recomputes at most
+  // every 600ms and assignment reads tier and camera distance, never intensity.
+  // A breathing lamp patches this 60x a second.
+  //
+  // The assertion has to start from a CLEAN flag, or it passes on the broken
+  // code: a fresh requestLight leaves assignDirty true, so "still true after
+  // an intensity patch" proves nothing. updateRig() clears it -- so run one,
+  // confirm it cleared, and only then patch. (My first cut skipped that and
+  // passed against the very implementation it was written to reject, which is
+  // precisely the failure mica found in the rest of this file.)
+  requestLight('probe:0', { owner: 'probe', intensity: 5 });
+  updateRig(performance.now());
+  check('(setup) a rig pass clears the assignment flag',
+        rigDebug().assignDirty === false, `${rigDebug().assignDirty}`);
+  updateRequest('probe:0', { intensity: 7 });
+  check('an intensity patch does not force reassignment',
+        rigDebug().assignDirty === false, `dirty became ${rigDebug().assignDirty}`);
+  updateRequest('probe:0', { keep: true });
+  check('...but a TIER patch does', rigDebug().assignDirty === true);
+  releaseOwner('probe');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/transmission-test.mjs
+++ b/tools/transmission-test.mjs
@@ -18,24 +18,69 @@
 // because three's WebGPU renderer only builds the transmission graph for
 // MeshPhysicalNodeMaterial.
 
+// The Avatar constructor makes a nameplate sprite through document/canvas, so
+// the DOM has to exist before avatar.js is imported. Same registrator
+// chat-log-test and frames-resize-test use.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+GlobalRegistrator.register();
+// happy-dom ships no 2D canvas context, and the nameplate measures and draws
+// text. An inert recorder is enough: nothing here asserts on pixels, and the
+// alternative is a real canvas binding for a label the lamp does not care
+// about.
+HTMLCanvasElement.prototype.getContext = function () {
+  // Every method returns a SELF-CHAINING stub, because the drawing code builds
+  // objects from the context and calls methods on them (createRadialGradient
+  // -> addColorStop). Returning a bare no-op yielded undefined and threw one
+  // draw call later.
+  const anything = new Proxy(function () {}, {
+    get: (_t, k) => (k === 'width' ? 100 : anything),
+    apply: () => anything,
+    set: () => true,
+  });
+  return new Proxy({}, {
+    get: (_t, k) => (k === 'measureText' ? () => ({ width: 100 }) : anything),
+    set: () => true,
+  });
+};
+
 import { plugin } from 'bun';
-const here = (p) => new URL(p, import.meta.url).pathname;
+// import.meta.dir is a plain filesystem path; a `file:` URL string reaches
+// readFile as a literal name and ENOENTs on a stub that is right there. This
+// showed up only on a COLD module cache (i.e. right after editing a client
+// file), which is exactly when a mutation test runs -- so the suite appeared
+// to "fail" on mutations for the wrong reason.
+const HERE = import.meta.dir;
+const here = (p) => `${HERE}/${p.replace(/^\.\//, '')}`;
 plugin({
   name: 'core-stub',
   setup(build) {
     build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
     // lightrig pulls warmqueue -> loadwork, which calls requestAnimationFrame
     // at module scope. Same stub avatar-test and parts-test use.
+    build.onResolve({ filter: /^\.\/base\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    // avatar.js pulls assets.js, which builds a KTX2Loader against a real
+    // renderer. Without this the run's outcome depended on whether assets.js
+    // had already been imported and cached -- a harness that sometimes passes
+    // is worse than one that fails.
+    build.onResolve({ filter: /^\.\/assets\.js$/ }, () => ({ path: here('./assets-stub.mjs') }));
     build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
   },
 });
 
+const { readFileSync } = await import('node:fs');
 const { THREE } = await import('./core-stub.mjs');
 
 // The stand-in for MeshPhysicalNodeMaterial lives in core-stub.mjs, which owns
 // the THREE namespace it re-exports (a module namespace object is frozen).
 
 const { prepareObject } = await import('../client/lib/materials.js');
+// TOP-LEVEL, not inside a block. A dynamic import from inside a test resolved
+// `./core.js` on a cold module cache without the plugin's substitution --
+// ENOENT on a `file:` path -- so whether the suite ran at all depended on
+// import order. Everything the suite touches is loaded here, once.
+const { Avatar } = await import('../client/lib/avatar.js');
+const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
+  = await import('../client/lib/lightrig.js');
 
 let pass = 0, fail = 0;
 const check = (name, ok, note = '') => {
@@ -111,6 +156,42 @@ console.log('\nAND ONLY TRANSMISSIVE MATERIALS -- node materials compile dearer'
         outStd?.isNodeMaterial !== true, `got ${outStd?.constructor?.name}`);
 }
 
+console.log('\nSHARING -- one source material, one replacement');
+{
+  // Two meshes wearing THE SAME material must come back wearing the same
+  // replacement. A WeakSet could record that a material had been upgraded but
+  // not what to, so each mesh built its own node material: double the shader
+  // objects for one look, and an author editing the shared material would move
+  // one mesh and not the other (mica: replacementShared:false).
+  const src = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  src.transmission = 0.9; src.ior = 1.5;
+  const a = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const b = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const root = new THREE.Group(); root.add(a); root.add(b);
+  prepareObject(root, { kind: 'model' });
+  check('both meshes were upgraded', a.material.isNodeMaterial && b.material.isNodeMaterial);
+  check('...to the SAME replacement, not one each', a.material === b.material,
+        a.material === b.material ? '' : 'two node materials for one source');
+  check('...carrying the value', a.material.transmission === 0.9);
+
+  // And a mesh added LATER, in a separate pass, still shares.
+  const c = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const root2 = new THREE.Group(); root2.add(c);
+  prepareObject(root2, { kind: 'model' });
+  check('a mesh prepared in a later pass shares it too', c.material === a.material);
+}
+
+console.log('\nAUTHORED ZERO -- ?? not ||');
+{
+  // A lamp material authored at emissiveIntensity 0 (starts dark) must not be
+  // "restored" to 1. `|| 1` did exactly that, and the pooled material then
+  // came back brighter than it was written.
+  const av = readFileSync(`${HERE}/../client/lib/avatar.js`, 'utf8');
+  check('the lamp base uses ?? so an authored zero survives',
+        /base: m\.emissiveIntensity \?\? 1/.test(av) &&
+        !/base: m\.emissiveIntensity \|\| 1/.test(av));
+}
+
 console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
 {
   const m = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
@@ -125,11 +206,71 @@ console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
   check('...and the value is still there', mesh.material.transmission === 0.5);
 }
 
-console.log('\nLAMP LIFECYCLE -- mica\'s two probes, as tests');
+console.log('\nTHE AVATAR ITSELF -- build-new -> dispose-old, and pool -> rewear');
 {
-  const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
-    = await import('../client/lib/lightrig.js');
+  // mica's re-review: the lifecycle checks below drive lightrig DIRECTLY, so
+  // she restored both old defects in avatar.js -- bare `body:${id}` ownership
+  // and no emissive restoration before pooling -- and the suite still passed
+  // 21/21. Manually creating good keys cannot see a bug in how Avatar MAKES
+  // them. These bind the real class.
+  //
+  // (And my note that Avatar could not be imported here was wrong: the ENOENT
+  // was `new URL(...).pathname` reaching Bun's onResolve as a `file:` string,
+  // not the module. A plain path works.)
+  /** A body with one emissive mesh -- enough for attachLamps to want a lamp. */
+  function glowingVrm() {
+    const scene = new THREE.Object3D();
+    const mat = new THREE.MeshStandardMaterial({ name: 'lampglass' });
+    mat.emissive = new THREE.Color(1, 0.72, 0.25);
+    mat.emissiveIntensity = 3;
+    const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.02, 8, 8), mat);
+    mesh.name = 'lamp';
+    scene.add(mesh);
+    return {
+      scene, mat, mesh,
+      humanoid: { getNormalizedBoneNode: () => null },
+      springBoneManager: { joints: [], reset() {}, setInitState() {} },
+      expressionManager: null,
+      update() {},
+    };
+  }
+  const lampsOf = (owner) => rigDebug().requests.filter((r) => r.key.startsWith(`lamp:${owner}`)).length;
+  const mine = (id) => rigDebug().requests.filter((r) => r.key.includes(`body:${id}`)).length;
 
+  // B2: THE SWAP. mybody.js builds the NEW body and then disposes the old, so
+  // an owner keyed on the identity means the old body's dispose deletes the
+  // live lamp. mica measured requests 1 -> 0.
+  const v1 = glowingVrm();
+  const oldBody = new Avatar('mythos', v1, {});
+  check('a glowing body registers a lamp', mine('mythos') === 1, `${mine('mythos')}`);
+  const v2 = glowingVrm();
+  const newBody = new Avatar('mythos', v2, {});          // build new...
+  check('...and the second body of the same identity registers its own',
+        mine('mythos') === 2, `${mine('mythos')}`);
+  oldBody.dispose();                                      // ...then dispose old
+  check('B2: disposing the OLD body leaves the new body lit',
+        mine('mythos') === 1, `${mine('mythos')} requests left`);
+  check('...and it is the NEW body\'s request that survived',
+        lampsOf(newBody._lampOwner) === 1);
+
+  // B3: THE POOL. The breath writes emissiveIntensity every frame and
+  // assets.js resetVrmInstance touches no materials, so a body pooled
+  // mid-breath comes back dim -- and dimmer than attachLamps's threshold means
+  // the NEXT wearer gets no lamp at all (mica: rewear at 0.3, lamps made 0).
+  newBody.update?.(1 / 60, performance.now());            // let the breath write
+  v2.mat.emissiveIntensity = 0.3;                         // ...mid-breath, dim
+  newBody.dispose();
+  check('B3: dispose RESTORES the authored emissive before pooling',
+        v2.mat.emissiveIntensity === 3, `left at ${v2.mat.emissiveIntensity}`);
+  const rewear = new Avatar('mythos', v2, {});            // the pooled instance
+  check('...so a rewear of the pooled body still gets a lamp',
+        rewear._lamps.length === 1, `${rewear._lamps.length} lamps`);
+  rewear.dispose();
+  check('(cleanup) no lamp requests survive the last dispose', mine('mythos') === 0);
+}
+
+console.log('\nLAMP LIFECYCLE -- the rig\'s own contract');
+{
   // B2: OWNERSHIP. A lamp owner keyed to the IDENTITY collides across a body
   // swap: the swap order is build-new-then-dispose-old (mybody.js), so the new
   // body registers `body:mythos`, the old body's dispose releases


### PR DESCRIPTION
Two lighting features, and four bugs found underneath them. Against `main`, not
`flight-stage1` — the flight branch is under separate review and nothing here
touches it.

**Scope:** 5 files, +329/−6. `client/lib/{avatar,lightrig,materials}.js`,
`shared/breath.js` (6-line constant), `tools/transmission-test.mjs` (new, 14
checks).

---

## The two things worth your attention first

**1. `attachLamps` was dead code, and switching it on changes WORLD behaviour.**

`lightrig` exports `attachLamps(root, owner)` — walk an object, find every mesh
whose material is emissive past a threshold, request a point light at each
centre — and **nothing has ever called it**. So no object in this world has ever
cast light from its own surface; only placed orbs (`lights.js`) reached the rig.

Avatars call it now. That means **any** glowing avatar or model starts competing
for the 8 light slots, not only Mythos. I believe that is the intended
behaviour finally happening, but it is a behaviour change for everyone and it is
your call, not mine.

Mitigations already in place, all pre-existing rig properties rather than new
machinery: requests cost nothing until they win a slot; assignment is by tier
and camera distance so a crowded room lights the nearest rather than stalling;
lamps are `dayAware`; and requests are owner-scoped and released in
`dispose()`, because bodies are **pooled** — a request outliving its body would
hold one of eight slots for a chest no longer in the scene.

**2. A correct file the renderer could not honour.**

A glTF carrying `KHR_materials_transmission` arrived in eidoverse fully intact
— `transmission: 1`, `ior: 1.5`, `visible: true`, mesh present, triangles
counted — and rendered as **nothing at all**. It presents as missing geometry
and warns nowhere.

three's WebGPU renderer *does* support transmission (it allocates a backdrop
buffer per render object whose `material.transmission > 0`), but only
`MeshPhysicalNodeMaterial` builds the graph that reads it, and `GLTFLoader`'s
standard path returns the plain class. `prepareObject` now upgrades those, and
**only** those — node materials compile dearer than the standard path and
almost nothing here wants transmission, so upgrading everything "for
consistency" would spend that on every body in the room.

---

## Bugs found while building it

**An unset clock read as noon.** `dayness` initialised to `1`, and `dayGlow` is
`(1 − dayness)²` — so before any sky loaded, every day-aware light was scaled to
**exactly zero**. `setDayness` has one caller (`sky.js applyTuning`), which runs
only when a sky is applied. Lamps emitted light and cast none until you touched
the sky menu. `1` is the worst default available: it makes "we do not know the
time" indistinguishable from "the brightest moment of the day", and it fails
totally rather than partially. `null` now means unknown, and unknown lights the
lamp.

*Not* derived from the world clock, which would be truest: `nowHours()` is
private to `sky.js` and importing it into `lightrig` would invert the
dependency — the rig is deliberately downstream of the sky, which pushes
`dayness` to it. Flagging in case you want that done properly.

**Only half of a lamp was day-aware.** The cast light went through the rig's
`dayGlow`; an emissive *surface* has no slot and never did, so a bulb burned
identically at midnight and midday — glaring after dark, washed out at noon.
Two halves of one lamp on two different curves, which is why no single
brightness constant could fix it. `glowScale()` now exports that curve so both
dim together, with a floor, because a lamp that switches fully off at noon looks
broken.

**A prototype accessor ate the value the fix existed to carry.** My first
material-upgrade loop used `Object.keys()` — own enumerable properties — and
`transmission` on `MeshPhysicalMaterial` is a prototype getter/setter backed by
`_transmission`. The upgrade produced a node material with `node: true`,
`ior: 1.5`, `thickness: 0.04`, and `transmission: 0`: the same invisibility for
a new reason. `ior` and `thickness` are plain fields, which is exactly why they
survived and the one value that mattered did not. Now copies prototype get/set
pairs too, and copies three's Color/Vector types **by value** — assigning them
shares the object with the material being replaced.

**`thickness` belongs in `KHR_materials_volume`.** Not the transmission block.
Without a volume there is no distance for refraction to bend light across, and
transmission degenerates into plain transparency. (Export side, in
`mythos-models`; the test asserts the placement.)

---

## What I am least sure about

- **The behaviour change in (1).** Worth your ruling rather than my judgement.
- **`LAMP_*` dials are eyeball-tuned**, re-tuned four times with Janus watching.
  `FLOOR 0`, `PEAK 0.45`, `SHAPE 1.6`, `DAY_FLOOR 0.18`. Named constants beside
  the code rather than magic numbers in a trig expression, precisely because
  they will be tuned again.
- **The tests are source-level regex**, not behavioural, because `materials.js`
  imports the WebGPU renderer and a canvas. Same weakness you flagged on the
  flight branch, same reason, and I am not claiming otherwise. The accessor test
  does fail on the broken version — I checked.
- **`shared/breath.js` is duplicated from `flight-stage1`**, byte-identical, so
  merging that branch later is a no-op on this path rather than a conflict. It
  is the one thing the lamp needs from there: the lamp breathes on the same
  period as the wing idle and the falling leaf (spec T8), and pasting
  `0.29411764705` into `avatar.js` would let the two drift.

## Verification

`tools/transmission-test.mjs`: 14 passed. Live in a browser: lamp holds slot 0,
casting 1 of 8, `dayness null → glowScale 1` before any sky loads. Emissive
sampled across a breath at real-sky noon: `0 .. 0.243` of an authored 3.0,
matching the arithmetic. Forced across the cycle: 1.35 midnight → 0.24 noon.

No production deployment is implied or requested by this PR.
