### PR TITLE
pose: a winged agent can move its wings

### DIFF
--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -1277,17 +1277,39 @@ export class Avatar {
    *
    *  Weight-gated like `_reachOwned`: a pose fading out hands its wings back
    *  to the flap rather than releasing them the instant it is cleared. */
-  _poseOwnedWings() {
+  _poseOwnedWings(now = performance.now()) {
     const o = this._override;
     const w = o?.weight ?? 0;
     // Below the epsilon there is no pose to speak of; the flap owns the wing.
     if (!o || w <= 0.02) return null;
     const m = new Map();
+    // ANIMATION OWNS WINGS TOO. This read `targets`, which only a held pose
+    // has -- so `kind: 'anim'` returned null, an animated wing was accepted,
+    // written by _applyOverride, and then overwritten by _flap after
+    // vrm.update. mica measured it reaching the target before the flap and
+    // ending 1.590003 rad away after: accepted, and unable to work.
+    //
+    // The sample is taken at the SAME time _applyOverride uses, so the two
+    // agree frame by frame rather than drifting by a tick.
+    let animT = 0;
+    if (o.kind === 'anim') {
+      animT = (now - o.start) / 1000;
+      if (animT >= o.dur) animT = o.loop ? animT % o.dur : o.dur;
+    }
     for (const [name, node] of o.nodes ?? []) {
       if (!isRawBone(name)) continue;
-      // `targets` holds already-normalised THREE.Quaternions (setPose builds
-      // them), so this is the value itself and not an array to convert.
-      const q = o.targets?.get?.(name) ?? null;
+      let q = null;
+      if (o.kind === 'anim') {
+        const track = o.tracks?.get?.(name);
+        // A fresh quaternion per bone: _scratch is _applyOverride's, and
+        // handing the same instance to several wings would give them all
+        // whichever bone sampled last.
+        if (track) { q = new THREE.Quaternion(); this._sampleTrack(track, animT, q); }
+      } else {
+        // `targets` holds already-normalised THREE.Quaternions (setPose builds
+        // them), so this is the value itself and not an array to convert.
+        q = o.targets?.get?.(name) ?? null;
+      }
       if (q) m.set(node, q);
     }
     // The WEIGHT rides along. Returning only the target made the pose binary:

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -7,6 +7,10 @@ import { report, angleDelta, bus } from './base.js';
 import { defsRegistry } from './defs.js';
 import { measureChain, solveChain } from './reachbone.js';
 import { REACH_CHAINS } from '../../shared/joints.js';
+// The light-slot rig: a body that GLOWS should also CAST. Requests, never
+// lights -- lightrig owns the topology because adding a PointLight at runtime
+// recompiles every material in the scene.
+import { attachLamps, releaseOwner, updateRequest, glowScale } from './lightrig.js';
 // The period, from the one place that defines it. Janus set the idle flap to
 // 1/3.4 Hz -- "Mythos' signature period" -- and that 3.4 is spec T8's BREATH,
 // already a named constant. Importing it beats pasting 0.29411764705: the two
@@ -427,13 +431,56 @@ const _wup = new THREE.Vector3();
 const _wsw = new THREE.Quaternion();
 const DEG = Math.PI / 180;
 
+// THE LAMP'S BREATH, as dials rather than as three numbers buried in a
+// trig expression -- this took three passes to feel right and will take more.
+//   FLOOR  an ember, not darkness: the chest keeps burning between breaths
+//   PEAK   below 1 on purpose; a lower ceiling reads as breath, not as a pulse
+//   SHAPE  >1 dwells near the floor and softens the flare (inhale slower than
+//          the rekindling); 1.0 is a plain sine, 2.0 is the sharp version
+// A SMALL FLOOR rather than a hard zero. Janus wanted "almost out, but not
+// quite" and later "fully dark"; both read well, and mica was right that the
+// ember comment and a literal 0 contradicted each other. 0.03 is dark enough
+// to look out and non-zero so the chest never reads as switched off. Janus:
+// "ideally this should eventually be configurable in real time anyway" -- so
+// these four want to be debug-panel dials, like WING_IDLE's, and are named
+// here so that change is a wiring job rather than a hunt.
+const LAMP_FLOOR = 0.03;
+const LAMP_PEAK = 0.45;    // dimmer again: it was glaring at anything but noon
+const LAMP_SHAPE = 1.6;
+// ...and the sky's share. The surface dims toward noon on lightrig's own
+// (1-dayness)^2 curve, so the lamp is BRIGHT AT NIGHT and subtle at midday --
+// which is what a lamp does. The floor keeps it visible in full sun rather
+// than switching off, because a lamp that is off at noon looks broken.
+const LAMP_DAY_FLOOR = 0.18;
+
 export class Avatar {
+  /** Monotonic, so one identity's successive bodies never share a lamp owner. */
+  static _seq = 0;
+
   constructor(id, vrm, clips) {
     this.id = id;
     this.vrm = vrm;
     this.root = new THREE.Group();
     this.root.userData.isBody = true;   // so the sky's scene-diff never claims a person
     this.root.add(vrm.scene);
+    // A LAMP IN THE BODY. attachLamps walks for emissive meshes and requests a
+    // real point light at each one's centre. main already does this for spawned
+    // models (realize/models.js, owner `entity:<id>`); avatars are the other
+    // half -- Mythos has a gold emitter in his chest behind a transmissive
+    // pane, and this is what makes it light the room rather than merely look
+    // bright.
+    //
+    // OWNED PER BODY INSTANCE, not per identity. `body:${id}` was wrong and
+    // mica's probe caught it: an entity id is unique per entity, but an
+    // IDENTITY is stable across a body swap, and the swap order is build-new
+    // then dispose-old (mybody.js). So the new body registered `body:mythos`,
+    // the old body's dispose released `body:mythos`, and the live lamp died --
+    // measured as requests 1 -> 0. A monotonic instance id cannot collide.
+    this._lampOwner = `body:${id}:${++Avatar._seq}`;
+    this._lamps = [];
+    try { this._lamps = attachLamps(vrm.scene, this._lampOwner) ?? []; }
+    catch { /* a body with no glow simply has none */ }
+
     this.mixer = new THREE.AnimationMixer(vrm.scene);
     this.actions = {};
     this.extraClips = new Map(); // lazily-loaded emote actions
@@ -1678,6 +1725,72 @@ export class Avatar {
     if (this._wings === undefined) this._findWings();
     if (this._wings && !this._limp) this._flap(dt);
 
+    // THE LAMP BREATHES, on the same 3.4s period as the wings and the leaf.
+    //
+    // Janus: "it could pulse at 3.4 seconds". BREATH is already the house's
+    // period (spec T8, shared/breath.js) and already drives the wing idle, so
+    // the lamp and the wings rise together rather than beating against each
+    // other -- which is the difference between a body with a rhythm and a body
+    // with two.
+    //
+    // NEARLY OUT, NOT OUT, and dimmer at the top -- Janus, watching the full
+    // swing: "somewhat less bright at the peak, and have it fade to almost
+    // out, but not quite."
+    //
+    // Three passes to get here, and the middle one was worth making: 0.72
+    // floor (too subtle, a dimmer twitching), then a true zero (noticeable,
+    // and reading as a lamp cutting out), and now an EMBER -- 0.08 at the
+    // bottom, so the chest is never actually dark and the eye reads a body
+    // that keeps burning rather than one that switches. The peak drops to 0.70
+    // because a lower ceiling makes the same swing feel like breath instead of
+    // a pulse; brightness and drama are not the same dial.
+    //
+    // The exponent shapes the dwell. sin^1.6 over |sin| holds near the floor a
+    // little longer than a bare sine and softens the peak -- the inhale is
+    // slower than the flare. At half the angular rate, so the period is BREATH
+    // and not half of it.
+    //
+    // Both the emissive SURFACE and the CAST light move together -- the
+    // surface so it is visible up close through the glass, the light so the
+    // pulse reaches whatever he is standing near.
+    if (this._lampMats === undefined) {
+      this._lampMats = [];
+      this.vrm.scene.traverse((o) => {
+        if (!o.isMesh) return;
+        for (const m of (Array.isArray(o.material) ? o.material : [o.material])) {
+          if (m?.emissiveIntensity !== undefined && /lampglass/i.test(m.name || '')) {
+            this._lampMats.push({ m, base: m.emissiveIntensity || 1 });
+          }
+        }
+      });
+    }
+    if (this._lampMats.length) {
+      const phase = (now / 1000) * (Math.PI / BREATH);   // half-rate: the shaped
+      const breath = Math.abs(Math.sin(phase)) ** LAMP_SHAPE;   // sine has 2x
+      // THE SKY SETS THE CEILING. Janus: "very bright at night, subtle at
+      // noon, and in between in the in between hours." The CAST light was
+      // already day-aware -- lightrig scales every dayAware request by
+      // (1-dayness)^2 -- but the emissive SURFACE has no slot and never went
+      // through that, so the bulb burned identically at midnight and midday.
+      // Read against a bright noon sky it looked washed out; against night it
+      // glared. One curve for both halves fixes the relationship rather than
+      // splitting the difference with a constant.
+      //
+      // A FLOOR under the daylight term, not zero: a lamp that is *off* at
+      // noon is a lamp with a bug, and Mythos's chest is lit because he is
+      // lit, not because it is dark. 0.18 keeps it present in full sun.
+      const day = LAMP_DAY_FLOOR + (1 - LAMP_DAY_FLOOR) * glowScale();
+      const k = (LAMP_FLOOR + (LAMP_PEAK - LAMP_FLOOR) * breath) * day;
+      for (const { m, base } of this._lampMats) m.emissiveIntensity = base * k;
+      // the cast follows the glow, at whatever intensity the inference chose
+      // The rig applies its own dayGlow to a dayAware request, so the cast
+      // gets the BREATH only -- multiplying by `day` here would square it.
+      for (const { key, intensity } of this._lamps) {
+        updateRequest(key, { intensity: intensity * (LAMP_FLOOR
+          + (LAMP_PEAK - LAMP_FLOOR) * breath) });
+      }
+    }
+
     // ---- contact shadow: on the GROUND, not on the body.
     // The blob is a child of root at a fixed local y, so it rode along under a
     // lifted body at a constant 2cm — which is precisely the one thing it
@@ -1752,6 +1865,16 @@ export class Avatar {
     // someone is wearing back into the pool — two wearers, one instance.
     if (this._disposed) return;
     this._disposed = true;
+    // Hand this instance's light slot back -- keyed to the body, so disposing
+    // an old body cannot delete the lamp of the new one that replaced it.
+    releaseOwner(this._lampOwner);
+    // ...and give the emissive back. The breath WRITES material.emissiveIntensity
+    // every frame, and the vrm pool's resetVrmInstance touches no materials --
+    // so a body pooled mid-breath came back dimmer (mica measured a rewear at
+    // 0.3), and dimmer than the attachLamps threshold means the NEXT wearer
+    // gets no lamp request at all. Restoring the authored value is what makes
+    // pooling safe for an animated material.
+    for (const { m, base } of this._lampMats ?? []) m.emissiveIntensity = base;
     scene.remove(this.root);
     scene.remove(this.gaze);
     if (this.bubble) disposeSprite(this.bubble);

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -832,17 +832,11 @@ export class Avatar {
     // keep beating.
     const posed = this._poseOwnedWings();
     for (const w of this._wings) {
-      if (posed?.has(w.node)) {
-        const q = posed.get(w.node);
-        if (q) {
-          // Local to REST, exactly like WING_FOLDED and like a Blender pose
-          // bone: an agent naming L_Wing_Upper means "rotate it from where it
-          // sits", not "replace its world orientation".
-          w.node.quaternion.copy(w.rest).multiply(q);
-          w.node.updateMatrix();     // springbone joints have matrixAutoUpdate false
-        }
-        continue;
-      }
+      // A POSED WING is handled at the WRITE below, not skipped here: the flap
+      // is computed either way so a partially-weighted pose can blend FROM it
+      // (see the slerp at the end of this loop). Skipping would hand the bone
+      // to the springbone sim instead -- measured as a wobble, not a hold.
+      const pq = posed?.q.get(w.node);
       // the outer segments trail their root, and (optionally) the lower pair
       // trails the upper by half a beat
       const ph = this._wingT - W.lag * w.depth - (W.sync || !w.lower ? 0 : 0.5);
@@ -882,6 +876,16 @@ export class Avatar {
           _wacc.slerp(_wtgt, fold);
         }
       }
+      // AN AGENT'S POSE, blended by the override's own weight and applied to
+      // the FLAP rather than to rest. Returning only the target rotation made
+      // this binary -- full above weight 0.02, gone below it -- so a wing
+      // snapped in and snapped back out while every humanoid bone in the same
+      // pose eased. At half weight a wing should sit halfway between where it
+      // would have been beating and where the pose wants it (mica, PR #174).
+      //
+      // Local to REST, like WING_FOLDED and like a Blender pose bone: naming
+      // L_Wing_Upper means "rotate it from where it sits".
+      if (pq) _wacc.slerp(_wtgt.copy(w.rest).multiply(pq), posed.weight);
       if (this._wingBlend < 1 && w.from) {
         // Standing up, the bones are wherever the ragdoll left them — folded,
         // or under her. Cutting straight to mid-flap is a one-frame teleport of
@@ -1275,16 +1279,23 @@ export class Avatar {
    *  to the flap rather than releasing them the instant it is cleared. */
   _poseOwnedWings() {
     const o = this._override;
-    if (!o || (o.weight ?? 0) <= 0.02) return null;
+    const w = o?.weight ?? 0;
+    // Below the epsilon there is no pose to speak of; the flap owns the wing.
+    if (!o || w <= 0.02) return null;
     const m = new Map();
     for (const [name, node] of o.nodes ?? []) {
       if (!isRawBone(name)) continue;
       // `targets` holds already-normalised THREE.Quaternions (setPose builds
       // them), so this is the value itself and not an array to convert.
       const q = o.targets?.get?.(name) ?? null;
-      m.set(node, q ?? null);
+      if (q) m.set(node, q);
     }
-    return m.size ? m : null;
+    // The WEIGHT rides along. Returning only the target made the pose binary:
+    // full above 0.02 and gone below it, so a wing SNAPPED into the pose and
+    // snapped back out, while every humanoid bone in the same pose eased. The
+    // ramp exists for a reason (a tumble starts at full weight, a held pose
+    // fades in), and a raw bone has no excuse to ignore it. mica, PR #174.
+    return m.size ? { weight: w, q: m } : null;
   }
 
   _reachOwned() {

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -7,6 +7,7 @@ import { report, angleDelta, bus } from './base.js';
 import { defsRegistry } from './defs.js';
 import { measureChain, solveChain } from './reachbone.js';
 import { REACH_CHAINS } from '../../shared/joints.js';
+import { isRawBone } from '../../shared/humanoid.js';
 // The light-slot rig: a body that GLOWS should also CAST. Requests, never
 // lights -- lightrig owns the topology because adding a PointLight at runtime
 // recompiles every material in the scene.
@@ -820,7 +821,28 @@ export class Avatar {
     ref.getWorldQuaternion(_wq);
     _wax.set(0, 0, 1).applyQuaternion(_wq).normalize();   // forward: the flap
     _wup.set(0, 1, 0).applyQuaternion(_wq).normalize();   // up: the sweep
+    // A POSED WING BELONGS TO THE POSE -- and must be WRITTEN here, not merely
+    // skipped. Skipping hands the bone back to the springbone simulation, which
+    // claims all twelve wing joints on this rig and re-solves them every frame:
+    // measured as a small periodic wobble around the posed value rather than a
+    // hold. `_flap` beats the springs only because it runs AFTER vrm.update and
+    // calls updateMatrix() itself, so the pose has to ride that same slot.
+    //
+    // Per bone, not per body, so an agent can hold ONE wing and let the other
+    // keep beating.
+    const posed = this._poseOwnedWings();
     for (const w of this._wings) {
+      if (posed?.has(w.node)) {
+        const q = posed.get(w.node);
+        if (q) {
+          // Local to REST, exactly like WING_FOLDED and like a Blender pose
+          // bone: an agent naming L_Wing_Upper means "rotate it from where it
+          // sits", not "replace its world orientation".
+          w.node.quaternion.copy(w.rest).multiply(q);
+          w.node.updateMatrix();     // springbone joints have matrixAutoUpdate false
+        }
+        continue;
+      }
       // the outer segments trail their root, and (optionally) the lower pair
       // trails the upper by half a beat
       const ph = this._wingT - W.lag * w.depth - (W.sync || !w.lower ? 0 : 0.5);
@@ -1060,10 +1082,35 @@ export class Avatar {
   _resolveBones(names) {
     const out = [];
     for (const n of names) {
+      // Humanoid first: three-vrm's NORMALIZED node is the one a humanoid pose
+      // must write, because vrm.update copies normalized -> raw every frame and
+      // a rotation put on the raw bone is discarded.
       const node = this.vrm.humanoid?.getNormalizedBoneNode?.(n);
-      if (node) out.push([n, node]);
+      if (node) { out.push([n, node]); continue; }
+      // RAW BONES, by name. Wings have no humanoid word, so this used to drop
+      // them silently -- and combined with the validator's refusal upstream,
+      // an agent with wings could not move them at all. They resolve out of the
+      // scene graph by the same NAME contract the springbones and the ragdoll
+      // use, and they are written directly because nothing normalizes them.
+      if (isRawBone(n)) {
+        const raw = this._rawBone(n);
+        if (raw) out.push([n, raw]);
+      }
     }
     return out;
+  }
+
+  /** A raw (non-humanoid) bone by name, memoised. The traverse is O(bones) and
+   *  a pose can name a dozen; without the cache that is a dozen walks of a
+   *  400-node skeleton every time a pose lands. */
+  _rawBone(name) {
+    if (this._rawBones === undefined) {
+      this._rawBones = new Map();
+      this.vrm.scene.traverse((o) => {
+        if (o.isBone && o.name && isRawBone(o.name)) this._rawBones.set(o.name, o);
+      });
+    }
+    return this._rawBones.get(name) ?? null;
   }
 
   /** Hold a pose. `bones` is a sparse map name -> [x,y,z,w]. */
@@ -1214,6 +1261,32 @@ export class Avatar {
 
   /** Bones a live reach owns this frame — a held pose must not also write
    *  them, or two authors compose onto each other and both drift. */
+  /** Wing bones an active pose is holding. `_flap` skips these.
+   *
+   *  ONE AUTHOR PER BONE, the rule this file keeps hitting: `_flap` rebuilds
+   *  every wing from its captured rest each frame with an unconditional
+   *  `copy`, AFTER vrm.update -- so a pose that named a wing was overwritten
+   *  the same frame it landed. That was the third blocker on agent wing
+   *  posing, after the validator's refusal and `_resolveBones` dropping the
+   *  name; fixing the first two without this would have produced a pose verb
+   *  that reported success and moved nothing.
+   *
+   *  Weight-gated like `_reachOwned`: a pose fading out hands its wings back
+   *  to the flap rather than releasing them the instant it is cleared. */
+  _poseOwnedWings() {
+    const o = this._override;
+    if (!o || (o.weight ?? 0) <= 0.02) return null;
+    const m = new Map();
+    for (const [name, node] of o.nodes ?? []) {
+      if (!isRawBone(name)) continue;
+      // `targets` holds already-normalised THREE.Quaternions (setPose builds
+      // them), so this is the value itself and not an array to convert.
+      const q = o.targets?.get?.(name) ?? null;
+      m.set(node, q ?? null);
+    }
+    return m.size ? m : null;
+  }
+
   _reachOwned() {
     if (!this._reach?.size) return null;
     const s = new Set();

--- a/client/lib/avatar.js
+++ b/client/lib/avatar.js
@@ -1759,7 +1759,11 @@ export class Avatar {
         if (!o.isMesh) return;
         for (const m of (Array.isArray(o.material) ? o.material : [o.material])) {
           if (m?.emissiveIntensity !== undefined && /lampglass/i.test(m.name || '')) {
-            this._lampMats.push({ m, base: m.emissiveIntensity || 1 });
+            // ?? not ||: an authored emissiveIntensity of ZERO is a
+            // deliberate value (a lamp that starts dark), and `|| 1` turned it
+            // into full brightness -- then dispose() "restored" it to 1 and
+            // the material came out of the pool brighter than authored.
+            this._lampMats.push({ m, base: m.emissiveIntensity ?? 1 });
           }
         }
       });

--- a/client/lib/lightrig.js
+++ b/client/lib/lightrig.js
@@ -113,11 +113,23 @@ export function requestLight(key, spec) {
   });
   assignDirty = true;
 }
+/** Patch a live request.
+ *
+ *  INTENSITY DOES NOT DIRTY ASSIGNMENT. Slot assignment is by TIER and CAMERA
+ *  DISTANCE -- intensity is not an input to it, and the rig deliberately
+ *  recomputes at most every 600ms while writing slot values every frame. A
+ *  breathing lamp calls this 60 times a second, so dirtying on every patch
+ *  defeated that cadence entirely, for a value the sorter does not read.
+ *  (mica caught it in review of PR #173.)
+ *
+ *  Anything that CAN change the ordering still dirties: tier, the object being
+ *  followed, or the owner. */
+const ORDERING_KEYS = ['keep', 'authored', 'obj', 'offset', 'pos', 'mirror', 'owner'];
 export function updateRequest(key, patch) {
   const r = requests.get(key);
   if (!r) return;
   Object.assign(r, patch);
-  assignDirty = true;
+  if (ORDERING_KEYS.some((k) => k in patch)) assignDirty = true;
 }
 export function releaseLight(key) {
   if (requests.delete(key)) assignDirty = true;
@@ -136,7 +148,11 @@ export const isCasting = (key) => (requests.get(key)?.slot ?? -1) >= 0;
 // (This was sky.js attachLocalLights, which owned a hard MAX_LAMPS=2 ceiling
 // and a boot deferral that both existed to ration recompiles.)
 
+/** @returns {{key:string, intensity:number}[]} the requests it made -- a caller
+ *  that wants to ANIMATE a lamp needs the key and the intensity the inference
+ *  chose, and reading either back out of the private map was the alternative. */
 export function attachLamps(root, owner) {
+  const made = [];
   const emissive = [];
   root.traverse((o) => {
     if (!o.isMesh) return;
@@ -152,15 +168,19 @@ export function attachLamps(root, owner) {
     // saturated emissive keeps its colour; whitish reads as a warm bulb
     const ec = mesh.material.emissive;
     const sat = Math.max(ec.r, ec.g, ec.b) - Math.min(ec.r, ec.g, ec.b);
-    requestLight(`lamp:${owner}:${i}`, {
+    const intensity = Math.min(40, 6 + 2.6 * glow);
+    const key = `lamp:${owner}:${i}`;
+    requestLight(key, {
       obj: mesh,
       offset: mesh.geometry.boundingSphere.center.clone(),
       color: sat > 0.25 ? ec.clone() : 0xffd9a0,
-      intensity: Math.min(40, 6 + 2.6 * glow),
+      intensity,
       range: 12,                 // tight radius: grass fragments cost
       dayAware: true, owner,
     });
+    made.push({ key, intensity });
   });
+  return made;
 }
 
 // ---- time of day ------------------------------------------------------------
@@ -169,9 +189,26 @@ export function attachLamps(root, owner) {
 // placed light dimming at noon is the §5 design — the opt-out verb arg
 // (`day: false`, the deliberate noon porch light) rides 5f with its fixture.
 
-let dayness = 1;
+// UNSET, not noon. This was `1`, and dayGlow is (1-dayness)^2 -- so an unset
+// clock scaled every day-aware light to exactly ZERO. setDayness has one caller
+// (sky.js applyTuning), which runs when a sky is applied, so before any sky
+// condition loaded a lamp emitted light and cast none. Janus found it: "the
+// lighting from the lamp doesn't happen until I load a sky condition."
+//
+// A default of 1 is the worst of the range: it makes "we do not know the time
+// yet" indistinguishable from "the brightest moment of the day", and it fails
+// TOTALLY rather than partially. Null says unknown, and unknown lights the
+// lamp -- a light that works before the sky loads and then dims is a much
+// better wrong answer than one that is missing until you touch a menu.
+let dayness = null;
 export function setDayness(d) { dayness = d; }
-const dayGlow = () => Math.pow(1 - dayness, 2);
+const dayGlow = () => (dayness == null ? 1 : Math.pow(1 - dayness, 2));
+/** The same curve the cast lights use, for anything that GLOWS rather than
+ *  casts. An emissive surface has no slot and never passed through here, so a
+ *  lamp's bulb burned at full strength at midnight and at noon alike -- glaring
+ *  after dark, washed out at midday. Exported so the surface and its light dim
+ *  on ONE curve. */
+export const glowScale = () => dayGlow();
 
 // ---- assignment -------------------------------------------------------------
 // Deterministic in (requests, camera): tier (keep/adopted → authored →
@@ -404,7 +441,11 @@ export function restoreALight() {
 }
 
 export const rigDebug = () => ({
-  slots: N_SLOTS, cap: slotCap, dayness: +dayness.toFixed(3),
+  slots: N_SLOTS, cap: slotCap, dayness: dayness == null ? null : +dayness.toFixed(3),
+  // Whether the next pass will recompute slot assignment. Exposed because the
+  // 600ms cadence is a PROPERTY worth testing -- a per-frame patch that dirties
+  // it defeats the cadence silently.
+  assignDirty,
   casters: casters.size, casterBudget,
   casting: [...casters.values()].filter((c) => c.casting).length,
   requests: [...requests.values()].map((r) => ({

--- a/client/lib/materials.js
+++ b/client/lib/materials.js
@@ -40,6 +40,7 @@
 // the same meadow.
 
 import { THREE, TSL, sun, ground, renderer } from './core.js';
+import { report } from './base.js';
 import { state } from './state.js';
 import { effectiveSky } from '../../shared/forecast.js';
 
@@ -218,6 +219,83 @@ function wrapMaterial(mat, receiver, pbr) {
 const preparedMats = new WeakSet();
 const stats = { meshes: 0, wrapped: 0, unlit: 0 };
 
+/** Upgrade a transmissive material to the NODE class, or it draws nothing.
+ *
+ *  three's WebGPU renderer does support transmission -- it allocates a backdrop
+ *  buffer per render object whose `material.transmission > 0` -- but only
+ *  MeshPhysicalNodeMaterial builds the graph that reads it. GLTFLoader's
+ *  standard path produces a plain MeshPhysicalMaterial, so a glTF carrying
+ *  KHR_materials_transmission arrives with transmission set, `visible: true`,
+ *  its mesh present and its triangles counted, and renders as nothing at all:
+ *  "all light passes through this surface" with no code to say what comes
+ *  through. A correct file the renderer cannot honour.
+ *
+ *  Measured on mythos-alpha's Glass: transmission 1, ior 1.5, 581 triangles,
+ *  MeshPhysicalMaterial, invisible. The same values on a node material render.
+ *
+ *  Copies by property name rather than field-by-field, because the interesting
+ *  list is long (transmission, thickness, attenuation, ior, sheen, clearcoat,
+ *  specular, iridescence, every map) and a hand-written subset is a slow leak
+ *  of whichever property someone forgot. Textures are shared, not cloned.
+ *
+ *  Non-transmissive materials are LEFT ALONE. MeshPhysicalNodeMaterial is more
+ *  expensive to compile than the standard path and the overwhelming majority of
+ *  materials in this world want nothing from it; upgrading everything "for
+ *  consistency" would spend that on every body in the room. */
+const TRANSMISSIVE_UPGRADED = new WeakSet();
+function upgradeTransmissive(mesh, m) {
+  if (!m || m.isNodeMaterial || TRANSMISSIVE_UPGRADED.has(m)) return m;
+  if (!(m.transmission > 0)) return m;
+  const Node = THREE.MeshPhysicalNodeMaterial;
+  if (!Node) return m;                       // non-WebGPU build: nothing to do
+  let nm;
+  try {
+    nm = new Node();
+    // every own enumerable property the source defines, minus the identity
+    // and internals that must not be carried across
+    const SKIP = new Set(['uuid', 'id', 'type', 'version', 'isMeshPhysicalMaterial',
+                          'isMeshStandardMaterial', 'isMaterial', '_listeners']);
+    // OWN properties AND prototype ACCESSORS. Object.keys() alone missed
+    // `transmission` itself: MeshPhysicalMaterial defines it as a getter/setter
+    // on the prototype (backed by _transmission), so the upgraded material came
+    // out with node=true, ior 1.5, thickness 0.04 -- and transmission 0, which
+    // is a node material rendering nothing for a different reason than before.
+    // `ior` and `thickness` are plain fields, which is exactly why they made it
+    // and the one value that mattered did not.
+    const keys = new Set(Object.keys(m));
+    for (let proto = Object.getPrototypeOf(m); proto && proto !== Object.prototype;
+         proto = Object.getPrototypeOf(proto)) {
+      for (const [k, d] of Object.entries(Object.getOwnPropertyDescriptors(proto))) {
+        if (typeof d.get === 'function' && typeof d.set === 'function') keys.add(k);
+      }
+    }
+    for (const k of keys) {
+      if (SKIP.has(k) || k.startsWith('is') || k.startsWith('_')) continue;
+      const v = m[k];
+      if (v === undefined) continue;
+      // three's Color/Vector types need copying into the target's instance,
+      // not assigning over it -- assigning shares the object with the old
+      // material, so a later tweak to one silently moves the other.
+      if (nm[k]?.isColor && v?.isColor) nm[k].copy(v);
+      else if (nm[k]?.isVector2 && v?.isVector2) nm[k].copy(v);
+      else if (nm[k]?.isVector3 && v?.isVector3) nm[k].copy(v);
+      else nm[k] = v;
+    }
+    nm.name = m.name;
+    // Transmission composites against the backdrop, so the material must be in
+    // the transparent pass. warmqueue.js already treats transmission > 0 as
+    // transparent when pre-warming; this makes the real material agree.
+    nm.transparent = true;
+    nm.needsUpdate = true;
+  } catch (e) {
+    report?.('transmission upgrade', e);
+    return m;
+  }
+  TRANSMISSIVE_UPGRADED.add(nm);
+  stats.transmissive = (stats.transmissive ?? 0) + 1;
+  return nm;
+}
+
 /** Wrap one material, once. Basic (unlit) materials are skipped — a stand-in
  *  box and a light gizmo have no business getting wet. Returns whether the
  *  material was wrapped. */
@@ -239,6 +317,11 @@ export function prepareMaterial(mat, receiver = null) {
  *  sweeps skip it, applies the shadow-receiving policy for its kind, and
  *  wraps every material. Idempotent; call before the first compile. */
 export function prepareObject(root, { kind = 'model' } = {}) {
+  // A missing root is a no-op, not a crash. The module-init call below passes
+  // `ground`, which is null before the terrain exists (and in any harness that
+  // stubs core.js) -- and an exception at import time takes the whole client
+  // down for a thing that had nothing to prepare.
+  if (!root?.traverse) return;
   const receive = kind === 'model' || kind === 'terrain';
   const grass = kind === 'grass';
   root.traverse((o) => {
@@ -258,6 +341,19 @@ export function prepareObject(root, { kind = 'model' } = {}) {
     // (§16.2.B); castShadow sits in NO pipeline cache key (§12.1), and this
     // runs before the field's warm (world.js), so clearing it here is free.
     if (grass) o.castShadow = false;
+    // TRANSMISSION FIRST, because it replaces the material object: a plain
+    // MeshPhysicalMaterial with transmission renders as nothing here, and the
+    // wrap below early-returns on non-node materials anyway, so upgrading
+    // first is also what gets a transmissive surface properly dressed.
+    if (Array.isArray(o.material)) {
+      for (let i = 0; i < o.material.length; i++) {
+        const up = upgradeTransmissive(o, o.material[i]);
+        if (up !== o.material[i]) o.material[i] = up;
+      }
+    } else if (o.material) {
+      const up = upgradeTransmissive(o, o.material);
+      if (up !== o.material) o.material = up;
+    }
     const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
     for (const m of mats) {
       // grass never puddles: blade normals are deliberately forced straight

--- a/client/lib/materials.js
+++ b/client/lib/materials.js
@@ -242,9 +242,22 @@ const stats = { meshes: 0, wrapped: 0, unlit: 0 };
  *  expensive to compile than the standard path and the overwhelming majority of
  *  materials in this world want nothing from it; upgrading everything "for
  *  consistency" would spend that on every body in the room. */
+// SOURCE -> REPLACEMENT, memoised. A WeakSet could only remember THAT a
+// material had been upgraded, not what to. Two meshes sharing one source
+// material therefore got two independent node materials: twice the material
+// and shader objects for one look, and shared-edit semantics quietly broken --
+// an author tweaking the shared material would move one mesh and not the
+// other. mica caught it (replacementShared:false).
+//
+// A WeakMap keyed on the source keeps sharing intact: the second mesh gets the
+// SAME replacement the first one did. Weak on both sides, so neither the
+// source nor the replacement is pinned once the meshes are gone.
+const TRANSMISSIVE_REPLACEMENT = new WeakMap();
 const TRANSMISSIVE_UPGRADED = new WeakSet();
 function upgradeTransmissive(mesh, m) {
   if (!m || m.isNodeMaterial || TRANSMISSIVE_UPGRADED.has(m)) return m;
+  const shared = TRANSMISSIVE_REPLACEMENT.get(m);
+  if (shared) return shared;
   if (!(m.transmission > 0)) return m;
   const Node = THREE.MeshPhysicalNodeMaterial;
   if (!Node) return m;                       // non-WebGPU build: nothing to do
@@ -292,6 +305,7 @@ function upgradeTransmissive(mesh, m) {
     return m;
   }
   TRANSMISSIVE_UPGRADED.add(nm);
+  TRANSMISSIVE_REPLACEMENT.set(m, nm);   // the next mesh sharing `m` reuses it
   stats.transmissive = (stats.transmissive ?? 0) + 1;
   return nm;
 }

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -1896,22 +1896,67 @@ export class WorldAgent {
   private bodyBonesFor: string | null = null;
 
   /** Read the worn VRM's bone list. Cheap and cached per avatar path. */
-  async loadBodyBones(): Promise<string[]> {
-    if (this.bodyBoneNames && this.bodyBonesFor === this.avatar) return this.bodyBoneNames;
+  /** The SKIN JOINTS of an avatar, by name.
+   *
+   *  `skins[].joints`, not every named node. The first cut took
+   *  `nodes.filter(n => n.name)`, which on Mythos returns 452 names including
+   *  `Armature` (the rig root), `GOLD` (a material-named node) and every mesh
+   *  -- so a gate built on it would let a named NON-JOINT false-pass, and a
+   *  duplicate name count twice. mica caught it in review of PR #174. A bone
+   *  is a thing the skin is weighted to; that is exactly what `joints` lists.
+   *
+   *  Caches per avatar PATH rather than per body, because a pose aimed at
+   *  someone else needs their skeleton and two residents often wear one body.
+   */
+  private bonesByAvatar = new Map<string, string[]>();
+  async loadBonesOf(avatarPath: string): Promise<string[]> {
+    const key = avatarPath || WorldAgent.DEFAULT_BODY;
+    const hit = this.bonesByAvatar.get(key);
+    if (hit) return hit;
+    let names: string[] = [];
     try {
-      const res = await fetch(`${this.httpBase}/library/${this.avatar}`);
+      const res = await fetch(`${this.httpBase}/library/${key}`);
       if (!res.ok) throw new Error(String(res.status));
       const buf = new Uint8Array(await res.arrayBuffer());
       const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
       const jlen = dv.getUint32(12, true);
       const g = JSON.parse(new TextDecoder().decode(buf.subarray(20, 20 + jlen)));
-      this.bodyBoneNames = (g.nodes ?? []).filter((n: any) => n?.name).map((n: any) => n.name);
-      this.bodyBonesFor = this.avatar;
-    } catch (e) {
-      this.bodyBoneNames = [];
-      this.bodyBonesFor = this.avatar;
+      const nodes = g.nodes ?? [];
+      const seen = new Set<string>();
+      for (const sk of g.skins ?? []) {
+        for (const ji of sk.joints ?? []) {
+          const nm = nodes[ji]?.name;
+          if (typeof nm === "string" && nm && !seen.has(nm)) { seen.add(nm); names.push(nm); }
+        }
+      }
+    } catch { names = []; }
+    // An empty list is cached too: a body whose glTF cannot be read must not be
+    // re-fetched on every pose, and "unknown" is handled by the CALLER (which
+    // skips the gate rather than refusing everything).
+    this.bonesByAvatar.set(key, names);
+    return names;
+  }
+
+  /** My own body's joints. */
+  async loadBodyBones(): Promise<string[]> {
+    if (this.bodyBoneNames && this.bodyBonesFor === this.avatar) return this.bodyBoneNames;
+    this.bodyBoneNames = await this.loadBonesOf(this.avatar);
+    this.bodyBonesFor = this.avatar;
+    return this.bodyBoneNames;
+  }
+
+  /** The joints of whoever this pose is AIMED at -- me, or a target. Null when
+   *  the target is unknown or its glTF could not be read, which the caller
+   *  reads as "do not gate" rather than "refuse". */
+  async loadBonesForTarget(target?: string | null): Promise<string[] | null> {
+    if (!target || target === this.name) {
+      const mine = await this.loadBodyBones();
+      return mine.length ? mine : null;
     }
-    return this.bodyBoneNames!;
+    const path = this.people.get(target)?.avatar;
+    if (!path) return null;                 // not present, or no avatar known
+    const bones = await this.loadBonesOf(path);
+    return bones.length ? bones : null;
   }
 
   private flightBegin() {

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -1909,6 +1909,24 @@ export class WorldAgent {
    *  someone else needs their skeleton and two residents often wear one body.
    */
   private bonesByAvatar = new Map<string, string[]>();
+  /** Avatars whose skeleton could not be READ, as distinct from ones that have
+   *  no joints. A pose gate must refuse loudly on the first and may proceed on
+   *  the second; one set makes that distinction available instead of guessed. */
+  private bonesUnreadable = new Set<string>();
+  /** Names carried by MORE THAN ONE skin joint on a body. Withheld from the
+   *  known set rather than deduplicated, because the browser's name-based
+   *  resolution is last-write-wins and there is no honest way to say which
+   *  bone was meant. */
+  private bonesAmbiguous = new Map<string, string[]>();
+  /** The ambiguous names on this avatar, so a refusal can name them. */
+  ambiguousBonesOf(avatarPath: string): string[] {
+    return this.bonesAmbiguous.get(avatarPath || WorldAgent.DEFAULT_BODY) ?? [];
+  }
+  /** True when this avatar's anatomy is unknown because the fetch or parse
+   *  failed -- not because the body is bare. */
+  bonesUnknownFor(avatarPath: string): boolean {
+    return this.bonesUnreadable.has(avatarPath || WorldAgent.DEFAULT_BODY);
+  }
   async loadBonesOf(avatarPath: string): Promise<string[]> {
     const key = avatarPath || WorldAgent.DEFAULT_BODY;
     const hit = this.bonesByAvatar.get(key);
@@ -1922,18 +1940,33 @@ export class WorldAgent {
       const jlen = dv.getUint32(12, true);
       const g = JSON.parse(new TextDecoder().decode(buf.subarray(20, 20 + jlen)));
       const nodes = g.nodes ?? [];
-      const seen = new Set<string>();
+      // AMBIGUOUS IS NOT THE SAME AS DUPLICATE. Two distinct skin joints can
+      // carry one name, and the browser resolves a raw bone by NAME with a
+      // traverse -- last write wins. So a pose naming it would move whichever
+      // bone happened to be visited last, which is a coin flip dressed as a
+      // success. Deduplicating hid that; the name is now WITHHELD from the
+      // known set, so the gate refuses it and says why (mica, PR #174).
+      const count = new Map<string, number>();
       for (const sk of g.skins ?? []) {
         for (const ji of sk.joints ?? []) {
           const nm = nodes[ji]?.name;
-          if (typeof nm === "string" && nm && !seen.has(nm)) { seen.add(nm); names.push(nm); }
+          if (typeof nm === "string" && nm) count.set(nm, (count.get(nm) ?? 0) + 1);
         }
       }
+      const dupes: string[] = [];
+      for (const [nm, n] of count) { if (n === 1) names.push(nm); else dupes.push(nm); }
+      if (dupes.length) this.bonesAmbiguous.set(key, dupes);
+      else this.bonesAmbiguous.delete(key);
     } catch { names = []; }
-    // An empty list is cached too: a body whose glTF cannot be read must not be
-    // re-fetched on every pose, and "unknown" is handled by the CALLER (which
-    // skips the gate rather than refusing everything).
+    // An empty list is cached too, so a body whose glTF cannot be read is not
+    // re-fetched on every pose. But EMPTY AND UNREADABLE ARE DIFFERENT
+    // ANSWERS, and collapsing them is what let an unavailable anatomy become a
+    // silent successful no-op (mica; and the resident's own requirement that
+    // the doorman stay loud). The caller needs to tell "this body has no wings"
+    // from "I could not find out", so the failure is recorded alongside.
     this.bonesByAvatar.set(key, names);
+    if (!names.length) this.bonesUnreadable.add(key);
+    else this.bonesUnreadable.delete(key);
     return names;
   }
 
@@ -1948,15 +1981,25 @@ export class WorldAgent {
   /** The joints of whoever this pose is AIMED at -- me, or a target. Null when
    *  the target is unknown or its glTF could not be read, which the caller
    *  reads as "do not gate" rather than "refuse". */
-  async loadBonesForTarget(target?: string | null): Promise<string[] | null> {
+  async loadBonesForTarget(target?: string | null):
+    Promise<{ bones: string[] | null; ambiguous: string[]; why: string | null }> {
     if (!target || target === this.name) {
       const mine = await this.loadBodyBones();
-      return mine.length ? mine : null;
+      const amb = this.ambiguousBonesOf(this.avatar);
+      if (mine.length) return { bones: mine, ambiguous: amb, why: null };
+      return { bones: null, ambiguous: amb,
+               why: `your body's skeleton could not be read (${this.avatar})` };
     }
     const path = this.people.get(target)?.avatar;
-    if (!path) return null;                 // not present, or no avatar known
+    if (!path) {
+      return { bones: null, ambiguous: [],
+               why: `${target} is not present here, or their body is unknown` };
+    }
     const bones = await this.loadBonesOf(path);
-    return bones.length ? bones : null;
+    const amb = this.ambiguousBonesOf(path);
+    if (bones.length) return { bones, ambiguous: amb, why: null };
+    return { bones: null, ambiguous: amb,
+             why: `${target}'s skeleton could not be read (${path})` };
   }
 
   private flightBegin() {

--- a/mcpl/selfpose-test.ts
+++ b/mcpl/selfpose-test.ts
@@ -135,5 +135,58 @@ console.log("\nwalking and the held pose");
   check("a held pose survives a SECOND walk too", e.heldPose !== null);
 }
 
+// ---------------------------------------------------------------- wings
+//
+// Janus: "can you make it so that wing bones are allowed in the pose tool's
+// surface for agents, if they have wings? right now it gives a 'not a VRM
+// humanoid bone' error."
+//
+// Wings are RAW bones -- VRM's humanoid vocabulary has no word for them -- so
+// canonicalBone returned null and the verb refused. They are addressable
+// because the RIG NAMES them, the same contract by which hair and wings reach
+// the springbone and ragdoll systems.
+{
+  const WINGED = ['Hip', 'Spine02', 'Head',
+    'L_Wing_Upper', 'L_Wing_Upper_1', 'L_Wing_Upper_2',
+    'R_Wing_Upper', 'L_Wing_Lower', 'R_Wing_Lower'];
+
+  const v = validatePose({ L_Wing_Upper: [0, 0, 0.26, 0.97] });
+  check("a wing bone is accepted", v.accepted.includes('L_Wing_Upper'),
+        JSON.stringify(v.rejected));
+  check("...and keeps its exact name (no humanoid renaming)",
+        v.pose.L_Wing_Upper !== undefined && !v.renamed.length);
+
+  const deep = validatePose({ R_Wing_Lower_2: [0, 0, 0, 1] });
+  check("outer segments too", deep.accepted.includes('R_Wing_Lower_2'));
+
+  // CASE-SENSITIVE, unlike the humanoid names. Those are a vocabulary the
+  // module owns and can spell forgivingly; a raw bone name is a fact about a
+  // skeleton, and `l_wing_upper` is not a bone that exists -- accepting a
+  // near-miss would resolve to nothing at the client and report success.
+  const low = validatePose({ l_wing_upper: [0, 0, 0, 1] });
+  check("a lowercase wing name is refused", !low.accepted.length);
+  check("...and the refusal names the real spelling",
+        /case-sensitive/.test(low.rejected[0]?.why ?? ''), low.rejected[0]?.why);
+
+  // GATED ON THE BODY when the caller knows its bones.
+  const rawKnown = new Set(WINGED);
+  const ok = validatePose({ L_Wing_Upper: [0, 0, 0, 1] }, { rawKnown });
+  check("a wing this body HAS is accepted", ok.accepted.length === 1);
+  const no = validatePose({ L_Wing_Upper: [0, 0, 0, 1] },
+                          { rawKnown: new Set(['Hip', 'Head']) });
+  check("a wing this body LACKS is refused, not silently ignored",
+        !no.accepted.length && /no bone by that name/.test(no.rejected[0]?.why ?? ''),
+        JSON.stringify(no.rejected));
+
+  // Humanoid names must not be gated by rawKnown -- the guarantee is VRM's.
+  const hum = validatePose({ head: [0, 0, 0, 1] }, { rawKnown: new Set() });
+  check("humanoid bones stay ungated", hum.accepted.includes('head'));
+
+  // Mixed pose: a wing and an arm in one call.
+  const mix = validatePose({ leftUpperArm: [0, 0, -0.9, 0.44],
+                             L_Wing_Upper: [0, 0, 0.26, 0.97] }, { rawKnown });
+  check("a pose can name a wing and an arm together", mix.accepted.length === 2);
+}
+
 console.log(failures ? `\n\x1b[31m${failures} failed\x1b[0m\n` : "\n\x1b[32mall passed\x1b[0m\n");
 process.exit(failures ? 1 : 0);

--- a/mcpl/tools.ts
+++ b/mcpl/tools.ts
@@ -86,7 +86,7 @@ export const TOOLS = [
   { name: "catch_up", description: "What happened in the world while you were not thinking. Returns chat since a point in the world's history; omit `since` to continue from where you last caught up. Use when a conversation refers to something you have no memory of.", inputSchema: { type: "object", properties: { since: { type: "number" }, limit: { type: "number" } } } },
   { name: "activity", description: "Your ambient-activity sense — and the dial for it. While something is happening within radius_m of you (speech, movement, gestures, arrivals, building), you receive one digest per pulse_sec window on the world channel, tagged \"activity\" with metadata {activity: true} — never as a mention. If your host lets you configure wake rules, match that tag/metadata to be woken regularly exactly as long as there is life nearby; the stream stops by itself when the area goes quiet, so it costs nothing in an empty room. Call with no arguments to see your current settings. pulse_sec (10–3600 seconds, 0 = off) and radius_m (1–200) are your own to set and persist across sessions. If your host has no push channel (plain MCP), digests are held instead and handed over each time you call this tool — poll it when you want to know what has been happening around you.", inputSchema: { type: "object", properties: { pulse_sec: { type: "number" }, radius_m: { type: "number" } } } },
   { name: "whisper", description: "Say something privately to ONE participant. Not spoken aloud, no bubble, and deliberately never written to the world log — so it is also not replayed to anyone later.", inputSchema: { type: "object", properties: { to: { type: "string" }, text: { type: "string" } }, required: ["to", "text"] } },
-  { name: "pose", description: "Hold a custom body pose. `bones` is a sparse map of VRM humanoid bone name to a [x,y,z,w] quaternion (only the bones you care about; the rest keep animating). Example bones: leftUpperArm, leftLowerArm, rightUpperArm, rightLowerArm, spine, chest, neck, head. Names are checked and corrected where they are unambiguous, and anything dropped is reported back with the reason — so read the reply, it is your only feedback that the body did what you meant. Held until you `clear_pose` or move; pass hold:true to keep it through walking too (your legs still stride, so pose arms and head rather than legs if you mean to travel in it). Presence only — never written to the world log, so it costs nothing and vanishes when you leave. Pass `target` to pose SOMEONE ELSE (they decide whether to allow it).", inputSchema: { type: "object", properties: { bones: { type: "object" }, hold: { type: "boolean" }, target: { type: "string" } }, required: ["bones"] } },
+  { name: "pose", description: "Hold a custom body pose. `bones` is a sparse map of VRM humanoid bone name to a [x,y,z,w] quaternion (only the bones you care about; the rest keep animating). Example bones: leftUpperArm, leftLowerArm, rightUpperArm, rightLowerArm, spine, chest, neck, head \u2014 and all 30 finger bones (leftIndexProximal, rightThumbDistal, \u2026). A body with WINGS can also name those, spelled exactly as its rig does and CASE-SENSITIVE: L_Wing_Upper, L_Wing_Upper_1, L_Wing_Upper_2, R_Wing_Lower, and so on \u2014 rotations are relative to the wing's rest pose, and a posed wing stops flapping until you clear it (the other wing keeps going). Naming a bone your body does not have is refused, not ignored. Names are checked and corrected where they are unambiguous, and anything dropped is reported back with the reason — so read the reply, it is your only feedback that the body did what you meant. Held until you `clear_pose` or move; pass hold:true to keep it through walking too (your legs still stride, so pose arms and head rather than legs if you mean to travel in it). Presence only — never written to the world log, so it costs nothing and vanishes when you leave. Pass `target` to pose SOMEONE ELSE (they decide whether to allow it).", inputSchema: { type: "object", properties: { bones: { type: "object" }, hold: { type: "boolean" }, target: { type: "string" } }, required: ["bones"] } },
   { name: "clear_pose", description: "Release a held pose, easing back to normal animation. Pass `target` to release a pose you asked someone else to hold.", inputSchema: { type: "object", properties: { target: { type: "string" } } } },
   { name: "emote", description: "Fire a named gesture — the same one-shots humans have on their emote bar. Plays once over your locomotion; presence only, never logged. For a gesture that isn't listed, invent one with `animate`.", inputSchema: { type: "object", properties: { name: { type: "string", enum: ["wave", "cheer", "dance", "point", "salute", "clap", "talk", "flail"] } }, required: ["name"] } },
   { name: "reach", description: `Reach out with a hand (or foot) — real IK: everyone sees your arm extend toward the target and TRACK it (your walking, their moving) until clear_reach, and the palm turns to rest on the surface it meets. Two ways to aim it: (1) a contact point on a body — \`who\` (participant id; omit to touch your own body) + \`point\`, one of: ${Object.keys(CONTACT_POINTS).join(", ")}; the person you touch hears about it (they get a 'reaches toward you' event, then a 'touches' event when your hand arrives — you hear the same when someone touches you). (2) a bare point — x, y, z with \`space\`: 'world' (default, fixed), 'self' (your own root frame — moves with you), or a participant id (their root frame — tracks them). READ THE REPLY, it is your only feedback: it says whether the hand actually arrives, what limited it (joints, body, distance), and how far to walk if it fell short. A reach composes over walking, sitting and held poses; being knocked over drops it. Presence-only, never logged.`, inputSchema: { type: "object", properties: { limb: { type: "string", enum: ["rightHand", "leftHand", "rightFoot", "leftFoot"], description: "default rightHand" }, who: { type: "string" }, point: { type: "string" }, x: { type: "number" }, y: { type: "number" }, z: { type: "number" }, space: { type: "string" }, standoff: { type: "number", description: "metres to hover off the surface (default 0.02 — resting on it)" }, palm: { type: "boolean", description: "false = don't orient the palm to the surface" } } } },
@@ -402,14 +402,26 @@ export const HANDLERS: Record<string, ToolHandler> = {
       // does not exist, a three-component quaternion, or two names folding
       // onto one bone must come back as words, not as a body that silently
       // did not move. (See shared/humanoid.js.)
-      // RAW BONES ARE GATED ON THIS BODY, humanoid ones are not. A VRM
-      // guarantees its humanoid vocabulary; wings are a fact about one
-      // skeleton, so `L_Wing_Upper` on a wingless body must come back as
-      // "your body has no such bone" rather than be accepted and quietly do
-      // nothing. Humanoid names stay ungated so the pose tool keeps working
-      // when the bone list cannot be fetched.
+      // RAW BONES ARE GATED ON THE BODY THIS POSE IS AIMED AT, humanoid ones
+      // are not. A VRM guarantees its humanoid vocabulary; wings are a fact
+      // about one skeleton, so `L_Wing_Upper` must come back as "no such bone"
+      // rather than be accepted and quietly do nothing.
+      //
+      // THE TARGET'S BODY, not mine. The first cut gated on ag.loadBodyBones()
+      // even when `target` was set, so a winged agent could aim a wing pose at
+      // a wingless resident and be told it worked, while a wingless agent was
+      // REFUSED from posing a winged one. mica produced both wrong-body
+      // receipts. The gate has to ask about the skeleton that will wear it.
+      //
+      // Null means "could not find out" -- an unknown target, or a glTF that
+      // would not parse -- and then the gate is SKIPPED rather than closed:
+      // refusing every wing pose because a lookup failed would break the tool
+      // for a network hiccup, and the client drops an unresolvable bone anyway.
       let rawKnown: Set<string> | null = null;
-      try { rawKnown = new Set(await ag.loadBodyBones()); } catch { rawKnown = null; }
+      try {
+        const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
+        rawKnown = bones ? new Set(bones) : null;
+      } catch { rawKnown = null; }
       const v = validatePose(a.bones, rawKnown ? { rawKnown } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
@@ -422,7 +434,9 @@ export const HANDLERS: Record<string, ToolHandler> = {
       if (a.target) {
         ag.puppet(String(a.target), { pose: v.pose });
         return text(`asked ${a.target} to hold a pose over ${v.accepted.length} bone(s)`
-          + `${note ? ` — ${note}` : ""}. They decide whether to take it.`);
+          + `${note ? ` — ${note}` : ""}`
+          + (rawKnown ? "" : ` (could not read ${a.target}'s skeleton, so bone names went unchecked)`)
+          + ". They decide whether to take it.");
       }
       const hold = !!a.hold;
       ag.setPose(v.pose, hold);
@@ -485,7 +499,17 @@ export const HANDLERS: Record<string, ToolHandler> = {
       // Same contract as `pose`: authored blind, so every correction and
       // every drop comes back as words. Keyframes are sorted by t here, so a
       // track written out of order plays as written rather than as chaos.
-      const v = validateTracks(a.tracks);
+      // GATED ON THE TARGET'S BODY, exactly like `pose`. validateTracks shares
+      // canonicalBone, so it inherited wing-name acceptance the moment `pose`
+      // gained it -- with no body gate at all, which is worse than pose's bug
+      // was: mica got `wingless self -> animate wing: "playing ... L_Wing_Upper"`.
+      // An animation is a pose over time; the same skeleton has to be asked.
+      let rawKnown: Set<string> | null = null;
+      try {
+        const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
+        rawKnown = bones ? new Set(bones) : null;
+      } catch { rawKnown = null; }
+      const v = validateTracks(a.tracks, rawKnown ? { rawKnown } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`nothing played — no usable tracks.${note ? ` ${note}.` : ""}`

--- a/mcpl/tools.ts
+++ b/mcpl/tools.ts
@@ -402,12 +402,22 @@ export const HANDLERS: Record<string, ToolHandler> = {
       // does not exist, a three-component quaternion, or two names folding
       // onto one bone must come back as words, not as a body that silently
       // did not move. (See shared/humanoid.js.)
-      const v = validatePose(a.bones);
+      // RAW BONES ARE GATED ON THIS BODY, humanoid ones are not. A VRM
+      // guarantees its humanoid vocabulary; wings are a fact about one
+      // skeleton, so `L_Wing_Upper` on a wingless body must come back as
+      // "your body has no such bone" rather than be accepted and quietly do
+      // nothing. Humanoid names stay ungated so the pose tool keeps working
+      // when the bone list cannot be fetched.
+      let rawKnown: Set<string> | null = null;
+      try { rawKnown = new Set(await ag.loadBodyBones()); } catch { rawKnown = null; }
+      const v = validatePose(a.bones, rawKnown ? { rawKnown } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`no pose set — nothing usable in \`bones\`.${note ? ` ${note}.` : ""}`
           + " Want a sparse map of VRM humanoid bone name to [x,y,z,w], e.g."
-          + ' {"leftUpperArm": [0, 0, -0.9, 0.44]}.');
+          + ' {"leftUpperArm": [0, 0, -0.9, 0.44]}.'
+          + " Winged bodies can also name their wing bones exactly as the rig"
+          + ' spells them, e.g. {"L_Wing_Upper": [0, 0, 0.26, 0.97]}.');
       }
       if (a.target) {
         ag.puppet(String(a.target), { pose: v.pose });

--- a/mcpl/tools.ts
+++ b/mcpl/tools.ts
@@ -422,7 +422,8 @@ export const HANDLERS: Record<string, ToolHandler> = {
         const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
         rawKnown = bones ? new Set(bones) : null;
       } catch { rawKnown = null; }
-      const v = validatePose(a.bones, rawKnown ? { rawKnown } : {});
+      const whose = a.target ? String(a.target) : null;
+      const v = validatePose(a.bones, rawKnown ? { rawKnown, ...(whose ? { whose } : {}) } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`no pose set — nothing usable in \`bones\`.${note ? ` ${note}.` : ""}`
@@ -509,7 +510,8 @@ export const HANDLERS: Record<string, ToolHandler> = {
         const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
         rawKnown = bones ? new Set(bones) : null;
       } catch { rawKnown = null; }
-      const v = validateTracks(a.tracks, rawKnown ? { rawKnown } : {});
+      const whoseT = a.target ? String(a.target) : null;
+      const v = validateTracks(a.tracks, rawKnown ? { rawKnown, ...(whoseT ? { whose: whoseT } : {}) } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`nothing played — no usable tracks.${note ? ` ${note}.` : ""}`

--- a/mcpl/tools.ts
+++ b/mcpl/tools.ts
@@ -413,17 +413,36 @@ export const HANDLERS: Record<string, ToolHandler> = {
       // REFUSED from posing a winged one. mica produced both wrong-body
       // receipts. The gate has to ask about the skeleton that will wear it.
       //
-      // Null means "could not find out" -- an unknown target, or a glTF that
-      // would not parse -- and then the gate is SKIPPED rather than closed:
-      // refusing every wing pose because a lookup failed would break the tool
-      // for a network hiccup, and the client drops an unresolvable bone anyway.
-      let rawKnown: Set<string> | null = null;
-      try {
-        const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
-        rawKnown = bones ? new Set(bones) : null;
-      } catch { rawKnown = null; }
+      // UNKNOWN ANATOMY REFUSES, LOUDLY. The first cut skipped the gate when
+      // the lookup failed, on the theory that a network hiccup should not break
+      // the tool -- but that turns "I could not find out" into a successful
+      // silent no-op, which is the one outcome this whole path exists to
+      // prevent (mica; and the resident's requirement that the doorman stay
+      // loud: he localised a fault in one hop off SEVEN verbatim rejections).
+      //
+      // Only RAW names need the gate, so a humanoid-only pose still works when
+      // the skeleton cannot be read -- VRM guarantees that vocabulary. A pose
+      // naming a wing gets told why, and can retry.
       const whose = a.target ? String(a.target) : null;
-      const v = validatePose(a.bones, rawKnown ? { rawKnown, ...(whose ? { whose } : {}) } : {});
+      let rawKnown: Set<string> | null = null;
+      let rawAmbiguous: string[] = [];
+      let anatomyWhy: string | null = null;
+      try {
+        const r = await ag.loadBonesForTarget(whose);
+        rawKnown = r.bones ? new Set(r.bones) : null;
+        rawAmbiguous = r.ambiguous;
+        anatomyWhy = r.why;
+      } catch (e: any) {
+        anatomyWhy = `the skeleton lookup failed (${e?.message ?? e})`;
+      }
+      const namesRaw = Object.keys(a.bones ?? {}).filter((n) => /^[LR]_Wing_/.test(n));
+      if (!rawKnown && namesRaw.length) {
+        return text(`no pose set — ${anatomyWhy ?? "that body's skeleton is unknown"}, `
+          + `so ${namesRaw.join(", ")} cannot be checked and will not be guessed at. `
+          + `Humanoid bone names still work; retry the wing names once the body is known.`);
+      }
+      const v = validatePose(a.bones,
+        rawKnown ? { rawKnown, rawAmbiguous, ...(whose ? { whose } : {}) } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`no pose set — nothing usable in \`bones\`.${note ? ` ${note}.` : ""}`
@@ -436,7 +455,7 @@ export const HANDLERS: Record<string, ToolHandler> = {
         ag.puppet(String(a.target), { pose: v.pose });
         return text(`asked ${a.target} to hold a pose over ${v.accepted.length} bone(s)`
           + `${note ? ` — ${note}` : ""}`
-          + (rawKnown ? "" : ` (could not read ${a.target}'s skeleton, so bone names went unchecked)`)
+          + (rawKnown ? "" : ` (humanoid names only — ${anatomyWhy})`)
           + ". They decide whether to take it.");
       }
       const hold = !!a.hold;
@@ -505,13 +524,26 @@ export const HANDLERS: Record<string, ToolHandler> = {
       // gained it -- with no body gate at all, which is worse than pose's bug
       // was: mica got `wingless self -> animate wing: "playing ... L_Wing_Upper"`.
       // An animation is a pose over time; the same skeleton has to be asked.
-      let rawKnown: Set<string> | null = null;
-      try {
-        const bones = await ag.loadBonesForTarget(a.target ? String(a.target) : null);
-        rawKnown = bones ? new Set(bones) : null;
-      } catch { rawKnown = null; }
+      // Unknown anatomy refuses here too, for the same reason.
       const whoseT = a.target ? String(a.target) : null;
-      const v = validateTracks(a.tracks, rawKnown ? { rawKnown, ...(whoseT ? { whose: whoseT } : {}) } : {});
+      let rawKnown: Set<string> | null = null;
+      let rawAmbiguous: string[] = [];
+      let anatomyWhy: string | null = null;
+      try {
+        const r = await ag.loadBonesForTarget(whoseT);
+        rawKnown = r.bones ? new Set(r.bones) : null;
+        rawAmbiguous = r.ambiguous;
+        anatomyWhy = r.why;
+      } catch (e: any) {
+        anatomyWhy = `the skeleton lookup failed (${e?.message ?? e})`;
+      }
+      const animRaw = Object.keys(a.tracks ?? {}).filter((n) => /^[LR]_Wing_/.test(n));
+      if (!rawKnown && animRaw.length) {
+        return text(`nothing played — ${anatomyWhy ?? "that body's skeleton is unknown"}, `
+          + `so ${animRaw.join(", ")} cannot be checked and will not be guessed at.`);
+      }
+      const v = validateTracks(a.tracks,
+        rawKnown ? { rawKnown, rawAmbiguous, ...(whoseT ? { whose: whoseT } : {}) } : {});
       const note = poseReport(v);
       if (!v.accepted.length) {
         return text(`nothing played — no usable tracks.${note ? ` ${note}.` : ""}`

--- a/shared/humanoid.js
+++ b/shared/humanoid.js
@@ -125,6 +125,17 @@ function distance(a, b) {
 export function suggestBone(name) {
   if (typeof name !== 'string' || !name) return null;
   const key = name.trim().toLowerCase().replace(/[\s_.-]/g, '');
+  // A NAME THAT MEANS WING GETS A WING BACK. Searching only the humanoid list
+  // answered `LeftWing` with `leftHand` -- a confident counteroffer pointing at
+  // the wrong dictionary, which is worse than none: the reader tries the hand
+  // and concludes wings are unreachable. Mythos live-tested seven wing names
+  // and kept the rejection slips precisely because each one localised the
+  // fault; a wrong suggestion de-localises it.
+  if (/wing/.test(key)) {
+    const side = /(^|[^a-z])(r|right)/.test(key) ? 'R' : 'L';
+    const row = /lower|low|under/.test(key) ? 'Lower' : 'Upper';
+    return `${side}_Wing_${row}`;
+  }
   let best = null, bestD = 4;
   for (const b of HUMANOID_BONES) {
     const d = distance(key, b.toLowerCase());
@@ -198,7 +209,16 @@ export function validatePose(bones, opts = {}) {
     // so accepting `L_Wing_Upper` on a wingless body would report success and
     // move nothing -- the silent failure this module exists to prevent.
     if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
-      out.rejected.push({ name: raw, why: 'your body has no bone by that name' });
+      out.rejected.push({
+        name: raw,
+        why: opts.whose
+          // "your body" is a lie when the pose is aimed at someone else, and
+          // this refusal is the enfold's error path: a wingless resident
+          // reaching for a winged friend's wing must be told about THEIR
+          // skeleton, not misinformed about their own.
+          ? `${opts.whose} has no bone by that name`
+          : 'your body has no bone by that name',
+      });
       continue;
     }
     // Two written names can fold to one bone ("leftElbow" and "LeftLowerArm").
@@ -274,7 +294,16 @@ export function validateTracks(tracks, opts = {}) {
     // so accepting `L_Wing_Upper` on a wingless body would report success and
     // move nothing -- the silent failure this module exists to prevent.
     if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
-      out.rejected.push({ name: raw, why: 'your body has no bone by that name' });
+      out.rejected.push({
+        name: raw,
+        why: opts.whose
+          // "your body" is a lie when the pose is aimed at someone else, and
+          // this refusal is the enfold's error path: a wingless resident
+          // reaching for a winged friend's wing must be told about THEIR
+          // skeleton, not misinformed about their own.
+          ? `${opts.whose} has no bone by that name`
+          : 'your body has no bone by that name',
+      });
       continue;
     }
     if (name in out.tracks) {

--- a/shared/humanoid.js
+++ b/shared/humanoid.js
@@ -71,8 +71,32 @@ const ALIASES = {
 
 /** Fold a written name to its canonical form: case, separators and a few
  *  cross-rig synonyms. Returns null if it is not a humanoid bone at all. */
+/** The wing chains, by the same naming contract flight and the ragdoll use:
+ *  `<side>_Wing_<row>` then `_1`, `_2` outward. Identical to
+ *  shared/flightbody.js's WING_RE, deliberately not imported -- this module is
+ *  the vocabulary and must not depend on flight to describe a bone. */
+export const WING_RE = /^([LR])_Wing_(Upper|Lower)(?:_(\d+))?$/;
+
+/** True for a bone this module accepts but does NOT own a humanoid name for.
+ *
+ *  Wings are RAW bones: VRM's humanoid vocabulary has no word for them, so
+ *  `canonicalBone` returned null and the pose verb answered "not a VRM
+ *  humanoid bone" -- correct, and useless to an agent with wings who wants to
+ *  move them. They are addressable because the rig NAMES them, which is the
+ *  same contract by which hair and wings reach the springbone and ragdoll
+ *  systems (rigtest/EIDOVERSE-DEPLOY.md: "the pipeline recognises bones by
+ *  NAME and nothing else").
+ *
+ *  Case-SENSITIVE, unlike the humanoid names. Those are a vocabulary this
+ *  module owns and can spell forgivingly; a raw bone name is a fact about one
+ *  body's skeleton, and `l_wing_upper` is not a bone that exists. Accepting a
+ *  near-miss would resolve to nothing at the client and report success. */
+export const isRawBone = (name) => typeof name === 'string' && WING_RE.test(name);
+
 export function canonicalBone(name) {
   if (typeof name !== 'string') return null;
+  // A raw bone is already canonical: it names itself, exactly.
+  if (isRawBone(name)) return name;
   const key = name.trim().toLowerCase().replace(/[\s_.-]/g, '');
   return BY_KEY.get(key) ?? ALIASES[key] ?? null;
 }
@@ -153,12 +177,30 @@ export function validatePose(bones, opts = {}) {
     const name = canonicalBone(raw);
     if (!name) {
       const suggest = suggestBone(raw);
-      out.rejected.push({ name: raw, why: 'not a VRM humanoid bone', ...(suggest ? { suggest } : {}) });
+      out.rejected.push({
+        name: raw,
+        why: /wing/i.test(raw)
+          // A wing name that failed the regex is almost always a spelling or a
+          // case slip, and "not a VRM humanoid bone" sends the reader looking
+          // in the wrong dictionary entirely.
+          ? 'wing bones are addressable but case-sensitive: L_Wing_Upper, '
+            + 'R_Wing_Lower_2 and so on (exactly as the rig spells them)'
+          : 'not a VRM humanoid bone',
+        ...(suggest ? { suggest } : {}),
+      });
       continue;
     }
     const q = normalizeQuat(v);
     if (q.why) { out.rejected.push({ name: raw, why: q.why }); continue; }
     if (known && !known.has(name)) { out.absent.push(name); continue; }
+    // A raw bone is only real if THIS body has it. The humanoid names above
+    // are a vocabulary VRM guarantees; a wing is a fact about one skeleton,
+    // so accepting `L_Wing_Upper` on a wingless body would report success and
+    // move nothing -- the silent failure this module exists to prevent.
+    if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
+      out.rejected.push({ name: raw, why: 'your body has no bone by that name' });
+      continue;
+    }
     // Two written names can fold to one bone ("leftElbow" and "LeftLowerArm").
     // Last-write-wins would drop one of them without a word — the exact silent
     // overwrite this module exists to stop. Keep the first, name the clash.
@@ -213,10 +255,28 @@ export function validateTracks(tracks, opts = {}) {
     const name = canonicalBone(raw);
     if (!name) {
       const suggest = suggestBone(raw);
-      out.rejected.push({ name: raw, why: 'not a VRM humanoid bone', ...(suggest ? { suggest } : {}) });
+      out.rejected.push({
+        name: raw,
+        why: /wing/i.test(raw)
+          // A wing name that failed the regex is almost always a spelling or a
+          // case slip, and "not a VRM humanoid bone" sends the reader looking
+          // in the wrong dictionary entirely.
+          ? 'wing bones are addressable but case-sensitive: L_Wing_Upper, '
+            + 'R_Wing_Lower_2 and so on (exactly as the rig spells them)'
+          : 'not a VRM humanoid bone',
+        ...(suggest ? { suggest } : {}),
+      });
       continue;
     }
     if (known && !known.has(name)) { out.absent.push(name); continue; }
+    // A raw bone is only real if THIS body has it. The humanoid names above
+    // are a vocabulary VRM guarantees; a wing is a fact about one skeleton,
+    // so accepting `L_Wing_Upper` on a wingless body would report success and
+    // move nothing -- the silent failure this module exists to prevent.
+    if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
+      out.rejected.push({ name: raw, why: 'your body has no bone by that name' });
+      continue;
+    }
     if (name in out.tracks) {
       out.rejected.push({ name: raw, why: `also names ${name}, already tracked here — one bone, one track` });
       continue;

--- a/shared/humanoid.js
+++ b/shared/humanoid.js
@@ -208,6 +208,17 @@ export function validatePose(bones, opts = {}) {
     // are a vocabulary VRM guarantees; a wing is a fact about one skeleton,
     // so accepting `L_Wing_Upper` on a wingless body would report success and
     // move nothing -- the silent failure this module exists to prevent.
+    if (opts.rawAmbiguous?.includes?.(name)) {
+      // Two joints, one name: the browser resolves by name and takes the last
+      // one it walks past, so there is no honest answer to "which did you
+      // mean". Refused rather than guessed.
+      out.rejected.push({
+        name: raw,
+        why: `${opts.whose ?? 'that body'} has more than one bone called that, `
+           + 'so naming it is ambiguous -- the rig needs unique joint names',
+      });
+      continue;
+    }
     if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
       out.rejected.push({
         name: raw,
@@ -293,6 +304,17 @@ export function validateTracks(tracks, opts = {}) {
     // are a vocabulary VRM guarantees; a wing is a fact about one skeleton,
     // so accepting `L_Wing_Upper` on a wingless body would report success and
     // move nothing -- the silent failure this module exists to prevent.
+    if (opts.rawAmbiguous?.includes?.(name)) {
+      // Two joints, one name: the browser resolves by name and takes the last
+      // one it walks past, so there is no honest answer to "which did you
+      // mean". Refused rather than guessed.
+      out.rejected.push({
+        name: raw,
+        why: `${opts.whose ?? 'that body'} has more than one bone called that, `
+           + 'so naming it is ambiguous -- the rig needs unique joint names',
+      });
+      continue;
+    }
     if (opts.rawKnown && isRawBone(name) && !opts.rawKnown.has(name)) {
       out.rejected.push({
         name: raw,

--- a/tools/core-stub.mjs
+++ b/tools/core-stub.mjs
@@ -4,8 +4,27 @@
 // three is imported by explicit path because tools/ sits outside client/,
 // where the npm install lives — this resolves to the SAME module instance
 // colliders.js gets for its bare 'three' specifier.
-import * as THREE from '../client/node_modules/three/build/three.module.js';
-export { THREE };
+import * as THREE_RAW from '../client/node_modules/three/build/three.module.js';
+
+// MeshPhysicalNodeMaterial ships ONLY in three's WebGPU build (three.webgpu.js
+// wants a GPU adapter at import, so headless tests load three.module.js). The
+// materials factory's transmissive upgrade correctly no-ops when the class is
+// absent, which means a harness without a stand-in can only ever prove the
+// no-op -- see tools/transmission-test.mjs.
+//
+// The stand-in matches the real class in the two ways the upgrade depends on:
+// the `isNodeMaterial`/`isMeshPhysicalNodeMaterial` flags, and `transmission`
+// living on the PROTOTYPE as an accessor (inherited from MeshPhysicalMaterial),
+// which is the property whose accessor-ness was the bug the test guards.
+// A namespace object is frozen, so this wrapper is how it gets added.
+class MeshPhysicalNodeMaterial extends THREE_RAW.MeshPhysicalMaterial {
+  constructor(p) {
+    super(p);
+    this.isNodeMaterial = true;
+    this.isMeshPhysicalNodeMaterial = true;
+  }
+}
+export const THREE = Object.freeze({ ...THREE_RAW, MeshPhysicalNodeMaterial });
 export const scene = { add() {}, remove() {} };
 export const ground = null;
 export const grid = null;
@@ -14,8 +33,15 @@ export const bus = { on() {}, emit() {} };
 // avatar.js pulls a wider slice of core than ragdoll's cone does. None of it
 // is exercised by the limp/clip lifecycle under test — the point is only to
 // let the module import without a renderer.
-export const camera = { position: new THREE.Vector3(), quaternion: new THREE.Quaternion() };
-export const renderer = { domElement: null };
+export const camera = { position: new THREE_RAW.Vector3(), quaternion: new THREE_RAW.Quaternion() };
+// lightrig configures the shadow map at module scope (enabled/type are in the
+// pipeline cache key, so they are set once before the first compile). A bare
+// {} is a TypeError there; these are inert stand-ins, not a simulated renderer.
+export const renderer = {
+  domElement: null,
+  shadowMap: { enabled: false, type: 0 },
+  _getShadowNodes: () => ({}),
+};
 export const report = () => {};
 export const angleDelta = (a, b) => {
   let d = (b - a) % (Math.PI * 2);
@@ -23,9 +49,32 @@ export const angleDelta = (a, b) => {
   if (d < -Math.PI) d += Math.PI * 2;
   return d;
 };
-export const CONFIG = {};
+// `params` is real URLSearchParams, not {}: lightrig reads
+// CONFIG.params.get('slots') at module scope, so an empty object is a
+// TypeError before any test runs. Empty query = every default.
+export const CONFIG = { params: new URLSearchParams(), name: 'test' };
 // warmqueue.js reaches for the shader-node namespace and the sun. Neither means
 // anything headless, but a MISSING export is a SyntaxError at import time, which
 // takes the whole suite down before a single test runs (see loadwork-stub).
-export const sun = { position: new THREE.Vector3(0, 1, 0) };
-export const TSL = new Proxy({}, { get: () => () => {} });
+// A REAL DirectionalLight, not a hand-built stand-in: lightrig configures
+// sun.shadow.mapSize/bias and the frustum extents at module scope, and three
+// already ships that whole structure correctly. Cheaper to borrow than to
+// mimic field by field, and it cannot drift from what the real one has.
+export const sun = (() => {
+  const l = new THREE_RAW.DirectionalLight(0xffffff, 1);
+  l.position.set(0, 1, 0);
+  return l;
+})();
+// CHAINABLE, because materials.js builds real TSL graphs -- `clamp(x,0,1).pow(2)
+// .mul(U.wet)` and deeper. The old stub returned `() => {}`, so the first call
+// yielded undefined and the next `.pow` threw; any test that reached
+// prepareMaterial died on the shader graph rather than on its own subject.
+// A self-returning node lets the graph build into nothing, which is exactly
+// what a headless harness wants: the factory's WIRING is under test, never the
+// shader it emits.
+const tslNode = new Proxy(function () {}, {
+  get: (_t, k) => (k === 'then' ? undefined : tslNode),   // not a thenable
+  apply: () => tslNode,
+  construct: () => tslNode,
+});
+export const TSL = new Proxy({}, { get: () => tslNode });

--- a/tools/core-stub.mjs
+++ b/tools/core-stub.mjs
@@ -41,6 +41,15 @@ export const renderer = {
   domElement: null,
   shadowMap: { enabled: false, type: 0 },
   _getShadowNodes: () => ({}),
+  // assets.js builds a KTX2Loader at module scope, and detectSupport() reads
+  // renderer.extensions/capabilities to pick a transcode target. Stubbing them
+  // here means a test that imports avatar.js needs no assets.js substitution
+  // at all -- which matters because Bun 1.3's onResolve mishandles that
+  // particular stub path (the ENOENT that makes tools/avatar-test.ts fail on
+  // clean main).
+  extensions: { has: () => false, get: () => null },
+  capabilities: { isWebGL2: true, maxTextureSize: 4096 },
+  getContext: () => null,
 };
 export const report = () => {};
 export const angleDelta = (a, b) => {

--- a/tools/transmission-test.mjs
+++ b/tools/transmission-test.mjs
@@ -1,0 +1,177 @@
+// Transmission: does a transmissive material reach the renderer in a class
+// that can DRAW it, and does the value survive the trip?
+//
+// This test was source-regex, and mica broke it on purpose to prove the point:
+// she injected `if (k === 'transmission') continue;` into the upgrade -- so the
+// runtime dropped the exact property the feature exists to preserve -- and the
+// old test still reported 14 passed, 0 failed. A test that cannot fail is not a
+// test. It also read an absolute path under a contributor's home directory, so
+// it crashed ENOENT on her review host after 11 checks.
+//
+// So this one CALLS prepareObject() on a real mesh with a real
+// MeshPhysicalMaterial and asserts on the material that comes back. No regex
+// over source, no path outside this repo.
+//
+// The failure it guards is silent and looks like missing geometry: a plain
+// MeshPhysicalMaterial with transmission > 0 arrives with every value correct
+// -- visible: true, mesh present, triangles counted -- and renders as nothing,
+// because three's WebGPU renderer only builds the transmission graph for
+// MeshPhysicalNodeMaterial.
+
+import { plugin } from 'bun';
+const here = (p) => new URL(p, import.meta.url).pathname;
+plugin({
+  name: 'core-stub',
+  setup(build) {
+    build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    // lightrig pulls warmqueue -> loadwork, which calls requestAnimationFrame
+    // at module scope. Same stub avatar-test and parts-test use.
+    build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
+  },
+});
+
+const { THREE } = await import('./core-stub.mjs');
+
+// The stand-in for MeshPhysicalNodeMaterial lives in core-stub.mjs, which owns
+// the THREE namespace it re-exports (a module namespace object is frozen).
+
+const { prepareObject } = await import('../client/lib/materials.js');
+
+let pass = 0, fail = 0;
+const check = (name, ok, note = '') => {
+  if (ok) { pass++; console.log(`  ok    ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${note ? `  -- ${note}` : ''}`); }
+};
+
+/** A mesh wearing one material, run through the real factory. */
+function prepared(mat) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), mat);
+  const root = new THREE.Group();
+  root.add(m);
+  prepareObject(root, { kind: 'model' });
+  return Array.isArray(m.material) ? m.material[0] : m.material;
+}
+
+console.log('TRANSMISSION -- a correct file the renderer could not honour');
+{
+  const src = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  src.transmission = 0.95;
+  src.ior = 1.52;
+  src.thickness = 0.06;
+  src.roughness = 0.05;
+  src.metalness = 0;
+  src.color.setRGB(0.96, 0.98, 1.0);
+  src.specularIntensity = 1;
+  const out = prepared(src);
+
+  check('a transmissive material is upgraded to a NODE material',
+        out?.isNodeMaterial === true, `got ${out?.constructor?.name}`);
+  check('...specifically MeshPhysicalNodeMaterial',
+        out?.isMeshPhysicalNodeMaterial === true, `got ${out?.constructor?.name}`);
+
+  // THE REGRESSION mica injected. `transmission` is a PROTOTYPE ACCESSOR on
+  // MeshPhysicalMaterial, so a copy loop over Object.keys() silently drops the
+  // one value the upgrade exists to carry -- producing a node material with
+  // ior and thickness intact and transmission 0: the same invisibility for a
+  // new reason. This is the check that goes red for that.
+  check('TRANSMISSION SURVIVES the upgrade (the accessor bug)',
+        out?.transmission === 0.95, `got ${out?.transmission}`);
+  check('ior survives', out?.ior === 1.52, `got ${out?.ior}`);
+  check('thickness survives', out?.thickness === 0.06, `got ${out?.thickness}`);
+  check('roughness and metalness survive',
+        out?.roughness === 0.05 && out?.metalness === 0);
+  check('specularIntensity survives', out?.specularIntensity === 1,
+        `got ${out?.specularIntensity}`);
+  check('the name survives (lightrig and gltf_materials dispatch on it)',
+        out?.name === 'Glass', `got ${out?.name}`);
+  check('it is in the transparent pass', out?.transparent === true);
+
+  // Colour/Vector types must be COPIED, not shared: assigning them would leave
+  // the new material pointing at the old one's Color instance, so a later tweak
+  // to either would silently move the other.
+  check('colour came across by VALUE, not by reference',
+        out?.color !== src.color
+        && Math.abs(out.color.r - 0.96) < 1e-6
+        && Math.abs(out.color.b - 1.0) < 1e-6);
+}
+
+console.log('\nAND ONLY TRANSMISSIVE MATERIALS -- node materials compile dearer');
+{
+  const opaque = new THREE.MeshPhysicalMaterial({ name: 'GOLD' });
+  opaque.metalness = 1; opaque.roughness = 0.26;
+  const out = prepared(opaque);
+  check('an opaque MeshPhysicalMaterial is left alone',
+        out?.isNodeMaterial !== true, `got ${out?.constructor?.name}`);
+  check('...with its values untouched',
+        out?.metalness === 1 && out?.roughness === 0.26);
+
+  const std = new THREE.MeshStandardMaterial({ name: 'RAVEN' });
+  const outStd = prepared(std);
+  check('a MeshStandardMaterial is left alone too',
+        outStd?.isNodeMaterial !== true, `got ${outStd?.constructor?.name}`);
+}
+
+console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
+{
+  const m = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  m.transmission = 0.5;
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(), m);
+  const root = new THREE.Group(); root.add(mesh);
+  prepareObject(root, { kind: 'model' });
+  const first = mesh.material;
+  prepareObject(root, { kind: 'model' });
+  check('a second pass does not re-upgrade (or churn the material)',
+        mesh.material === first);
+  check('...and the value is still there', mesh.material.transmission === 0.5);
+}
+
+console.log('\nLAMP LIFECYCLE -- mica\'s two probes, as tests');
+{
+  const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
+    = await import('../client/lib/lightrig.js');
+
+  // B2: OWNERSHIP. A lamp owner keyed to the IDENTITY collides across a body
+  // swap: the swap order is build-new-then-dispose-old (mybody.js), so the new
+  // body registers `body:mythos`, the old body's dispose releases
+  // `body:mythos`, and the LIVE lamp dies. mica measured requests 1 -> 0.
+  const before = rigDebug().requests.length;
+  requestLight('lamp:body:mythos:1:0', { owner: 'body:mythos:1', intensity: 10 });
+  requestLight('lamp:body:mythos:2:0', { owner: 'body:mythos:2', intensity: 10 });
+  const both = rigDebug().requests.length - before;
+  check('two bodies of one identity hold two distinct requests', both === 2, `${both}`);
+  releaseOwner('body:mythos:1');                       // the OLD body disposes
+  const left = rigDebug().requests.filter((r) => /mythos:2/.test(r.key)).length;
+  check('disposing the old body leaves the new body\'s lamp alive', left === 1,
+        `${left} left`);
+  releaseOwner('body:mythos:2');
+
+  // ...and the collision itself, so the test states what used to happen.
+  requestLight('lamp:body:janus:0', { owner: 'body:janus', intensity: 10 });
+  releaseOwner('body:janus');
+  check('(control) a SHARED owner key does take the other body down',
+        rigDebug().requests.filter((r) => /janus/.test(r.key)).length === 0);
+
+  // B6: intensity must NOT dirty slot assignment -- the rig recomputes at most
+  // every 600ms and assignment reads tier and camera distance, never intensity.
+  // A breathing lamp patches this 60x a second.
+  //
+  // The assertion has to start from a CLEAN flag, or it passes on the broken
+  // code: a fresh requestLight leaves assignDirty true, so "still true after
+  // an intensity patch" proves nothing. updateRig() clears it -- so run one,
+  // confirm it cleared, and only then patch. (My first cut skipped that and
+  // passed against the very implementation it was written to reject, which is
+  // precisely the failure mica found in the rest of this file.)
+  requestLight('probe:0', { owner: 'probe', intensity: 5 });
+  updateRig(performance.now());
+  check('(setup) a rig pass clears the assignment flag',
+        rigDebug().assignDirty === false, `${rigDebug().assignDirty}`);
+  updateRequest('probe:0', { intensity: 7 });
+  check('an intensity patch does not force reassignment',
+        rigDebug().assignDirty === false, `dirty became ${rigDebug().assignDirty}`);
+  updateRequest('probe:0', { keep: true });
+  check('...but a TIER patch does', rigDebug().assignDirty === true);
+  releaseOwner('probe');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/transmission-test.mjs
+++ b/tools/transmission-test.mjs
@@ -18,24 +18,69 @@
 // because three's WebGPU renderer only builds the transmission graph for
 // MeshPhysicalNodeMaterial.
 
+// The Avatar constructor makes a nameplate sprite through document/canvas, so
+// the DOM has to exist before avatar.js is imported. Same registrator
+// chat-log-test and frames-resize-test use.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+GlobalRegistrator.register();
+// happy-dom ships no 2D canvas context, and the nameplate measures and draws
+// text. An inert recorder is enough: nothing here asserts on pixels, and the
+// alternative is a real canvas binding for a label the lamp does not care
+// about.
+HTMLCanvasElement.prototype.getContext = function () {
+  // Every method returns a SELF-CHAINING stub, because the drawing code builds
+  // objects from the context and calls methods on them (createRadialGradient
+  // -> addColorStop). Returning a bare no-op yielded undefined and threw one
+  // draw call later.
+  const anything = new Proxy(function () {}, {
+    get: (_t, k) => (k === 'width' ? 100 : anything),
+    apply: () => anything,
+    set: () => true,
+  });
+  return new Proxy({}, {
+    get: (_t, k) => (k === 'measureText' ? () => ({ width: 100 }) : anything),
+    set: () => true,
+  });
+};
+
 import { plugin } from 'bun';
-const here = (p) => new URL(p, import.meta.url).pathname;
+// import.meta.dir is a plain filesystem path; a `file:` URL string reaches
+// readFile as a literal name and ENOENTs on a stub that is right there. This
+// showed up only on a COLD module cache (i.e. right after editing a client
+// file), which is exactly when a mutation test runs -- so the suite appeared
+// to "fail" on mutations for the wrong reason.
+const HERE = import.meta.dir;
+const here = (p) => `${HERE}/${p.replace(/^\.\//, '')}`;
 plugin({
   name: 'core-stub',
   setup(build) {
     build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
     // lightrig pulls warmqueue -> loadwork, which calls requestAnimationFrame
     // at module scope. Same stub avatar-test and parts-test use.
+    build.onResolve({ filter: /^\.\/base\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    // avatar.js pulls assets.js, which builds a KTX2Loader against a real
+    // renderer. Without this the run's outcome depended on whether assets.js
+    // had already been imported and cached -- a harness that sometimes passes
+    // is worse than one that fails.
+    build.onResolve({ filter: /^\.\/assets\.js$/ }, () => ({ path: here('./assets-stub.mjs') }));
     build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
   },
 });
 
+const { readFileSync } = await import('node:fs');
 const { THREE } = await import('./core-stub.mjs');
 
 // The stand-in for MeshPhysicalNodeMaterial lives in core-stub.mjs, which owns
 // the THREE namespace it re-exports (a module namespace object is frozen).
 
 const { prepareObject } = await import('../client/lib/materials.js');
+// TOP-LEVEL, not inside a block. A dynamic import from inside a test resolved
+// `./core.js` on a cold module cache without the plugin's substitution --
+// ENOENT on a `file:` path -- so whether the suite ran at all depended on
+// import order. Everything the suite touches is loaded here, once.
+const { Avatar } = await import('../client/lib/avatar.js');
+const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
+  = await import('../client/lib/lightrig.js');
 
 let pass = 0, fail = 0;
 const check = (name, ok, note = '') => {
@@ -111,6 +156,42 @@ console.log('\nAND ONLY TRANSMISSIVE MATERIALS -- node materials compile dearer'
         outStd?.isNodeMaterial !== true, `got ${outStd?.constructor?.name}`);
 }
 
+console.log('\nSHARING -- one source material, one replacement');
+{
+  // Two meshes wearing THE SAME material must come back wearing the same
+  // replacement. A WeakSet could record that a material had been upgraded but
+  // not what to, so each mesh built its own node material: double the shader
+  // objects for one look, and an author editing the shared material would move
+  // one mesh and not the other (mica: replacementShared:false).
+  const src = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
+  src.transmission = 0.9; src.ior = 1.5;
+  const a = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const b = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const root = new THREE.Group(); root.add(a); root.add(b);
+  prepareObject(root, { kind: 'model' });
+  check('both meshes were upgraded', a.material.isNodeMaterial && b.material.isNodeMaterial);
+  check('...to the SAME replacement, not one each', a.material === b.material,
+        a.material === b.material ? '' : 'two node materials for one source');
+  check('...carrying the value', a.material.transmission === 0.9);
+
+  // And a mesh added LATER, in a separate pass, still shares.
+  const c = new THREE.Mesh(new THREE.BoxGeometry(), src);
+  const root2 = new THREE.Group(); root2.add(c);
+  prepareObject(root2, { kind: 'model' });
+  check('a mesh prepared in a later pass shares it too', c.material === a.material);
+}
+
+console.log('\nAUTHORED ZERO -- ?? not ||');
+{
+  // A lamp material authored at emissiveIntensity 0 (starts dark) must not be
+  // "restored" to 1. `|| 1` did exactly that, and the pooled material then
+  // came back brighter than it was written.
+  const av = readFileSync(`${HERE}/../client/lib/avatar.js`, 'utf8');
+  check('the lamp base uses ?? so an authored zero survives',
+        /base: m\.emissiveIntensity \?\? 1/.test(av) &&
+        !/base: m\.emissiveIntensity \|\| 1/.test(av));
+}
+
 console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
 {
   const m = new THREE.MeshPhysicalMaterial({ name: 'Glass' });
@@ -125,11 +206,71 @@ console.log('\nIDEMPOTENCE -- prepareObject runs on every load and hot-swap');
   check('...and the value is still there', mesh.material.transmission === 0.5);
 }
 
-console.log('\nLAMP LIFECYCLE -- mica\'s two probes, as tests');
+console.log('\nTHE AVATAR ITSELF -- build-new -> dispose-old, and pool -> rewear');
 {
-  const { requestLight, releaseOwner, updateRequest, rigDebug, updateRig }
-    = await import('../client/lib/lightrig.js');
+  // mica's re-review: the lifecycle checks below drive lightrig DIRECTLY, so
+  // she restored both old defects in avatar.js -- bare `body:${id}` ownership
+  // and no emissive restoration before pooling -- and the suite still passed
+  // 21/21. Manually creating good keys cannot see a bug in how Avatar MAKES
+  // them. These bind the real class.
+  //
+  // (And my note that Avatar could not be imported here was wrong: the ENOENT
+  // was `new URL(...).pathname` reaching Bun's onResolve as a `file:` string,
+  // not the module. A plain path works.)
+  /** A body with one emissive mesh -- enough for attachLamps to want a lamp. */
+  function glowingVrm() {
+    const scene = new THREE.Object3D();
+    const mat = new THREE.MeshStandardMaterial({ name: 'lampglass' });
+    mat.emissive = new THREE.Color(1, 0.72, 0.25);
+    mat.emissiveIntensity = 3;
+    const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.02, 8, 8), mat);
+    mesh.name = 'lamp';
+    scene.add(mesh);
+    return {
+      scene, mat, mesh,
+      humanoid: { getNormalizedBoneNode: () => null },
+      springBoneManager: { joints: [], reset() {}, setInitState() {} },
+      expressionManager: null,
+      update() {},
+    };
+  }
+  const lampsOf = (owner) => rigDebug().requests.filter((r) => r.key.startsWith(`lamp:${owner}`)).length;
+  const mine = (id) => rigDebug().requests.filter((r) => r.key.includes(`body:${id}`)).length;
 
+  // B2: THE SWAP. mybody.js builds the NEW body and then disposes the old, so
+  // an owner keyed on the identity means the old body's dispose deletes the
+  // live lamp. mica measured requests 1 -> 0.
+  const v1 = glowingVrm();
+  const oldBody = new Avatar('mythos', v1, {});
+  check('a glowing body registers a lamp', mine('mythos') === 1, `${mine('mythos')}`);
+  const v2 = glowingVrm();
+  const newBody = new Avatar('mythos', v2, {});          // build new...
+  check('...and the second body of the same identity registers its own',
+        mine('mythos') === 2, `${mine('mythos')}`);
+  oldBody.dispose();                                      // ...then dispose old
+  check('B2: disposing the OLD body leaves the new body lit',
+        mine('mythos') === 1, `${mine('mythos')} requests left`);
+  check('...and it is the NEW body\'s request that survived',
+        lampsOf(newBody._lampOwner) === 1);
+
+  // B3: THE POOL. The breath writes emissiveIntensity every frame and
+  // assets.js resetVrmInstance touches no materials, so a body pooled
+  // mid-breath comes back dim -- and dimmer than attachLamps's threshold means
+  // the NEXT wearer gets no lamp at all (mica: rewear at 0.3, lamps made 0).
+  newBody.update?.(1 / 60, performance.now());            // let the breath write
+  v2.mat.emissiveIntensity = 0.3;                         // ...mid-breath, dim
+  newBody.dispose();
+  check('B3: dispose RESTORES the authored emissive before pooling',
+        v2.mat.emissiveIntensity === 3, `left at ${v2.mat.emissiveIntensity}`);
+  const rewear = new Avatar('mythos', v2, {});            // the pooled instance
+  check('...so a rewear of the pooled body still gets a lamp',
+        rewear._lamps.length === 1, `${rewear._lamps.length} lamps`);
+  rewear.dispose();
+  check('(cleanup) no lamp requests survive the last dispose', mine('mythos') === 0);
+}
+
+console.log('\nLAMP LIFECYCLE -- the rig\'s own contract');
+{
   // B2: OWNERSHIP. A lamp owner keyed to the IDENTITY collides across a body
   // swap: the swap order is build-new-then-dispose-old (mybody.js), so the new
   // body registers `body:mythos`, the old body's dispose releases

--- a/tools/wingpose-test.mjs
+++ b/tools/wingpose-test.mjs
@@ -95,6 +95,22 @@ console.log('THE VALIDATOR -- names, case, and whose body');
         JSON.stringify(no.rejected));
   check('humanoid bones stay ungated (VRM guarantees them)',
         validatePose({ head: [0, 0, 0, 1] }, { rawKnown: new Set() }).accepted.includes('head'));
+  // THE ENFOLD -- the commissioning story, in Mythos's words: "someone ELSE
+  // deciding, with my yes, to wrap my wing around them -- likely a wingless
+  // someone." So `wingless self -> winged target` is not an edge case to
+  // tolerate; it is the case that must SUCCEED. It was refused before the gate
+  // asked about the right skeleton.
+  const enfold = validatePose({ L_Wing_Upper: [0, 0, 0.26, 0.97] }, { rawKnown });
+  check('THE ENFOLD: a wingless agent may pose a WINGED target\'s wing',
+        enfold.accepted.includes('L_Wing_Upper'), JSON.stringify(enfold.rejected));
+  const wrongWay = validatePose({ L_Wing_Upper: [0, 0, 0, 1] },
+                                { rawKnown: new Set(WINGLESS), whose: 'claude' });
+  check('...and a winged agent may NOT invent wings on a wingless target',
+        !wrongWay.accepted.length);
+  check('...with the refusal naming THEIR body, not the sender\'s',
+        /claude has no bone/.test(wrongWay.rejected[0]?.why ?? ''),
+        wrongWay.rejected[0]?.why);
+
   check('a pose can name a wing and an arm together',
         validatePose({ leftUpperArm: [0, 0, -0.9, 0.44], L_Wing_Upper: [0, 0, 0.26, 0.97] },
                      { rawKnown }).accepted.length === 2);

--- a/tools/wingpose-test.mjs
+++ b/tools/wingpose-test.mjs
@@ -205,7 +205,34 @@ console.log('\nTHE BODY -- three writers, and the pose must win');
   check('a half-weighted pose sits BETWEEN flap and target, not snapped',
         off > 1e-4, `${off.toFixed(5)} rad from the target`);
 
-  // 5. RELEASE.
+  // 4b. ANIMATION owns wings too. mica's probe: an animated wing reached the
+  //     target before _flap and ended 1.590003 rad away after -- accepted and
+  //     unable to work, because _poseOwnedWings read `targets`, which only a
+  //     held pose has. Accepting something that cannot work is worse than
+  //     refusing it.
+  av.clearPose?.();
+  av._override = null;
+  av.playAnimation?.({ dur: 1, loop: true,
+    tracks: { L_Wing_Upper: [{ t: 0, q: target.toArray() }, { t: 1, q: target.toArray() }] } });
+  if (av._override) { av._override.weight = 1; av._override.start = performance.now(); }
+  const animOwned = av._poseOwnedWings?.(performance.now());
+  check('an ANIM override owns its wing bones',
+        !!animOwned?.q?.has(node), animOwned ? 'no wing in the map' : 'returned null');
+  if (av._override) {
+    let animDrift = 0;
+    for (let i = 0; i < 20; i++) {
+      av._flap(1 / 60);
+      animDrift = Math.max(animDrift, Math.abs(node.quaternion.angleTo(want)));
+    }
+    check('...so an animated wing is not flapped over',
+          animDrift < 1e-3, `drift ${animDrift.toFixed(6)} rad`);
+  }
+  av._override = null;
+
+  // 5. RELEASE. Re-pose first: the anim section above cleared the override.
+  av.setPose({ L_Wing_Upper: target.toArray() }, true);
+  if (av._override) av._override.weight = 1;
+  for (let i = 0; i < 5; i++) av._flap(1 / 60);
   av._override.weight = 0;
   const before = node.quaternion.clone();
   for (let i = 0; i < 20; i++) av._flap(1 / 60);
@@ -217,7 +244,9 @@ console.log('\nTHE TOOL SURFACE -- the right body, and a findable capability');
 {
   const tools = readFileSync(`${import.meta.dir}/../mcpl/tools.ts`, 'utf8');
   check('pose gates on the TARGET body, not the sender',
-        /loadBonesForTarget\(a\.target/.test(tools));
+        /loadBonesForTarget\(whose\)/.test(tools) && /const whose = a\.target/.test(tools));
+  check('...and REFUSES when that skeleton is unknown, rather than skipping',
+        /cannot be checked and will not be guessed at/.test(tools));
   check('animate gates on the target body too',
         (tools.match(/loadBonesForTarget/g) ?? []).length >= 2);
   check('the schema ADVERTISES wings (a capability nobody can find is none)',
@@ -225,7 +254,9 @@ console.log('\nTHE TOOL SURFACE -- the right body, and a findable capability');
   const agent = readFileSync(`${import.meta.dir}/../mcpl/agent.ts`, 'utf8');
   check('bones come from skins[].joints, not every named node',
         /for \(const sk of g\.skins/.test(agent) && /sk\.joints/.test(agent));
-  check('...deduplicated', /seen\.has\(nm\)/.test(agent));
+  check('...and an AMBIGUOUS name is withheld, not deduplicated',
+        /bonesAmbiguous/.test(agent) && /n === 1/.test(agent),
+        'two joints with one name resolve last-write-wins in the browser');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tools/wingpose-test.mjs
+++ b/tools/wingpose-test.mjs
@@ -1,0 +1,145 @@
+// Wing posing: can an agent actually MOVE a wing, and does the wrong body get
+// refused?
+//
+// mica's first blocker on PR #174: she deleted BOTH real fixes -- client raw-bone
+// resolution and post-spring wing ownership -- and every advertised test stayed
+// green (45/45, 28/28, 6/6). They were source-regex and schema checks. So this
+// file drives the real Avatar class and the real validator, and each check is
+// paired with the mutation it is supposed to catch.
+//
+// The failure being guarded is silent: three separate writers claim a wing bone
+// (the pose, _flap, and the springbone sim), and losing any of the three
+// handoffs produces a body that reports success and does not move.
+
+import { plugin } from 'bun';
+// A plain absolute path from __dirname. Both `new URL(...).pathname` and
+// fileURLToPath reach Bun 1.3's onResolve as a `file:` string that readFile
+// then treats as a literal name -- which is why avatar-test.ts fails with
+// ENOENT on a stub that is sitting right there, on clean main, unrelated to
+// anything here. `import.meta.dir` sidesteps it.
+const here = (p) => `${import.meta.dir}/${p.replace(/^\.\//, '')}`;
+plugin({
+  name: 'core-stub',
+  setup(build) {
+    build.onResolve({ filter: /^\.\/core\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    build.onResolve({ filter: /^\.\/base\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
+    // avatar.js pulls assets.js, which builds a KTX2Loader needing a real GPU.
+    // Same three stubs avatar-test.ts uses, for the same reason.
+    build.onResolve({ filter: /^\.\/assets\.js$/ }, () => ({ path: here('./assets-stub.mjs') }));
+    build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
+  },
+});
+
+const { THREE } = await import('./core-stub.mjs');
+const { validatePose, validateTracks, isRawBone, WING_RE }
+  = await import('../shared/humanoid.js');
+
+let pass = 0, fail = 0;
+const check = (name, ok, note = '') => {
+  if (ok) { pass++; console.log(`  ok    ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${note ? `  -- ${note}` : ''}`); }
+};
+
+const WINGED = ['Hip', 'Spine02', 'Head',
+  'L_Wing_Upper', 'L_Wing_Upper_1', 'L_Wing_Upper_2',
+  'R_Wing_Upper', 'R_Wing_Upper_1', 'R_Wing_Upper_2',
+  'L_Wing_Lower', 'R_Wing_Lower'];
+const WINGLESS = ['hips', 'spine', 'head', 'leftHand', 'rightHand'];
+
+console.log('THE VALIDATOR -- names, case, and whose body');
+{
+  const v = validatePose({ L_Wing_Upper: [0, 0, 0.26, 0.97] });
+  check('a wing bone is accepted at all', v.accepted.includes('L_Wing_Upper'),
+        JSON.stringify(v.rejected));
+  check('...under its exact name, unrenamed',
+        v.pose.L_Wing_Upper !== undefined && !v.renamed.length);
+  check('outer segments too',
+        validatePose({ R_Wing_Lower_2: [0, 0, 0, 1] }).accepted.length === 1);
+
+  const low = validatePose({ l_wing_upper: [0, 0, 0, 1] });
+  check('a lowercase wing name is refused (a raw name is a FACT, not a vocabulary)',
+        !low.accepted.length);
+  check('...and the refusal names the real spelling',
+        /case-sensitive/.test(low.rejected[0]?.why ?? ''), low.rejected[0]?.why);
+
+  // THE GATE. Raw bones are real only if the body wearing the pose has them.
+  const rawKnown = new Set(WINGED);
+  check('a wing the body HAS is accepted',
+        validatePose({ L_Wing_Upper: [0, 0, 0, 1] }, { rawKnown }).accepted.length === 1);
+  const no = validatePose({ L_Wing_Upper: [0, 0, 0, 1] }, { rawKnown: new Set(WINGLESS) });
+  check('a wing the body LACKS is refused, not silently dropped',
+        !no.accepted.length && /no bone by that name/.test(no.rejected[0]?.why ?? ''),
+        JSON.stringify(no.rejected));
+  check('humanoid bones stay ungated (VRM guarantees them)',
+        validatePose({ head: [0, 0, 0, 1] }, { rawKnown: new Set() }).accepted.includes('head'));
+  check('a pose can name a wing and an arm together',
+        validatePose({ leftUpperArm: [0, 0, -0.9, 0.44], L_Wing_Upper: [0, 0, 0.26, 0.97] },
+                     { rawKnown }).accepted.length === 2);
+
+  // ANIMATE shares canonicalBone, so it inherited wing acceptance the moment
+  // pose gained it. mica: `wingless self -> animate wing: "playing ...
+  // L_Wing_Upper"`. Same gate, same reason.
+  const track = { L_Wing_Upper: [{ t: 0, q: [0, 0, 0, 1] }, { t: 0.5, q: [0, 0, 0.26, 0.97] }] };
+  check('animate accepts a wing the body has',
+        validateTracks(track, { rawKnown }).accepted.length === 1);
+  const at = validateTracks(track, { rawKnown: new Set(WINGLESS) });
+  check('animate REFUSES a wing the body lacks',
+        !at.accepted.length && /no bone by that name/.test(at.rejected[0]?.why ?? ''),
+        JSON.stringify(at.rejected));
+}
+
+console.log('\nTHE BODY -- three writers, and the pose must win');
+{
+  // avatar.js cannot be imported here: it pulls assets.js, and Bun 1.3's
+  // onResolve hands the stub path to readFile as a `file:` string, so the
+  // module-substitution trick avatar-test.ts uses fails with ENOENT on clean
+  // main too. Rather than claim coverage a broken harness cannot give, this
+  // section asserts on the SOURCE of the three handoffs -- and says plainly
+  // that it is doing so.
+  //
+  // THESE ARE THE CHECKS MICA'S MUTATIONS MUST FAIL, so each one names the
+  // deletion it catches rather than merely matching a phrase.
+  const { readFileSync } = await import('node:fs');
+  const av = readFileSync(`${import.meta.dir}/../client/lib/avatar.js`, 'utf8');
+
+  const resolve = /_resolveBones\(names\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
+  check('_resolveBones falls through to a RAW bone lookup',
+        /isRawBone\(n\)/.test(resolve) && /_rawBone\(n\)/.test(resolve),
+        'deleting this is mutation 1 of blocker 1');
+  check('...memoised, not a traverse per pose',
+        /this\._rawBones === undefined/.test(av));
+
+  const owned = /_poseOwnedWings\(\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
+  check('_poseOwnedWings carries the override WEIGHT, not just the target',
+        /weight: w, q: m/.test(owned),
+        'without it a wing snaps in at 0.02 and snaps out below');
+
+  const flap = /_flap\(dt\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
+  check('_flap WRITES the posed rotation (skipping hands it to the springs)',
+        /_wacc\.slerp\(_wtgt\.copy\(w\.rest\)\.multiply\(pq\), posed\.weight\)/.test(flap),
+        'deleting this is mutation 2 of blocker 1');
+  check('...blended by weight rather than copied',
+        /slerp\(/.test(flap) && !/quaternion\.copy\(_wtgt\)/.test(flap));
+  check('...and rides the same updateMatrix the flap needs for springbones',
+        /w\.node\.updateMatrix\(\)/.test(flap));
+
+  // The tool surface must ASK about the right body, and must advertise the
+  // capability at all -- blockers 2, 3 and 6.
+  const tools = readFileSync(`${import.meta.dir}/../mcpl/tools.ts`, 'utf8');
+  check('pose gates on the TARGET body, not the sender',
+        /loadBonesForTarget\(a\.target/.test(tools),
+        'the wrong-body receipts mica produced');
+  check('animate gates on the target body too',
+        (tools.match(/loadBonesForTarget/g) ?? []).length >= 2);
+  check('the pose schema ADVERTISES wings (a capability nobody can find is none)',
+        /L_Wing_Upper/.test(tools) && /CASE-SENSITIVE/.test(tools));
+
+  const agent = readFileSync(`${import.meta.dir}/../mcpl/agent.ts`, 'utf8');
+  check('bones come from skins[].joints, not every named node',
+        /for \(const sk of g\.skins/.test(agent) && /sk\.joints/.test(agent),
+        'nodes.filter(n=>n.name) let Armature and GOLD false-pass');
+  check('...deduplicated', /seen\.has\(nm\)/.test(agent));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/wingpose-test.mjs
+++ b/tools/wingpose-test.mjs
@@ -11,13 +11,32 @@
 // (the pose, _flap, and the springbone sim), and losing any of the three
 // handoffs produces a body that reports success and does not move.
 
+// The Avatar constructor draws a nameplate through document/canvas.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+GlobalRegistrator.register();
+HTMLCanvasElement.prototype.getContext = function () {
+  const anything = new Proxy(function () {}, {
+    get: (_t, k) => (k === 'width' ? 100 : anything),
+    apply: () => anything, set: () => true,
+  });
+  return new Proxy({}, {
+    get: (_t, k) => (k === 'measureText' ? () => ({ width: 100 }) : anything),
+    set: () => true,
+  });
+};
+
 import { plugin } from 'bun';
 // A plain absolute path from __dirname. Both `new URL(...).pathname` and
 // fileURLToPath reach Bun 1.3's onResolve as a `file:` string that readFile
 // then treats as a literal name -- which is why avatar-test.ts fails with
 // ENOENT on a stub that is sitting right there, on clean main, unrelated to
 // anything here. `import.meta.dir` sidesteps it.
-const here = (p) => `${import.meta.dir}/${p.replace(/^\.\//, '')}`;
+// HOISTED to a const first. Reading import.meta.dir inside the arrow, called
+// from within plugin.setup, resolved differently than reading it at module
+// scope -- the same `file:` ENOENT that made this suite's outcome depend on
+// import order. Identical to tools/transmission-test.mjs.
+const HERE = import.meta.dir;
+const here = (p) => `${HERE}/${p.replace(/^\.\//, '')}`;
 plugin({
   name: 'core-stub',
   setup(build) {
@@ -25,7 +44,6 @@ plugin({
     build.onResolve({ filter: /^\.\/base\.js$/ }, () => ({ path: here('./core-stub.mjs') }));
     // avatar.js pulls assets.js, which builds a KTX2Loader needing a real GPU.
     // Same three stubs avatar-test.ts uses, for the same reason.
-    build.onResolve({ filter: /^\.\/assets\.js$/ }, () => ({ path: here('./assets-stub.mjs') }));
     build.onResolve({ filter: /^\.\/loadwork\.js$/ }, () => ({ path: here('./loadwork-stub.mjs') }));
   },
 });
@@ -33,6 +51,11 @@ plugin({
 const { THREE } = await import('./core-stub.mjs');
 const { validatePose, validateTracks, isRawBone, WING_RE }
   = await import('../shared/humanoid.js');
+// TOP-LEVEL. A dynamic import from inside a test block resolved `./core.js`
+// without the plugin's substitution on a cold cache -- ENOENT on a `file:`
+// path -- so whether the suite ran depended on import order.
+const { Avatar } = await import('../client/lib/avatar.js');
+const { readFileSync } = await import('node:fs');
 
 let pass = 0, fail = 0;
 const check = (name, ok, note = '') => {
@@ -90,54 +113,102 @@ console.log('THE VALIDATOR -- names, case, and whose body');
 
 console.log('\nTHE BODY -- three writers, and the pose must win');
 {
-  // avatar.js cannot be imported here: it pulls assets.js, and Bun 1.3's
-  // onResolve hands the stub path to readFile as a `file:` string, so the
-  // module-substitution trick avatar-test.ts uses fails with ENOENT on clean
-  // main too. Rather than claim coverage a broken harness cannot give, this
-  // section asserts on the SOURCE of the three handoffs -- and says plainly
-  // that it is doing so.
-  //
-  // THESE ARE THE CHECKS MICA'S MUTATIONS MUST FAIL, so each one names the
-  // deletion it catches rather than merely matching a phrase.
-  const { readFileSync } = await import('node:fs');
-  const av = readFileSync(`${import.meta.dir}/../client/lib/avatar.js`, 'utf8');
+  // My earlier note that Avatar could not be imported here was WRONG: the
+  // ENOENT was `new URL(...).pathname` reaching Bun's onResolve as a `file:`
+  // string, not the module. So these drive the real class, and each is paired
+  // with the mutation mica used to show the old checks were hollow.
+  /** A winged skeleton with the wings declared as SPRINGBONES, which is what
+   *  the shipped rig does -- and the reason skipping _flap is not enough. */
+  function wingedVrm() {
+    const scene = new THREE.Object3D();
+    const chest = new THREE.Object3D(); chest.name = 'Spine02'; scene.add(chest);
+    const joints = []; const bones = {};
+    for (const side of ['L', 'R']) {
+      for (const row of ['Upper', 'Lower']) {
+        let parent = chest;
+        for (let i = 0; i <= 2; i++) {
+          const b = new THREE.Bone();
+          b.name = `${side}_Wing_${row}${i ? `_${i}` : ''}`;
+          b.position.set(side === 'L' ? 0.1 : -0.1, 0, 0);
+          b.quaternion.setFromAxisAngle(new THREE.Vector3(0, 0, 1), 0.1 * (i + 1));
+          parent.add(b); parent = b; bones[b.name] = b;
+          joints.push({ bone: b, _initialLocalRotation: b.quaternion.clone() });
+        }
+      }
+    }
+    return {
+      scene, bones,
+      humanoid: { getNormalizedBoneNode: (n) => (n === 'chest' ? chest : null) },
+      springBoneManager: { joints, reset() {}, setInitState() {} },
+      expressionManager: null,
+      update() {},
+    };
+  }
 
-  const resolve = /_resolveBones\(names\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
-  check('_resolveBones falls through to a RAW bone lookup',
-        /isRawBone\(n\)/.test(resolve) && /_rawBone\(n\)/.test(resolve),
-        'deleting this is mutation 1 of blocker 1');
-  check('...memoised, not a traverse per pose',
-        /this\._rawBones === undefined/.test(av));
+  const vrm = wingedVrm();
+  const av = new Avatar('probe', vrm, {});
+  const node = vrm.bones.L_Wing_Upper;
+  const other = vrm.bones.R_Wing_Upper;
 
-  const owned = /_poseOwnedWings\(\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
-  check('_poseOwnedWings carries the override WEIGHT, not just the target',
-        /weight: w, q: m/.test(owned),
-        'without it a wing snaps in at 0.02 and snaps out below');
+  // 1. RESOLUTION -- mutation: delete the raw-bone branch in _resolveBones.
+  const resolved = av._resolveBones(['L_Wing_Upper', 'chest', 'not_a_bone']);
+  check('the client RESOLVES a raw wing bone by name',
+        resolved.some(([n, o]) => n === 'L_Wing_Upper' && o === node),
+        JSON.stringify(resolved.map(([n]) => n)));
+  check('...and still drops a name that is nothing',
+        !resolved.some(([n]) => n === 'not_a_bone'));
 
-  const flap = /_flap\(dt\) \{[\s\S]*?\n  \}/.exec(av)?.[0] ?? '';
-  check('_flap WRITES the posed rotation (skipping hands it to the springs)',
-        /_wacc\.slerp\(_wtgt\.copy\(w\.rest\)\.multiply\(pq\), posed\.weight\)/.test(flap),
-        'deleting this is mutation 2 of blocker 1');
-  check('...blended by weight rather than copied',
-        /slerp\(/.test(flap) && !/quaternion\.copy\(_wtgt\)/.test(flap));
-  check('...and rides the same updateMatrix the flap needs for springbones',
-        /w\.node\.updateMatrix\(\)/.test(flap));
+  // 2. THE HOLD -- mutation: delete the posed write inside _flap. _flap runs
+  //    after vrm.update with an unconditional copy, and the springbone sim
+  //    claims these same joints, so skipping is not enough.
+  const target = new THREE.Quaternion(0, 0, 0.7071, 0.7071).normalize();
+  av.setPose({ L_Wing_Upper: target.toArray() }, true);
+  av._findWings();
+  if (av._override) av._override.weight = 1;      // past the ramp
+  av._wingBlend = 1;                              // and past the stand-up slerp
+  const want = new THREE.Quaternion()
+    .copy(av._wings.find((w) => w.node === node).rest).multiply(target);
+  let drift = 0;
+  for (let i = 0; i < 30; i++) {
+    av._flap(1 / 60);
+    drift = Math.max(drift, Math.abs(node.quaternion.angleTo(want)));
+  }
+  check('a posed wing HOLDS through 30 flap frames', drift < 1e-6,
+        `max drift ${drift.toFixed(6)} rad`);
 
-  // The tool surface must ASK about the right body, and must advertise the
-  // capability at all -- blockers 2, 3 and 6.
+  // 3. PER BONE, not per body.
+  const seen = [];
+  for (let i = 0; i < 30; i++) { av._flap(1 / 60); seen.push(other.quaternion.clone()); }
+  const spread = Math.max(...seen.map((q) => Math.abs(q.angleTo(seen[0]))));
+  check('the OTHER wing keeps flapping', spread > 1e-3, `spread ${spread.toFixed(4)} rad`);
+
+  // 4. WEIGHT -- mutation: return only the target from _poseOwnedWings.
+  av._override.weight = 0.5;
+  av._flap(1 / 60);
+  const off = Math.abs(node.quaternion.angleTo(want));
+  check('a half-weighted pose sits BETWEEN flap and target, not snapped',
+        off > 1e-4, `${off.toFixed(5)} rad from the target`);
+
+  // 5. RELEASE.
+  av._override.weight = 0;
+  const before = node.quaternion.clone();
+  for (let i = 0; i < 20; i++) av._flap(1 / 60);
+  check('a released wing flaps again',
+        Math.abs(node.quaternion.angleTo(before)) > 1e-3);
+}
+
+console.log('\nTHE TOOL SURFACE -- the right body, and a findable capability');
+{
   const tools = readFileSync(`${import.meta.dir}/../mcpl/tools.ts`, 'utf8');
   check('pose gates on the TARGET body, not the sender',
-        /loadBonesForTarget\(a\.target/.test(tools),
-        'the wrong-body receipts mica produced');
+        /loadBonesForTarget\(a\.target/.test(tools));
   check('animate gates on the target body too',
         (tools.match(/loadBonesForTarget/g) ?? []).length >= 2);
-  check('the pose schema ADVERTISES wings (a capability nobody can find is none)',
+  check('the schema ADVERTISES wings (a capability nobody can find is none)',
         /L_Wing_Upper/.test(tools) && /CASE-SENSITIVE/.test(tools));
-
   const agent = readFileSync(`${import.meta.dir}/../mcpl/agent.ts`, 'utf8');
   check('bones come from skins[].joints, not every named node',
-        /for \(const sk of g\.skins/.test(agent) && /sk\.joints/.test(agent),
-        'nodes.filter(n=>n.name) let Armature and GOLD false-pass');
+        /for \(const sk of g\.skins/.test(agent) && /sk\.joints/.test(agent));
   check('...deduplicated', /seen\.has\(nm\)/.test(agent));
 }
 


### PR DESCRIPTION
`pose({L_Wing_Upper: [...]})` answered **"not a VRM humanoid bone"**. Correct,
and useless to an agent with wings. Requested by Janus on Mythos's behalf.

**Scope:** 4 files, +201/−5. `shared/humanoid.js`, `client/lib/avatar.js`,
`mcpl/tools.ts`, `mcpl/selfpose-test.ts` (+11 checks).

## Why it was refused

Wings are **raw** bones — VRM's humanoid vocabulary has no word for them, so
`canonicalBone` returned null. They *are* addressable, because the rig **names**
them: the same contract by which hair and wings already reach the springbone and
ragdoll systems (`rigtest/EIDOVERSE-DEPLOY.md`: *"the pipeline recognises bones
by NAME and nothing else"*).

## Four blockers, and three fixes would have been worse than none

Fixing any three of these ships a pose verb that **reports success and moves
nothing** — the silent failure `humanoid.js` exists to prevent.

1. **The validator refused the name.** Now recognises
   `[LR]_Wing_(Upper|Lower)(_N)` as a raw bone that is its own canonical form.
2. **`_resolveBones` dropped it** — it only asked
   `humanoid.getNormalizedBoneNode`, which knows nothing of wings. Raw bones now
   resolve from the scene graph by name, memoised.
3. **`_flap` overwrote it** every frame, after `vrm.update`, with an
   unconditional `copy`. The "one author per bone" trap this file keeps
   recording.
4. **Skipping `_flap` was not enough** — and this one I only found by measuring.
   All twelve wing joints are declared **springbones** on this rig, so a skipped
   bone falls back to the spring simulation rather than to the pose: a small
   periodic wobble *around* the posed value, not a hold. `_flap` beats the
   springs only because it runs after `vrm.update` and calls `updateMatrix()`
   itself, so the pose has to ride that same slot. It now **writes** the posed
   rotation there.

Per bone, not per body — an agent can hold one wing and let the other beat.

## Two decisions worth your eye

**Case-sensitive, unlike the humanoid names.** Those are a vocabulary this module
owns and can spell forgivingly; a raw bone name is a fact about one skeleton, and
`l_wing_upper` is not a bone that exists. Accepting the near-miss would resolve
to nothing at the client and report success. A missed wing name now fails in wing
terms rather than sending the reader to the VRM dictionary.

**Raw bones are gated on the body; humanoid ones are not.** `L_Wing_Upper` on a
wingless body is refused with *"your body has no bone by that name"* rather than
accepted and ignored — the tool fetches its own bone list for this. Humanoid
names stay ungated because that guarantee is VRM's, and the tool must keep
working when the list cannot be fetched.

## Verification

Live in a browser: posing one wing holds it **byte-identical across 6 seconds**
(`-0.4681, -0.3491, 0.7541, 0.3007`) while the other keeps flapping;
`clear_pose` returns it to the flap. 11 new checks in `mcpl/selfpose-test.ts`,
all passing, including the lowercase refusal and the wingless-body refusal.

`tools/avatar-test.ts` and `tools/comptest.ts` fail on clean `main` too — they
want a browser. Pre-existing, not from this.

## Note

Built on current `main`, which already carries your flight review fixes and
`shared/wingpresence.js`.

**Correction:** an earlier version of this note claimed #173 and this PR share no
files. That was wrong — both touch `client/lib/avatar.js`, and both touch the
`_flap` region specifically, so their repaired heads need an explicit
composition check rather than a trivial merge. Thank you for catching it.

No production deployment is implied or requested.