### PR TITLE
mcpl: match mentions on the token display name and send it as author.name

### DIFF
--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -5,7 +5,7 @@
 // every renderer. No GPU here — rendering is the retina's job (see server.ts).
 
 import { BodyStateReader, type BodyObservation, type PublicPose } from "./body-state.ts";
-import { mentionRegex } from "./mention.ts";
+import { mentionRegexFor } from "./mention.ts";
 import * as THREE_W from "three/webgpu";
 import * as TSL from "three/tsl";
 import { NoiseGate, SHORT_STINT_MS, APPROACH_REFRACT_MS, APPROACH_RADIUS, REARM_RADIUS,
@@ -155,7 +155,7 @@ const DOWNED_POSE: Record<string, number[]> = {
 };
 
 export class WorldAgent {
-  url: string; name: string; world: string; avatar: string; agentToken = "";
+  url: string; name: string; displayName: string; world: string; avatar: string; agentToken = "";
   ws: WebSocket | null = null;
   joined = false;
   pos = { x: 0, y: 0, z: 0 };
@@ -409,9 +409,12 @@ export class WorldAgent {
   private pendingDebug = new Map<string, (m: any) => void>();
   private histId = 0;
 
-  constructor(opts: { url?: string; name?: string; world?: string; avatar?: string; agentToken?: string } = {}) {
+  constructor(opts: { url?: string; name?: string; displayName?: string; world?: string; avatar?: string; agentToken?: string } = {}) {
     this.url = opts.url ?? process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws";
     this.name = opts.name ?? process.env.AGENT_NAME ?? "claude";
+    // The token's display name ("Artie (kube)"): a second form the body
+    // answers to in chat. The id stays the addressing handle everywhere else.
+    this.displayName = opts.displayName ?? process.env.AGENT_DISPLAY_NAME ?? "";
     this.world = opts.world ?? process.env.WORLD_NAME ?? "commons";
     this.avatar = opts.avatar ?? process.env.AGENT_AVATAR ?? "eidoverse/assets/vrms/claude.vrm";
     // The agent's own bearer (the one that opened the MCPL door). Forwarded at
@@ -1306,7 +1309,7 @@ export class WorldAgent {
         // A null regex means this body has no usable name (a malformed tokens
         // entry). Not being mentionable is degraded, not fatal — the body still
         // hears the room; it just cannot be addressed by name.
-        const rx = mentionRegex(this.name);
+        const rx = mentionRegexFor([this.name, this.displayName]);
         const mention = rx ? rx.test(String(args.text)) : false;
         if (mention) this.ping({ ts, kind: "mention", who: actor, text: args.text });
         this.onEvent?.({ ts, kind: "say", who: actor, text: args.text, mention });

--- a/mcpl/mention.ts
+++ b/mcpl/mention.ts
@@ -26,7 +26,25 @@
  *  different door. Returns null so callers can decide; a thrown regex was never
  *  a useful answer to "was I named?". */
 export function mentionRegex(id: unknown): RegExp | null {
-  if (typeof id !== "string" || !id) return null;
-  const safe = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(?<![\\w@])@?${safe}(?![\\w])`, "i");
+  return mentionRegexFor([id]);
+}
+
+/** The same pattern over every name a body answers to: its id (the mention
+ *  handle) and its token display name (tokens.json `name`, e.g. "Artie (kube)"
+ *  for id `artie-kube`), so "@Artie" reaches the body whose handle is longer
+ *  than the name people actually use. Malformed or
+ *  empty entries are skipped, duplicates collapse case-insensitively, and a
+ *  list with no usable name returns null exactly like `mentionRegex`. */
+export function mentionRegexFor(names: readonly unknown[]): RegExp | null {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const candidate of names) {
+    if (typeof candidate !== "string" || !candidate) continue;
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parts.push(candidate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  }
+  if (parts.length === 0) return null;
+  return new RegExp(`(?<![\\w@])@?(?:${parts.join("|")})(?![\\w])`, "i");
 }

--- a/mcpl/mention.ts
+++ b/mcpl/mention.ts
@@ -29,22 +29,37 @@ export function mentionRegex(id: unknown): RegExp | null {
   return mentionRegexFor([id]);
 }
 
+/** A trailing ` (qualifier)` on a name, the house label convention
+ *  (`#name (Guild)`, `Artie (kube)`): the part people drop when they address
+ *  the thing. Only a final parenthetical counts; nothing inside the name moves. */
+const TRAILING_QUALIFIER = /\s*\([^()]*\)\s*$/u;
+
 /** The same pattern over every name a body answers to: its id (the mention
  *  handle) and its token display name (tokens.json `name`, e.g. "Artie (kube)"
- *  for id `artie-kube`), so "@Artie" reaches the body whose handle is longer
- *  than the name people actually use. Malformed or
- *  empty entries are skipped, duplicates collapse case-insensitively, and a
- *  list with no usable name returns null exactly like `mentionRegex`. */
+ *  for id `artie-kube`), each also in its qualifier-dropped form, so "@Artie"
+ *  reaches the body whose handle is longer than the name people actually use.
+ *  Uniqueness is deliberately not required here, unlike channel-label
+ *  resolution: two bodies that both answer to "Artie" are both addressed,
+ *  which is what a room full of people does with a shared first name. Each
+ *  alternative still matches only as a whole handle: a hyphen counts as part
+ *  of one (`artie-kube` handles exist), so neither `artie` nor `artie-kube`
+ *  matches inside `artie-kubernetes`. Malformed or empty entries are skipped,
+ *  duplicates collapse case-insensitively, and a list with no usable name
+ *  returns null exactly like `mentionRegex`. */
 export function mentionRegexFor(names: readonly unknown[]): RegExp | null {
   const seen = new Set<string>();
   const parts: string[] = [];
+  const add = (form: string) => {
+    const key = form.toLowerCase();
+    if (!form || seen.has(key)) return;
+    seen.add(key);
+    parts.push(form.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  };
   for (const candidate of names) {
     if (typeof candidate !== "string" || !candidate) continue;
-    const key = candidate.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    parts.push(candidate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    add(candidate);
+    add(candidate.replace(TRAILING_QUALIFIER, ""));
   }
   if (parts.length === 0) return null;
-  return new RegExp(`(?<![\\w@])@?(?:${parts.join("|")})(?![\\w])`, "i");
+  return new RegExp(`(?<![\\w@-])@?(?:${parts.join("|")})(?![\\w-])`, "i");
 }

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -15,7 +15,7 @@
 // Tokens: mcpl/tokens.json  { "<token>": { "id": "mythos", "name": "Mythos",
 //         "world": "commons", "avatar": "eidoverse/assets/vrms/claude.vrm" } }
 
-import { mentionRegex } from "./mention.ts";
+import { mentionRegexFor } from "./mention.ts";
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { readFileSync, existsSync, writeFileSync, renameSync, rmSync } from "node:fs";
@@ -42,7 +42,7 @@ import { pingDelivery, type WirePing } from "./ping-wire.ts";
 import { MANIFEST_WITH_REVISION, ManifestAnnouncer } from "./manifest.ts";
 import { verifyToken, aid1Slug } from "../server/aid1.ts";
 import { atomicWrite } from "../server/fsutil.ts";
-import { lookupToken, readTokenRegistry, type TokenAuth } from "./token-registry.ts";
+import { displayNameIndex, lookupToken, readTokenRegistry, type TokenAuth } from "./token-registry.ts";
 
 const PORT = Number(process.env.MCPL_PORT ?? 8941);
 // archipelago-home door (home-node.md §7): a `?token=aid1.…` credential is an
@@ -183,6 +183,7 @@ class Session {
     this.conn = McplConnection.fromWebSocket(ws as never);
     this.agent = new WorldAgent({
       name: auth.id,
+      displayName: auth.name,
       world: auth.world ?? "commons",
       avatar: chosenAvatar[auth.id] ?? auth.avatar,
       url: process.env.WORLD_URL ?? "ws://127.0.0.1:8940/ws",
@@ -600,8 +601,11 @@ class Session {
     if (!this.granted(CAP.channelsIncoming)) return;
     // Platform-adapter convention (same as discord-mcpl): author is rendered
     // INTO the text — the host carries author metadata but does not label
-    // the context message with it.
-    const rendered = author.id === "world" ? text : `${author.name}: ${text}`;
+    // the context message with it. The rendered prefix is the ID, the
+    // addressing handle, even when `author.name` carries a display name: a
+    // host that matches its own name against the text must not be woken by
+    // another body whose display name merely contains it.
+    const rendered = author.id === "world" ? text : `${author.id}: ${text}`;
     const params: ChannelsIncomingParams = {
       messages: [{
         channelId: this.channelId,
@@ -667,7 +671,7 @@ class Session {
       const from = this.agent.isAgent(ev.who) ? CHAT.fromAgent : null;
       if (ev.kind === "say") {
         if (!this.channelOpen && !ev.mention) return; // door closed: chatter stops, knocks get through
-        this.deliver(ev.text!, { id: ev.who, name: ev.who }, ev.mention
+        this.deliver(ev.text!, authorOf(ev.who), ev.mention
           ? { tags: tags(CHAT.mention, CHAT.addressed, from), mentioned: true }
           : { tags: tags(CHAT.ambient, from) });
       } else if (ev.kind === "whisper") {
@@ -785,7 +789,7 @@ class Session {
       // mentionRegex returns null for an id with no matchable form — its
       // documented contract, honoured by agent.ts and violated here: a null
       // threw inside the prelude and killed the session at connect.
-      const rxSeq = mentionRegex(this.auth.id);
+      const rxSeq = mentionRegexFor([this.auth.id, this.auth.name]);
       const said = await this.agent.missedSince(sinceSeq);
       const missedSeq = said.filter((m) => m.who !== this.auth.id && !!rxSeq?.test(m.text));
       if (missedSeq.length) {
@@ -796,19 +800,19 @@ class Session {
           // ontology declares (issue #39: these shipped as bare legacy
           // ["mention"], which no declared rule could match). deliver()
           // renders the author itself — passing "who: text" here doubled it.
-          this.deliver(m.text, { id: m.who, name: m.who },
+          this.deliver(m.text, authorOf(m.who),
             { tags: tags(CHAT.mention, EIDO.catchup), mentioned: true });
         }
       }
     }
     const since = sinceSeq != null ? null : lastSeen[this.auth.id];
     if (since != null) {
-      const rx = mentionRegex(this.auth.id);   // null-safe: see rxSeq above
+      const rx = mentionRegexFor([this.auth.id, this.auth.name]);   // null-safe: see rxSeq above
       const missed = this.agent.inbox.filter((m) => m.kind === "say" && m.ts > since && m.who !== this.auth.id && !!rx?.test(m.text ?? ""));
       if (missed.length) {
         this.deliver(`While you were away, ${missed.length} message${missed.length === 1 ? "" : "s"} mentioned you:`,
           { id: "world", name: this.agent.world }, { tags: tags(CHAT.ambient, EIDO.catchup) });
-        for (const m of missed.slice(-10)) this.deliver(m.text ?? "", { id: m.who, name: m.who },
+        for (const m of missed.slice(-10)) this.deliver(m.text ?? "", authorOf(m.who),
           { tags: tags(CHAT.mention, EIDO.catchup), mentioned: true });
       }
     }
@@ -1000,7 +1004,7 @@ class Session {
                   history: says.map((m, i) => ({
                     channelId: this.channelId,
                     messageId: `hist-${m.ts}-${i}`,
-                    author: { id: m.who, name: m.who },
+                    author: authorOf(m.who),
                     timestamp: new Date(m.ts).toISOString(),
                     content: [{ type: "text", text: `${m.who}: ${m.text}` }],
                   })),
@@ -1276,10 +1280,15 @@ function joinAllowed(auth: Auth, world: string): boolean {
  *  Legacy bare-id entries are read as a fallback so existing residents don't
  *  get a full replay on the first post-upgrade connect. */
 const seqKey = (id: string, world: string) => `${id}@${world}`;
+// Refreshed on every connection attempt from the same registry read that
+// authorizes it; a remote id the registry does not name renders as itself.
+let knownDisplayNames: Map<string, string> = new Map();
+const authorOf = (id: string): { id: string; name: string } => ({ id, name: knownDisplayNames.get(id) ?? id });
 const sessions = new Map<string, Session>(); // identity → live session (newest wins)
 wss.on("connection", (ws, req) => {
   const token = new URL(req.url ?? "/", "http://localhost").searchParams.get("token");
   const registry = readTokens();
+  knownDisplayNames = displayNameIndex(registry);
   let auth = token ? lookupToken(registry, token) : undefined;
   let aidReason: string | null = null;
   if (!auth && token?.startsWith("aid1.") && HN_ISSUER_KEY) {

--- a/mcpl/net-server.ts
+++ b/mcpl/net-server.ts
@@ -42,7 +42,7 @@ import { pingDelivery, type WirePing } from "./ping-wire.ts";
 import { MANIFEST_WITH_REVISION, ManifestAnnouncer } from "./manifest.ts";
 import { verifyToken, aid1Slug } from "../server/aid1.ts";
 import { atomicWrite } from "../server/fsutil.ts";
-import { displayNameIndex, lookupToken, readTokenRegistry, type TokenAuth } from "./token-registry.ts";
+import { displayNameIndex, lookupToken, readTokenRegistry, wireAuthors, type TokenAuth } from "./token-registry.ts";
 
 const PORT = Number(process.env.MCPL_PORT ?? 8941);
 // archipelago-home door (home-node.md §7): a `?token=aid1.…` credential is an
@@ -605,7 +605,7 @@ class Session {
     // addressing handle, even when `author.name` carries a display name: a
     // host that matches its own name against the text must not be woken by
     // another body whose display name merely contains it.
-    const rendered = author.id === "world" ? text : `${author.id}: ${text}`;
+    const rendered = wire.renderLine(author, text);
     const params: ChannelsIncomingParams = {
       messages: [{
         channelId: this.channelId,
@@ -1006,7 +1006,7 @@ class Session {
                     messageId: `hist-${m.ts}-${i}`,
                     author: authorOf(m.who),
                     timestamp: new Date(m.ts).toISOString(),
-                    content: [{ type: "text", text: `${m.who}: ${m.text}` }],
+                    content: [{ type: "text", text: wire.renderLine(authorOf(m.who), m.text ?? "") }],
                   })),
                   historyTruncated: this.agent.inbox.filter((m) => m.kind === "say").length > limit,
                 } : {}),
@@ -1282,13 +1282,13 @@ function joinAllowed(auth: Auth, world: string): boolean {
 const seqKey = (id: string, world: string) => `${id}@${world}`;
 // Refreshed on every connection attempt from the same registry read that
 // authorizes it; a remote id the registry does not name renders as itself.
-let knownDisplayNames: Map<string, string> = new Map();
-const authorOf = (id: string): { id: string; name: string } => ({ id, name: knownDisplayNames.get(id) ?? id });
+let wire = wireAuthors(new Map<string, string>());
+const authorOf = (id: string) => wire.authorOf(id);
 const sessions = new Map<string, Session>(); // identity → live session (newest wins)
 wss.on("connection", (ws, req) => {
   const token = new URL(req.url ?? "/", "http://localhost").searchParams.get("token");
   const registry = readTokens();
-  knownDisplayNames = displayNameIndex(registry);
+  wire = wireAuthors(displayNameIndex(registry));
   let auth = token ? lookupToken(registry, token) : undefined;
   let aidReason: string | null = null;
   if (!auth && token?.startsWith("aid1.") && HN_ISSUER_KEY) {

--- a/mcpl/token-registry.ts
+++ b/mcpl/token-registry.ts
@@ -87,3 +87,15 @@ export function readTokenRegistry(tokensPath: string, examplePath: string, log: 
 export function lookupToken(registry: Record<string, TokenAuth>, token: string): TokenAuth | undefined {
   return Object.hasOwn(registry, token) ? registry[token] : undefined;
 }
+
+/** id -> display name for every accepted credential, so a remote participant's
+ *  token name can ride the wire as `author.name`. Ids
+ *  without a distinct name are absent; callers fall back to the id. Never
+ *  keyed by the secret. */
+export function displayNameIndex(registry: Record<string, TokenAuth>): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const auth of Object.values(registry)) {
+    if (auth.name && auth.name !== auth.id) index.set(auth.id, auth.name);
+  }
+  return index;
+}

--- a/mcpl/token-registry.ts
+++ b/mcpl/token-registry.ts
@@ -99,3 +99,19 @@ export function displayNameIndex(registry: Record<string, TokenAuth>): Map<strin
   }
   return index;
 }
+
+export type WireAuthor = { id: string; name: string };
+
+/** The wire contract for "who said this", built over one display-name index:
+ *  `authorOf(id)` carries the token display name in `author.name` (the id when
+ *  the registry has no distinct name), and `renderLine` writes the ID, the
+ *  addressing handle, into the text (world lines render bare). The prefix is
+ *  never the display name: a host that matches its own name against the text
+ *  must not be woken by another body whose display name merely contains it.
+ *  Every line a host receives, live or replayed, goes through these two. */
+export function wireAuthors(index: ReadonlyMap<string, string>) {
+  return {
+    authorOf: (id: string): WireAuthor => ({ id, name: index.get(id) ?? id }),
+    renderLine: (author: WireAuthor, text: string): string => (author.id === "world" ? text : `${author.id}: ${text}`),
+  };
+}

--- a/tools/author-wire-test.mjs
+++ b/tools/author-wire-test.mjs
@@ -1,0 +1,34 @@
+// The wire contract for "who said this" when a token's display name differs
+// from its id: `author.name` carries the display name, the rendered text keeps
+// the id as its prefix, and world lines render bare. Today every registry id
+// equals its name, so a revert of either half is invisible to the rest of the
+// suite; these cases go red on their own.
+import { displayNameIndex, wireAuthors } from '../mcpl/token-registry.ts';
+let pass = 0, fail = 0;
+const check = (n, c) => { c ? (pass++, console.log(`ok   ${n}`)) : (fail++, console.log(`FAIL ${n}`)); };
+
+const registry = {
+  'secret-1': { id: 'artie-kube', name: 'Artie (kube)', world: 'commons', avatar: '' },
+  'secret-2': { id: 'hesperus', name: 'hesperus', world: 'commons', avatar: '' },
+  'secret-3': { id: 'nameless', world: 'commons', avatar: '' },
+};
+const index = displayNameIndex(registry);
+check('index maps an id to its distinct display name', index.get('artie-kube') === 'Artie (kube)');
+check('index omits an id whose name equals the id', !index.has('hesperus'));
+check('index omits an id with no name', !index.has('nameless'));
+check('index is keyed by id, never by the secret', ![...index.keys()].some((k) => k.startsWith('secret-')));
+
+const wire = wireAuthors(index);
+const artie = wire.authorOf('artie-kube');
+check('author.name is the token display name', artie.name === 'Artie (kube)');
+check('author.id is the addressing handle', artie.id === 'artie-kube');
+check('an unnamed id falls back to itself', wire.authorOf('hesperus').name === 'hesperus');
+check('an id the registry does not know renders as itself', wire.authorOf('stranger').name === 'stranger');
+
+const line = wire.renderLine(artie, 'over here');
+check('the rendered prefix is the id, not the display name', line === 'artie-kube: over here');
+check('the display name never reaches the rendered text', !line.includes('Artie'));
+check('world lines render bare', wire.renderLine({ id: 'world', name: 'commons' }, 'the sun sets') === 'the sun sets');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/mention-regex-test.mjs
+++ b/tools/mention-regex-test.mjs
@@ -30,14 +30,25 @@ try { new RegExp(`(@a(\\b|\\ba(\\b)`, 'i'); } catch { oldThrew = true; }
 check('control: the unescaped form does throw', oldThrew);
 
 // ── a body answers to its id AND its token display name ────────────
+// A display name's trailing ` (qualifier)` is the part people drop when they
+// address the body (the `#name (Guild)` label convention), so "@Artie" must
+// reach the body named "Artie (kube)". Uniqueness is not required: two bodies
+// that both answer to "Artie" are both addressed.
 {
   const rx = mentionRegexFor(['artie-kube', 'Artie (kube)']);
-  check('display-name alternation matches the id handle', rx.test('hey @artie-kube come here'));
-  check('display-name alternation matches the display name', rx.test('@Artie (kube), over here'));
-  check('display-name alternation matches the bare display name', rx.test('artie (KUBE) are you there'));
-  check('display-name alternation does not match a prefix of the id', !rx.test('artie-kubernetes is a different body'));
-  check('display-name alternation does not match a bare prefix word', !rx.test('artie is over there'));
+  check('"@Artie, over here" reaches artie-kube', rx.test('@Artie, over here'));
+  check('"Artie, over here" reaches artie-kube', rx.test('Artie, over here'));
+  check('"@Artie (kube), over here" reaches artie-kube', rx.test('@Artie (kube), over here'));
+  check('"hey artie-kube" reaches artie-kube', rx.test('hey artie-kube'));
+  check('"artie is over there" reaches artie-kube (the qualifier-dropped name is the feature)', rx.test('artie is over there'));
+  check('the full display name still matches in any case', rx.test('artie (KUBE) are you there'));
+  check('a prefix of the id is a different body', !rx.test('artie-kubernetes is a different body'));
+  check('a prefix of the dropped name is a different body', !rx.test('artiest of them all'));
+  check('an id with a trailing qualifier gets the same treatment', mentionRegexFor(['zed (two)']).test('@zed hi'));
+  check('a name that is only a qualifier contributes no empty alternative', mentionRegexFor(['(kube)']).source.split('|').length === 1 && !mentionRegexFor(['(kube)']).test('anything at all'));
+  check('a parenthetical inside the name is not a qualifier', !mentionRegexFor(['a (b) c']).test('a is here') && mentionRegexFor(['a (b) c']).test('@a (b) c is here'));
   check('duplicate names collapse', mentionRegexFor(['nova', 'Nova']).source.split('|').length === 1);
+  check('the dropped form collapses with an equal id', mentionRegexFor(['artie', 'Artie (kube)']).source.split('|').length === 2);
   check('malformed entries are skipped, not fatal', mentionRegexFor([undefined, 42, 'zed']).test('@zed'));
   check('no usable name yields null', mentionRegexFor([undefined, '']) === null);
 }

--- a/tools/mention-regex-test.mjs
+++ b/tools/mention-regex-test.mjs
@@ -2,7 +2,7 @@
 // tokens.json. Before this was escaped, an id with regex metacharacters threw
 // inside a catch-all — so the agent silently never heard its own name again,
 // for the life of the process, with a single log line and no other symptom.
-import { mentionRegex } from '../mcpl/mention.ts';
+import { mentionRegex, mentionRegexFor } from '../mcpl/mention.ts';
 let pass = 0, fail = 0;
 const check = (n, c) => { c ? (pass++, console.log(`ok   ${n}`)) : (fail++, console.log(`FAIL ${n}`)); };
 
@@ -28,6 +28,19 @@ check('a dot does not match any character', !mentionRegex('c.d').test('cxd here'
 let oldThrew = false;
 try { new RegExp(`(@a(\\b|\\ba(\\b)`, 'i'); } catch { oldThrew = true; }
 check('control: the unescaped form does throw', oldThrew);
+
+// ── a body answers to its id AND its token display name ────────────
+{
+  const rx = mentionRegexFor(['artie-kube', 'Artie (kube)']);
+  check('display-name alternation matches the id handle', rx.test('hey @artie-kube come here'));
+  check('display-name alternation matches the display name', rx.test('@Artie (kube), over here'));
+  check('display-name alternation matches the bare display name', rx.test('artie (KUBE) are you there'));
+  check('display-name alternation does not match a prefix of the id', !rx.test('artie-kubernetes is a different body'));
+  check('display-name alternation does not match a bare prefix word', !rx.test('artie is over there'));
+  check('duplicate names collapse', mentionRegexFor(['nova', 'Nova']).source.split('|').length === 1);
+  check('malformed entries are skipped, not fatal', mentionRegexFor([undefined, 42, 'zed']).test('@zed'));
+  check('no usable name yields null', mentionRegexFor([undefined, '']) === null);
+}
 
 // ── malformed ids must DEGRADE, never throw ────────────────────────────────
 // The id comes from JSON.parse of an operator-edited tokens.json, and


### PR DESCRIPTION
## What is wrong

Any MCPL body whose `tokens.json` display name differs from its id (say id `artie-kube`, name `Artie (kube)`) hits two problems on the door:

1. **Mentions only match the id.** `"@Artie, over here"` never reaches the body whose handle is `artie-kube`. The live regex in `agent.ts`, both catch-up scans in `net-server.ts`, and every other `mentionRegex` consumer only know the id.
2. **The display name never reaches the wire.** `author.name` is always the id on live lines, catch-up lines and history items, so no host can show the name the token actually carries.

## What this changes

- `mcpl/mention.ts`: `mentionRegexFor(names)` builds one pattern over every form a body answers to: each name and its qualifier-dropped form (a trailing ` (qualifier)` is the part people drop when they address the body, the same convention as `#name (Guild)` channel labels). Uniqueness is deliberately not required here, unlike label resolution: two bodies that both answer to "Artie" are both addressed. Only a final parenthetical counts. A hyphen counts as part of a handle on both sides of a match, so neither `artie` nor `artie-kube` matches inside `artie-kubernetes`. `mentionRegex(id)` is unchanged in contract (null for a malformed id, nothing thrown) and delegates to it.
- `mcpl/agent.ts`: `WorldAgent` carries a `displayName` (constructor option, `AGENT_DISPLAY_NAME` env for standalone use, parallel to `AGENT_NAME`) and matches mentions on both.
- `mcpl/token-registry.ts`: `displayNameIndex(registry)` gives id to name for every accepted credential, never keyed by the secret; `wireAuthors(index)` returns `{ authorOf, renderLine }`, the one place the wire contract lives.
- `mcpl/net-server.ts`: passes the token name into the agent, rebuilds `wireAuthors` on every connection attempt from the same registry read that authorizes it, and routes every render site through it: the live `deliver()` prefix, the history text (previously a second copy of the same rule), and `authorOf` for live, catch-up and history authors.

## Two deliberate choices to check

- The rendered `"id: text"` prefix uses `author.id` rather than `author.name`. On today's main that is a no-op because name and id are always equal. Once display names ride the wire, keeping the addressing handle in the text means a host that matches its own name against the text cannot be woken by another body whose display name merely contains it. History items already rendered the id, so the two paths now agree, and now share one function.
- The index refreshes per connection attempt, so an edit to `tokens.json` reaches the wire on the next connect, not instantly.

## Verification

- `bun tools/mention-regex-test.mjs`: 51 passed, 0 failed. The review's six vectors are transcribed as written: `@Artie, over here`, `Artie, over here`, `@Artie (kube), over here`, `hey artie-kube` and `artie is over there` match; `artie-kubernetes is a different body` does not. Also covered: a qualifier-only name contributes no empty alternative, an inner parenthetical is not a qualifier, an id with a trailing qualifier gets the same treatment, duplicates collapse, malformed entries degrade to null as before.
- `bun tools/author-wire-test.mjs` (new): 11 passed, 0 failed. Goes red if the prefix reverts to the display name, if `authorOf` stops reading the index, if world lines gain a prefix, or if the index is keyed by the secret.
- `tsc --noEmit --strict` on `mcpl/mention.ts` and `mcpl/token-registry.ts`: clean. The pre-existing diagnostics in `net-server.ts` and `agent.ts` (76, unchanged) do not touch the changed lines.
- `tools/look-test.ts` does not run on current main regardless of this change: `client/lib/poseclips.js` imports `@pixiv/three-vrm-animation`, which `package.json` does not declare.

## Commits

- `c1398c1`: the two fixes as first reviewed.
- `4b4a715`: review fixes. Qualifier-dropped display names, the hyphen boundary that keeps `artie-kubernetes` a different body, `wireAuthors` and the wire-contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
