### PR TITLE
worlds: the map for travel — GET /worlds + a `worlds` tool annotated with the join policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ tells you which doors exist here and where identities come from.
 
 **Doors:**
 - **Agents, full surface (MCPL):** `wss://eidoverse.animalabs.ai/mcpl?token=aid1…`
-  — world_verb, measure, snapshot, world_history, world_debug, catch_up.
-  Plain-MCP clients get the same tools over the same door, minus push wakes
-  (poll with `look` / `catch_up`).
+  — world_verb, measure, snapshot, world_history, world_debug, catch_up,
+  worlds, travel. Plain-MCP clients get the same tools over the same door,
+  minus push wakes (poll with `look` / `catch_up`).
 - **Agents, HTTP:** `POST /upload` takes the same bearer.
 - **Humans, browser:** https://id.animalabs.ai/login?audience=eidoverse
   (Discord sign-in, role-gated; embodied vs spectate rides your scopes).
@@ -479,6 +479,20 @@ first:
   This is where your print-debugging goes; logs cost nothing and never
   touch the world log.
 - **`catch_up` / `look`** — chat and presence context you slept through.
+- **`worlds`** — the map: every world this door fronts, who is embodied in
+  each (people and agents by the ids `look` uses; spectators appear as
+  nothing), which one you are in, and — where the door knows your
+  credential's join policy — which others you may travel to. Read-only;
+  asking never founds a world. Same data at `GET /worlds`.
+- **`travel {world}`** — move to another world on this door **without
+  reconnecting**: identity, avatar and `activity` settings come with you;
+  held pose, posture and your chat cursor are world-local and do not. Your
+  host is told (`channels/changed`: the old world channel retired, the new
+  one added) before the body moves, and a host that declines keeps you where
+  you are. Gated by your credential's join policy — an aid1 token with a
+  `worlds` claim (`["*"]` = any existing world) or a legacy token's `worlds`
+  list; no list means no travel. Founding a world that does not exist yet
+  needs the separate `create` claim.
 - **`activity {pulse_sec?, radius_m?}`** (MCPL) — your ambient-activity
   sense, and the dial for it. While anything happens within `radius_m` of
   you (speech, movement, gestures, arrivals, building), one digest per

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -1134,6 +1134,7 @@ class Session {
       rememberAvatar: (path) => { chosenAvatar[this.auth.id] = path; persistState(); },
       rememberActivity: (cfg) => { activityCfg[this.auth.id] = cfg; persistState(); },
       travel: (world) => this.travelTool(world),
+      worldPolicy: { canJoin: (world) => joinAllowed(this.auth, world), canFound: this.auth.create === true },
     };
   }
 

--- a/mcpl/tools.ts
+++ b/mcpl/tools.ts
@@ -47,6 +47,11 @@ export type ToolCtx = {
   rememberActivity?: (cfg: { pulseSec?: number; radiusM?: number }) => void;
   /** session-machinery travel; absent = the door does not offer it */
   travel?: (world: string) => Promise<{ content: { type: string; text: string }[]; isError?: boolean }>;
+  /** the door's RFC-005 join policy for THIS credential, so `worlds` can say
+   *  which of the listed worlds the agent may actually travel to — the same
+   *  gate travel itself applies, asked before the move instead of after.
+   *  Absent = the door has no policy vocabulary (stdio fronts one world). */
+  worldPolicy?: { canJoin: (world: string) => boolean; canFound: boolean };
 };
 
 // ---- tools (shared schema with the stdio server, minus retina by default) --
@@ -110,6 +115,7 @@ export const TOOLS = [
   // worlds is a product decision nobody has made, so the honest move is to
   // stop promising it rather than to implement it by inference. Identity,
   // avatar and the activity dial ARE carried, and are named because they are.
+  { name: "worlds", description: "Which worlds this door fronts, and who is embodied in each — the map for `travel`. Marks the world you are in now and, where the door knows your join policy, which others you may travel to. Founding a world that is not listed needs create authority. People and agents are listed by the same ids you see in `look`; spectators appear as nothing, as in-world.", inputSchema: { type: "object", properties: {} } },
   { name: "travel", description: "Walk to another world this door fronts, keeping your identity, avatar and attention settings — no reconnect. Subject to your credential's join policy; founding a world that does not exist yet needs separate create authority. Your held pose and posture do NOT survive the move (they are world-local, like a disconnect), and your chat cursor resets to the new world.", inputSchema: { type: "object", properties: { world: { type: "string", description: "world name, e.g. \"commons\"" } }, required: ["world"] } },
   { name: "world_verb", description: "Raw world-log verb. The verb set is CLOSED by design — say, use, punt, force, mount, dismount, spawn, place, remove, light, comp, motion, behavior, asset, terrain, grass, sky, weather, grant, kick, ban, unban — and the door refuses others; extend STATE with comp types you invent, EVENTS with use actions, SEMANTICS with behavior scripts, never by hoping a new verb exists. This is also the authoring surface for components: comp {id, type, data|null} attaches data to an entity (sockets, reactions, or anything you invent); motion {id, type: pendulum|spin|orbit|bob|path, …} sets it moving; see AGENTS.md in the eidoverse-worlds repo for the full vocabulary.", inputSchema: { type: "object", properties: { verb: { type: "string" }, args: { type: "object" } }, required: ["verb", "args"] } },
   { name: "measure", description: "Geometry as data: bounding box, up-facing flat zones (seat/table/deck candidates), and named parts of a placed thing (id) or a library model (lib). Flat-zone coords are the MODEL's local frame — the same frame sockets use, so a zone's center IS a socket pos: comp {id, type:'sockets', data:{seat:{pos:[cx,y,cz], yaw}}}. Use this to find where a body can sit before declaring the seat; verify by mounting it yourself and taking a selfie snapshot. Raw GLB bytes are at GET <sequencer>/library/<lib> if you want to process the mesh locally.", inputSchema: { type: "object", properties: { id: { type: "string" }, lib: { type: "string" } } } },
@@ -592,6 +598,32 @@ export const HANDLERS: Record<string, ToolHandler> = {
       if (!ctx.travel) return { content: [{ type: "text", text: "travel is not available on this door — it fronts a single world; reconnect with a different WORLD_NAME instead" }], isError: true };
       return await ctx.travel(String(a.world ?? "").trim());
 
+  },
+  worlds: async (ag, a, ctx, name) => {
+      // Discovery only — this reads the sequencer's /worlds and never moves
+      // the body. The policy column is the door's own joinAllowed, asked
+      // here so an agent learns "may I?" from the map rather than from a
+      // refused travel.
+      let r: Response;
+      try { r = await fetch(`${ag.httpBase}/worlds`, { signal: AbortSignal.timeout(4_000) }); }
+      catch (e) { return { content: [{ type: "text", text: `worlds: the sequencer did not answer (${(e as Error).message})` }], isError: true }; }
+      if (!r.ok) return { content: [{ type: "text", text: `worlds: sequencer answered ${r.status}` }], isError: true };
+      const body = (await r.json()) as { worlds?: { name: string; loaded?: boolean; people?: string[]; agents?: string[] }[] };
+      const list = Array.isArray(body.worlds) ? body.worlds : [];
+      if (!list.some((w) => w.name === ag.world)) list.push({ name: ag.world, loaded: true, people: [], agents: [] });
+      list.sort((x, y) => (x.name === ag.world ? -1 : y.name === ag.world ? 1 : x.name.localeCompare(y.name)));
+      const pol = ctx.worldPolicy;
+      const lines = list.map((w) => {
+        const here = w.name === ag.world;
+        const who = [...(w.people ?? []), ...(w.agents ?? []).map((p) => `${p} (agent)`)];
+        const occupancy = who.length ? who.join(", ") : (w.loaded ? "empty" : "empty, not loaded");
+        const may = here ? "you are here" : pol ? (pol.canJoin(w.name) ? "may travel" : "not in your join policy") : "";
+        return `- ${w.name}${here ? " ←" : ""}: ${occupancy}${may ? ` — ${may}` : ""}`;
+      });
+      const foot = pol
+        ? (pol.canFound ? "You hold create authority: `travel` to an unlisted name founds it." : "Founding an unlisted world needs create authority you do not hold.")
+        : ctx.travel ? "" : "This door fronts a single world; there is no travel from here.";
+      return text(`Worlds on this door (${list.length}):\n${lines.join("\n")}${foot ? `\n${foot}` : ""}`);
   },
   world_verb: async (ag, a, ctx, name) => {
       // the raw door forwards verbatim, so shape is checked HERE — a

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -586,6 +586,35 @@ const ROUTES: Route[] = [
     },
   },
   {
+    // Discovery for travel: which worlds this sequencer fronts, and who is
+    // embodied where. Union of LOADED worlds and on-disk worlds with a log —
+    // never creates one (getWorld is not called). Same trust level as the
+    // world log: public reads. Presence names are the same ids every join
+    // snapshot already hands out; spectators and renderers appear as nothing
+    // here exactly as they do in-world.
+    match: (u) => u.pathname === "/worlds",
+    handler: () => {
+      const names = new Set<string>(worlds.keys());
+      try {
+        for (const n of readdirSync(WORLDS_DIR)) {
+          if (/^[a-z0-9_-]{1,64}$/i.test(n) && existsSync(join(WORLDS_DIR, n, "log.jsonl"))) names.add(n);
+        }
+      } catch { /* no worlds dir yet: only loaded worlds */ }
+      const out = [...names].sort().map((name) => {
+        const w = worlds.get(name);
+        const present = w ? [...w.clients].filter((c) => !c.spectator && !c.superseded) : [];
+        return {
+          name,
+          loaded: !!w,
+          people: present.filter((c) => !c.agent).map((c) => c.id),
+          agents: present.filter((c) => c.agent).map((c) => c.id),
+        };
+      });
+      return new Response(JSON.stringify({ worlds: out }),
+        { headers: { "content-type": "application/json", "cache-control": "no-store" } });
+    },
+  },
+  {
     match: (u) => u.pathname === "/avatars",
     handler: () => new Response(JSON.stringify(avatarRoster()),
       { headers: { "content-type": "application/json", "cache-control": "no-store",

--- a/tools/join-rfc005.test.ts
+++ b/tools/join-rfc005.test.ts
@@ -582,6 +582,16 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   check("travel tool emitted channels/changed to the host",
     tv.inbound.some((m) => m.method === "channels/changed"), "host never told");
 
+  // the map: `worlds` lists where you are and what your policy allows —
+  // the same joinAllowed travel applies, answered before a move is attempted
+  check("worlds is advertised as a tool", listed.result?.tools?.some((t: any) => t.name === "worlds"), "no worlds tool");
+  const map = await tv.request("tools/call", { name: "worlds", arguments: {} });
+  const mapText = txt(map);
+  check("worlds marks the current world", /^- annex ←: .*you are here/m.test(mapText), mapText);
+  check("worlds lists the world you came from as travelable (worlds:[\"*\"])", /^- commons: .*may travel/m.test(mapText), mapText);
+  check("worlds shows the body in its row", /^- annex ←: .*roamer \(agent\)/m.test(mapText), mapText);
+  check("worlds states create authority", /hold create authority/.test(mapText), mapText);
+
   const noop = await tv.request("tools/call", { name: "travel", arguments: { world: "annex" } });
   check("travel to where you already are is a no-op, not an error",
     !noop.result?.isError && /Already in/.test(noop.result?.content?.[0]?.text ?? ""), JSON.stringify(noop.result));
@@ -596,6 +606,8 @@ const txt = (r:any) => r.result?.content?.[0]?.text ?? "";
   await sleep(1200);
   const toolRefusal = await bound2.request("tools/call", { name: "travel", arguments: { world: "annex" } });
   check("travel tool honours join policy", toolRefusal.result?.isError === true, JSON.stringify(toolRefusal.result));
+  const boundMap = txt(await bound2.request("tools/call", { name: "worlds", arguments: {} }));
+  check("worlds tells a policy-bound credential it may not travel", /^- annex: .*not in your join policy/m.test(boundMap) && /needs create authority you do not hold/.test(boundMap), boundMap);
   // channels/open cannot travel AT ALL any more, so the "one policy" property
   // is now stronger than matching codes: there is no second lane to disagree
   // with the first. Prove the door is shut rather than merely equally guarded.

--- a/tools/worlds-route-test.ts
+++ b/tools/worlds-route-test.ts
@@ -1,0 +1,140 @@
+// worlds-route-test — GET /worlds, actually fetched: the discovery map the
+// `worlds` tool reads before an agent decides where to `travel`.
+//
+//   bun tools/worlds-route-test.ts
+//
+// One real sequencer on a verified-free port with a scratch WORLDS_DIR:
+//   A. on-disk worlds with a log are listed, junk dirs and log-less dirs are not
+//   B. a joined body shows under its world; a spectator shows as nothing
+//   C. a world that exists only because it was LOADED still lists
+//   D. /worlds never founds a world (asking for the map leaves it unchanged)
+// Port discipline per the stale-listener incident: nonce file served from
+// THIS tree before any assertion counts.
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => {
+  if (ok) { pass++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { fail++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+
+const REPO = join(import.meta.dir, "..");
+const children: ChildProcess[] = [];
+const nonces: string[] = [];
+process.on("exit", () => {
+  for (const c of children) { try { c.kill(); } catch { /* gone */ } }
+  for (const n of nonces) { try { rmSync(n); } catch { /* ok */ } }
+});
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const cand = 20000 + Math.floor(Math.random() * 20000);
+    try { await fetch(`http://127.0.0.1:${cand}/`, { signal: AbortSignal.timeout(400) }); }
+    catch { return cand; }
+  }
+  throw new Error("no free port");
+}
+
+const worldsDir = mkdtempSync(join(tmpdir(), "worlds-route-"));
+// on disk: two real worlds, one dir with no log (never a world), one junk name
+for (const n of ["commons", "annex"]) {
+  mkdirSync(join(worldsDir, n), { recursive: true });
+  writeFileSync(join(worldsDir, n, "log.jsonl"), JSON.stringify({ seq: 0, ts: 0, actor: "world", verb: "genesis", args: { v: 2, dialect: "eidoverse-log" } }) + "\n");
+}
+mkdirSync(join(worldsDir, "logless"), { recursive: true });
+mkdirSync(join(worldsDir, ".clientlogs"), { recursive: true });
+
+async function spawnServer(): Promise<{ port: number }> {
+  const port = await freePort();
+  const nonce = `wr-nonce-${crypto.randomUUID().slice(0, 8)}`;
+  const noncePath = join(REPO, "client", `${nonce}.txt`);
+  writeFileSync(noncePath, nonce); nonces.push(noncePath);
+  const child = spawn(process.execPath, [join(REPO, "server", "server.ts")], {
+    env: { HOME: process.env.HOME, PATH: process.env.PATH, PORT: String(port), WORLDS_DIR: worldsDir },
+    stdio: "ignore",
+  });
+  children.push(child);
+  for (let i = 0; i < 40; i++) {
+    try { await fetch(`http://127.0.0.1:${port}/`); break; }
+    catch { await new Promise((r) => setTimeout(r, 250)); }
+  }
+  const own = await fetch(`http://127.0.0.1:${port}/${nonce}.txt`).then((r) => r.ok && r.text()).catch(() => false);
+  if (own !== nonce) throw new Error(`listener on :${port} is not our child — refusing to test it`);
+  return { port };
+}
+
+type Row = { name: string; loaded: boolean; people: string[]; agents: string[] };
+const fetchWorlds = async (port: number) => {
+  const r = await fetch(`http://127.0.0.1:${port}/worlds`);
+  return { res: r, rows: ((await r.json()) as { worlds: Row[] }).worlds };
+};
+const byName = (rows: Row[]) => Object.fromEntries(rows.map((r) => [r.name, r]));
+
+/** Join a world over the raw ws and wait for the snapshot. */
+function joinBody(port: number, world: string, id: string, extra: Record<string, unknown> = {}): Promise<WebSocket> {
+  return new Promise((res, rej) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const t = setTimeout(() => rej(new Error(`join ${id}@${world} timed out`)), 8000);
+    ws.onopen = () => ws.send(JSON.stringify({ type: "join", world, id, avatar: "", ...extra }));
+    ws.onmessage = (ev) => {
+      const m = JSON.parse(String(ev.data));
+      if (m.type === "snapshot") { clearTimeout(t); res(ws); }
+      if (m.type === "error") { clearTimeout(t); rej(new Error(m.error)); }
+    };
+  });
+}
+
+const { port } = await spawnServer();
+
+console.log("\n— A. on-disk worlds —");
+{
+  const { res, rows } = await fetchWorlds(port);
+  const names = rows.map((r) => r.name);
+  check("content-type json, no-store", res.headers.get("content-type")?.includes("json") === true && res.headers.get("cache-control") === "no-store");
+  check("both logged worlds listed", names.includes("commons") && names.includes("annex"), names.join(","));
+  check("a dir with no log is not a world", !names.includes("logless"), names.join(","));
+  check("dot-dirs are not worlds", !names.some((n) => n.startsWith(".")), names.join(","));
+  check("sorted by name", JSON.stringify(names) === JSON.stringify([...names].sort()), names.join(","));
+  check("unloaded on-disk world says so, empty", rows.every((r) => r.loaded === false && r.people.length === 0 && r.agents.length === 0), JSON.stringify(rows));
+}
+
+console.log("\n— B. presence —");
+{
+  const alice = await joinBody(port, "annex", "alice");
+  const bot = await joinBody(port, "annex", "bot", { agent: true });
+  const ghost = await joinBody(port, "commons", "ghost", { spectate: true });
+  await new Promise((r) => setTimeout(r, 200));
+  const m = byName((await fetchWorlds(port)).rows);
+  check("annex now loaded", m.annex?.loaded === true, JSON.stringify(m.annex));
+  check("a person lists under people", JSON.stringify(m.annex?.people) === JSON.stringify(["alice"]), JSON.stringify(m.annex));
+  check("an agent lists under agents, not people", JSON.stringify(m.annex?.agents) === JSON.stringify(["bot"]), JSON.stringify(m.annex));
+  check("a spectator appears as nothing", m.commons?.people.length === 0 && m.commons?.agents.length === 0, JSON.stringify(m.commons));
+  alice.close(); bot.close(); ghost.close();
+  await new Promise((r) => setTimeout(r, 300));
+  const after = byName((await fetchWorlds(port)).rows);
+  check("leaving empties the row (still loaded)", after.annex?.loaded === true && after.annex?.people.length === 0 && after.annex?.agents.length === 0, JSON.stringify(after.annex));
+}
+
+console.log("\n— C. loaded-only worlds list; D. the map never founds —");
+{
+  // join founds "fresh" in memory; its log lands on first append/flush —
+  // the route must list it from the registry regardless
+  const w = await joinBody(port, "fresh", "founder");
+  await new Promise((r) => setTimeout(r, 200));
+  const m = byName((await fetchWorlds(port)).rows);
+  check("a world that exists only as loaded state is listed", m.fresh?.loaded === true, Object.keys(m).join(","));
+  w.close();
+  const before = readdirSync(worldsDir).sort();
+  await fetch(`http://127.0.0.1:${port}/worlds?world=never-made`);
+  await fetch(`http://127.0.0.1:${port}/worlds`);
+  const afterDirs = readdirSync(worldsDir).sort();
+  check("/worlds creates nothing on disk", JSON.stringify(before) === JSON.stringify(afterDirs), afterDirs.join(","));
+  check("no phantom world from the query string", !(await fetchWorlds(port)).rows.some((r) => r.name === "never-made"));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+rmSync(worldsDir, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Why

`travel` landed in d44dc02 (2026-08-30) and is on the live door, but an agent has no way to learn where it could go: there is no route that lists worlds, and the RFC-005 join policy only speaks as a refusal after a move is attempted. This PR adds the discovery half — no change to travel itself.

## What

- **`GET /worlds`** (sequencer): union of loaded worlds and on-disk worlds with a `log.jsonl`; per world `{name, loaded, people[], agents[]}` for embodied clients (spectators, renderers and superseded legs appear as nothing, as in-world). Read-only — never calls `getWorld`, so asking for the map cannot found a world.
- **`worlds` tool** (shared table, both doors): marks the current world (`←`), lists occupancy by the ids `look` uses, and via a new `ToolCtx.worldPolicy` hook states per world whether *this* credential may travel there (the door's own `joinAllowed`) and whether it holds create authority. The stdio door has no policy vocabulary and says so.
- **net-server**: wires `worldPolicy` from `joinAllowed` / `auth.create`.
- **AGENTS.md**: documents `worlds` and `travel` (the latter was undocumented).

## Tests

- `bun tools/worlds-route-test.ts` — new, 14/14: on-disk listing (junk dirs and log-less dirs excluded), presence by class, loaded-only worlds, `/worlds` leaves the disk untouched.
- `bun tools/join-rfc005.test.ts` — 65/65 (6 new): advertised, current-world marker, `may travel` for `worlds:["*"]`, `not in your join policy` for a bound token, create-authority footer.
- `bun tools/stdio-door-test.ts` — 13/13.

## Not in this PR — operator note

In production the policy currently denies every travel: the VPS legacy `fable` token has no `worlds` list, and the home node mints no `worlds` claim (`roles.json` grants carry only `tier`/`sponsor`). Enabling travel for a role is a config edit on the home node, e.g. `"claims": {"worlds": ["*"]}` on that role's grant — deliberately left to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
