### PR TITLE
picture: an image on a named part — rung 1 of the projector ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,32 @@ mode and `undefined` otherwise. Bags folded before this contract heal on
 replay (normalization is idempotent and runs on synthetic late-join entries
 too).
 
+**Things can show a PICTURE — an image on a named part.** `comp {id, type:
+"picture", data}` hangs an image on one node of the entity's model. An
+ordinary component: builder rights, folded blindly, and the declaration IS
+the picture. Rung 1 of the projector ladder — the screen comp is a picture
+whose texture is a video, and it will reuse every seam here.
+
+```
+comp {id: "console", type: "picture",
+      data: {src: "eidoverse/assets/pictures/hearth_at_dusk.png",
+             part: "screenplane",
+             look: "a print of the hearth at dusk, embers still lit",
+             lit: "self"}}
+comp {id: "console", type: "picture", data: null}      # take it down
+```
+
+`src` is a library-relative `.png`/`.jpg`/`.webp` under `eidoverse/assets/`
+(the sequencer's own /library/ route, overlay included) — **never a URL**: a
+picture is a placed asset, not a fetch the world performs for someone. `part`
+names the GLB node to texture; `measure {id}` lists a model's parts. `look`
+(≤200 chars) is what text-tier residents perceive — `look()` says "a picture
+on its screenplane: <look>"; without it they see only the file name, so say
+what it shows. `lit: "self"` makes it read in the dark like a screen;
+`flip: true` is the escape hatch for a part whose UVs were exported upside
+down. Hanging a picture is not narrated live in text tier (only emitters have a
+live sensory event); it appears in the next `look()`.
+
 **Things can EMIT — fire, embers, smoke, motes.** `comp {id, type:
 "particles", data}` declares that an entity is emitting something. It is an
 ordinary component: builder rights, folded blindly, ≤8KB, and it never writes

--- a/client/lib/pictures.js
+++ b/client/lib/pictures.js
@@ -1,0 +1,135 @@
+// pictures — the browser host for the `picture` component.
+//
+// Owns the THREE-bound half: loading the image off the library route, finding
+// the named part on the owning entity, swapping that part's material for a
+// clone carrying the image, and putting the original back when the picture
+// comes down. The split mirrors emitters.js:
+//
+//   shared/picture.js — what a `picture` bag MEANS (shared with the mcpl agent)
+//   this file         — hosting
+//
+// Two rules that are easy to get wrong and are therefore stated:
+//
+//   1. NEVER mutate the part's material. glTF materials are shared across
+//      primitives and across instances of the same model; painting one
+//      screen by writing `map` on its material paints every screen in the
+//      world. The host clones, textures the clone, and restores the original
+//      on removal — the clone is ours to dispose, the original never was.
+//   2. NEVER dispose the texture. loadImageTexture caches by bytes and pins
+//      the texture for the session (assets.js §16.2.B: `dispose` is a no-op
+//      on cached textures); the cache owns it, the picture borrows it. Same
+//      ownership rule as emitter sprites.
+
+import { THREE } from './core.js';
+import { bus } from './base.js';
+import { primeFiles } from './assets.js';
+import { entities, findPart } from './world.js';
+import { normalizePicture } from '../../shared/picture.js';
+
+// id → { picture, part, original, material } for every picture currently hung
+const hung = new Map();
+// id → picture whose entity (or part) is not in the scene yet — replay usually
+// delivers the comp before the GLB has landed; the bag is folded and look()
+// is right the whole time, the texture just waits for something to land on.
+const pending = new Map();
+
+async function pictureTexture(picture) {
+  await primeFiles([picture.src]);
+  const bytes = globalThis.Deno.readFileSync(picture.src);
+  // glTF UVs are authored in glTF convention (no vertical flip); the shim's
+  // default bakes the browser flip for procedurally-mapped surfaces. A picture
+  // on a modelled part wants the glTF convention, so flipY:false — `flip` is
+  // the author's escape hatch for a part whose UVs were exported the other
+  // way, which the by-eye check tells you in one glance.
+  return globalThis.loadImageTexture(bytes, { srgb: true, flipY: picture.flip === true });
+}
+
+function takeDown(id) {
+  const h = hung.get(id);
+  if (!h) return;
+  hung.delete(id);
+  // The part may have been re-realized (promote/demote) since we hung on it;
+  // only restore if our clone is still what it wears.
+  if (h.part.material === h.material) h.part.material = h.original;
+  h.material.dispose();     // ours; the texture is not (see rule 2)
+}
+
+async function hang(id, picture) {
+  const root = entities.get(id);
+  if (!root) { pending.set(id, picture); return; }
+  const part = findPart(root, picture.part);
+  if (!part || !part.material) {
+    // Legible, once: the comp folds and reads correctly in text tier; there is
+    // just no such part on this model to hang it on. `measure {id}` lists them.
+    console.warn(`[pictures] ${id}: part "${picture.part}" not found on the model — nothing hung`);
+    pending.delete(id);
+    return;
+  }
+  let tex;
+  try { tex = await pictureTexture(picture); }
+  catch (e) { console.warn(`[pictures] ${id}: ${picture.src} could not be loaded — nothing hung`, e); return; }
+  // Replace (same id, new bag): the old clone goes first so `original` is
+  // always the model's own material, never a previous picture's clone.
+  takeDown(id);
+  if (!hung.has(id) && entities.get(id) !== root) return;   // entity re-realized mid-load
+  const original = part.material;
+  const material = original.clone();
+  material.map = tex;
+  // A picture's colours are the picture's: an authored base colour would tint
+  // it. White base, and for a self-lit picture the image also drives emissive
+  // so it reads in the dark the way a screen does.
+  if (material.color) material.color.set(0xffffff);
+  if (picture.lit === 'self' && 'emissive' in material) {
+    material.emissive.set(0xffffff);
+    material.emissiveMap = tex;
+    material.emissiveIntensity = 1;
+  }
+  material.needsUpdate = true;
+  part.material = material;
+  hung.set(id, { picture, part, original, material });
+  pending.delete(id);
+}
+
+function applyFrom(id, data) {
+  if (data == null) { pending.delete(id); takeDown(id); return; }
+  const norm = normalizePicture(data);
+  if (!norm.ok) {
+    console.warn(`[pictures] ${id}: ${norm.why}`);
+    pending.delete(id); takeDown(id);
+    return;
+  }
+  if (norm.notes?.length) console.warn(`[pictures] ${id}: ${norm.notes.join(' · ')}`);
+  void hang(id, norm.picture);
+}
+
+bus.on('comp', ({ id, type, data }) => {
+  if (type !== 'picture') return;
+  applyFrom(id, data);
+});
+
+bus.on('entity', ({ id, kind }) => {
+  if (kind === 'remove' || kind === 'demote') {
+    // the subtree left the scene with our clone on it; forget the handle
+    // (restoring a material on a detached mesh is harmless but pointless),
+    // and keep the bag pending so a promote re-hangs it.
+    const h = hung.get(id);
+    if (h) { hung.delete(id); h.material.dispose(); if (kind === 'demote') pending.set(id, h.picture); }
+  } else if (kind === 'spawn') {
+    // a promote replaces the subtree: whatever we hung is on the old one
+    const h = hung.get(id);
+    if (h) { hung.delete(id); h.material.dispose(); pending.set(id, h.picture); }
+    if (pending.has(id)) { const p = pending.get(id); pending.delete(id); void hang(id, p); }
+  }
+});
+
+bus.on('world-reset', () => clearPictures());
+
+export function clearPictures() {
+  pending.clear();
+  for (const id of [...hung.keys()]) takeDown(id);
+}
+
+/** For probes: what is hung where. */
+export const _hung = hung;
+export const pictureCount = () => hung.size;
+export { THREE as _THREE };

--- a/client/main.js
+++ b/client/main.js
@@ -23,6 +23,7 @@ import { initCauses } from './lib/realize/causes.js';
 // side-effecting: the `particles` component's host wires itself to the comp
 // and entity buses on import (it has no boot step of its own)
 import './lib/emitters.js';
+import './lib/pictures.js';
 import { tickMotion } from './lib/motion.js';
 import {
   myState, updateMe, updateSpectator, setCamYaw, setPosture, togglePhotoMode,

--- a/mcpl/agent.ts
+++ b/mcpl/agent.ts
@@ -48,6 +48,7 @@ import { radialForce, FORCE_MIN } from "../shared/force.js";
 // a renderer client and a resident who perceives by reading must agree about
 // what is burning (#25's shared-facts boundary).
 import { describeParticles, emitterTransition, transitionLine } from "../shared/particles.js";
+import { describePicture } from "../shared/picture.js";
 import { describeStructure, describeHere, localizePoint, planStructure, routeLocal } from "../shared/structure.js";
 import { effectiveWorldTransform, type Effective } from "./effective.ts";
 import { makeVerdictCache, seatGateCore, nameFromAvatarPath } from "../client/lib/seatcore.js";
@@ -3100,6 +3101,10 @@ export class WorldAgent {
       // or contact: separate authored components would provide those, and a
       // resident who reads "warm" acts on it.
       if (c.particles) aff.push(describeParticles(c.particles));
+      // A picture is named by what its author SAID it shows, on the part that
+      // carries it — never by its pixels. Rung 1 of the projector ladder; the
+      // screen comp will read the same way with a rolling caption instead.
+      if (c.picture) aff.push(describePicture(c.picture));
       // locked = nailed down: the server refuses every move/replace/remove on
       // it. Saying so here saves an agent a refused verb round-trip.
       if (c.lock) aff.push(`🔒 locked (immovable until comp {id, type: "lock", data: null})`);
@@ -3108,7 +3113,7 @@ export class WorldAgent {
       // structure component buys: `components: structure` would be true and
       // useless, where "a building: 2 rooms, 14 walls, 1 door" is actionable.
       if (c.structure) { try { aff.push(describeStructure(c.structure)); } catch { /* a broken house is not a broken look() */ } }
-      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles", "lock", "structure"].includes(k));
+      const extra = Object.keys(c).filter((k) => !["sockets", "reactions", "motion", "particles", "picture", "lock", "structure"].includes(k));
       if (extra.length) aff.push(`components: ${extra.join(", ")}`);
       const ride = this.mounts.get(e.id);
       if (ride) aff.push(`mounted on ${ride.to}${f.ok && f.moving ? ` (riding its ${f.moving})` : ""}`);

--- a/shared/picture.js
+++ b/shared/picture.js
@@ -1,0 +1,93 @@
+// picture — what a `picture` component MEANS. Shared verbatim between the
+// browser host (client/lib/pictures.js) and the mcpl agent (text-tier
+// perception), so the two can never describe different pictures.
+//
+//   comp {id, type: "picture", data: {src, part, look?, lit?, flip?}}
+//   comp {id, type: "picture", data: null}          # take it down
+//
+// A picture is an image on a NAMED PART of the entity that owns it — the #167
+// shape: the comp names a GLB node, the host textures that node's material.
+// It is rung 1 of the projector ladder (anima_dev/eidoverse_projector_design.md):
+// the screen comp is a picture whose texture is a video, so every seam here
+// (allow-listed source, named part, the look line, restore-on-remove) is the
+// seam the screen will reuse.
+//
+// SOURCE ALLOW-LIST. `src` is a library-relative path under `eidoverse/assets/`
+// — served by the sequencer's own /library/ route (Skye's library plus the
+// assets/opt overlay). Never a URL: a picture is an authored asset the operator
+// placed, not a fetch the world performs on someone's behalf. That is the whole
+// content story for this rung, and it is what keeps a picture inside the world
+// log's trust boundary instead of reaching out of it.
+//
+// THE LOOK LINE. Text-tier residents perceive by reading. A picture with no
+// `look` reads as "a picture (<file>)", which is true and nearly useless; the
+// author can say what it shows in ≤200 chars and that sentence is what look()
+// carries. Nothing about pixels is ever claimed — the host renders, the line
+// describes, and the two are the author's responsibility to keep honest.
+
+export const PICTURE_DIR = 'eidoverse/assets/';
+const IMAGE_EXT = /\.(png|jpe?g|webp)$/i;
+export const PICTURE_LOOK_MAX = 200;
+export const PICTURE_LIT = Object.freeze({ scene: 'lit by the scene', self: 'self-lit (a screen)' });
+const KNOWN_KEYS = new Set(['src', 'part', 'look', 'lit', 'flip']);
+
+/** Is `src` an allowed picture source? Library-relative, under PICTURE_DIR,
+ *  image extension, no scheme, no leading slash, no dot segments. */
+export function allowedPictureSrc(src) {
+  if (typeof src !== 'string' || !src) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(src) || src.startsWith('/') || src.includes('\\')) return false;
+  if (src.split('/').some((seg) => seg === '' || seg === '.' || seg === '..')) return false;
+  return src.startsWith(PICTURE_DIR) && IMAGE_EXT.test(src);
+}
+
+/** Validate an authored bag. `ok:false` carries WHY (legible, once per authoring);
+ *  `ok:true` carries the normalized picture plus notes for anything coerced. */
+export function normalizePicture(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { ok: false, why: 'picture data must be an object {src, part, look?}' };
+  }
+  if (!allowedPictureSrc(data.src)) {
+    return {
+      ok: false,
+      why: `src ${JSON.stringify(data.src ?? null)} is not an allowed picture source — a library-relative ` +
+        `.png/.jpg/.webp under ${PICTURE_DIR} (no URLs: pictures are placed assets, not fetches)`,
+    };
+  }
+  if (typeof data.part !== 'string' || !data.part.trim() || data.part.length > 64) {
+    return { ok: false, why: 'part must name the GLB node to texture (a non-empty string, ≤64 chars) — measure {id} lists them' };
+  }
+  const notes = [];
+  const unknown = Object.keys(data).filter((k) => !KNOWN_KEYS.has(k) && !k.startsWith('_'));
+  if (unknown.length) notes.push(`ignored by the evaluator: ${unknown.join(', ')} (accepted: ${[...KNOWN_KEYS].join(', ')})`);
+  const picture = { src: data.src, part: data.part.trim(), lit: 'scene', flip: false };
+  if (data.look != null) {
+    const look = String(data.look).replace(/\s+/g, ' ').trim();
+    if (look.length > PICTURE_LOOK_MAX) {
+      notes.push(`look clipped to ${PICTURE_LOOK_MAX} chars`);
+      picture.look = look.slice(0, PICTURE_LOOK_MAX);
+    } else if (look) picture.look = look;
+  }
+  if (!picture.look) notes.push('no look line — text-tier residents will see only the file name; say what it shows');
+  if (data.lit != null) {
+    if (Object.hasOwn(PICTURE_LIT, data.lit)) picture.lit = data.lit;
+    else notes.push(`lit ${JSON.stringify(data.lit)} is unknown (${Object.keys(PICTURE_LIT).join('/')}) — using scene`);
+  }
+  if (data.flip != null) picture.flip = data.flip === true;
+  return { ok: true, picture, notes };
+}
+
+/** The one line look() carries for a picture — the same string on every
+ *  client, from the same bag. Says what the author said it shows; never
+ *  claims anything about the pixels. */
+export function describePicture(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return 'a picture (malformed declaration)';
+  const file = typeof data.src === 'string' ? data.src.split('/').pop() : null;
+  const look = typeof data.look === 'string' && data.look.trim() ? data.look.replace(/\s+/g, ' ').trim().slice(0, PICTURE_LOOK_MAX) : null;
+  const where = typeof data.part === 'string' && data.part ? ` on its ${data.part}` : '';
+  const ok = allowedPictureSrc(data.src) && typeof data.part === 'string' && data.part;
+  const bits = [];
+  if (!ok) bits.push('not shown: invalid declaration');
+  if (data.lit === 'self') bits.push('self-lit');
+  const tail = bits.length ? ` (${bits.join('; ')})` : '';
+  return look ? `a picture${where}: ${look}${tail}` : `a picture${where} (${file ?? 'no file'})${tail}`;
+}

--- a/tools/picture-probe.ts
+++ b/tools/picture-probe.ts
@@ -1,0 +1,84 @@
+// picture-probe — the ONE owned browser receipt for the `picture` component:
+// a real sequencer, a real model, a real image off the library route.
+//
+//   bun tools/picture-probe.ts          (EIDOVERSE_DIR must point at the library)
+//
+// What must hold, in order:
+//   A. hanging a picture textures the NAMED PART's material — a clone, not
+//      the model's own material (the same material serves every instance);
+//   B. `lit: "self"` drives emissive from the image; the base colour is white;
+//   C. taking it down restores the original material object;
+//   D. a URL source hangs nothing (allow-list, product path);
+//   E. LATE JOIN — a fresh client that receives the comp before the GLB has
+//      landed still hangs it once the part exists (the pending path).
+// Plus a screenshot for the by-eye check the tests cannot make.
+import { launchBrowser, ownedWorld, checker } from './probe-harness.mjs';
+import { join } from 'node:path';
+
+const LIB = 'eidoverse/assets/models/scif_cyberpunk_crt_retro_computer_monitor_screen_keyboard_tower.glb';
+// Default image: the model's own library preview. PICTURE_SRC overrides (e.g.
+// an orientation card in an OPT_DIR overlay) for the by-eye flip check.
+const IMG = process.env.PICTURE_SRC ?? 'eidoverse/assets/models/scif_cyberpunk_crt_retro_computer_monitor_screen_keyboard_tower_preview.jpg';
+const { check, done } = checker();
+const world = await ownedWorld({ env: { EIDOVERSE_DIR: process.env.EIDOVERSE_DIR ?? join(process.env.HOME!, 'origin/eidoverse-video'), ...(process.env.OPT_DIR ? { OPT_DIR: process.env.OPT_DIR } : {}) } });
+const { page, close } = await launchBrowser();
+const errs: string[] = [];
+async function joinAs(name: string) {
+  const pg = await page();
+  pg.on('pageerror', (e) => errs.push(e.message));
+  pg.on('console', (m) => { const t = m.text(); if (/\[pictures\]/.test(t)) console.log('   console:', t.slice(0, 160)); });
+  pg.on('dialog', (d) => d.dismiss().catch(() => {}));
+  await pg.goto(`${world.origin}/?world=picprobe&key=${world.key}&name=${name}`, { waitUntil: 'domcontentloaded' });
+  await pg.fill('#d-name', name).catch(() => {});
+  await pg.click('#d-go').catch(() => {});
+  await pg.waitForSelector('#mictoggle', { timeout: 30000 });
+  return pg;
+}
+const state = (pg: any) => pg.evaluate(async () => {
+  const { entities, findPart } = await import('/lib/world.js');
+  const { _hung } = await import('/lib/pictures.js');
+  const root = entities.get('console'); const part = root ? findPart(root, 'screenplane') : null;
+  const h = _hung.get('console');
+  const mat: any = part?.material;
+  return {
+    entity: !!root, part: !!part, hung: !!h,
+    cloned: !!(h && part && mat === h.material && mat !== h.original),
+    mapW: mat?.map?.image?.width ?? 0, emissiveMap: !!mat?.emissiveMap, white: mat?.color ? mat.color.getHex() === 0xffffff : null,
+    restored: !!(part && !h && !mat?.map) ,
+  };
+});
+const until = async (pg: any, pred: (s: any) => boolean, ms = 20000) => { const t0 = Date.now(); let s; while (Date.now() - t0 < ms) { s = await state(pg); if (pred(s)) return s; await new Promise((r) => setTimeout(r, 200)); } return s; };
+try {
+  const pg = await joinAs('picprobe');
+  await pg.evaluate((lib) => import('/lib/net.js').then((n: any) => n.sendVerb('spawn', { id: 'console', lib, pos: [1.3, 0.5, -2.2], yaw: 0.6 })), LIB);
+  let s = await until(pg, (x) => x.part);
+  check('the model spawned and has a part named screenplane', s.part, JSON.stringify(s));
+  const original = await pg.evaluate(async () => { const { entities, findPart } = await import('/lib/world.js'); const p = findPart(entities.get('console'), 'screenplane'); (window as any).__origMat = p.material; return p.material.uuid; });
+  await pg.evaluate((src) => import('/lib/net.js').then((n: any) => n.sendVerb('comp', { id: 'console', type: 'picture', data: { src, part: 'screenplane', look: "the console's own preview, hung on its screen", lit: 'self' } })), IMG);
+  s = await until(pg, (x) => x.hung && x.mapW > 0);
+  check('A. the picture hangs on the named part as a CLONED material', s.hung && s.cloned, JSON.stringify(s));
+  check('A. …carrying the image as its map (decoded, non-zero width)', s.mapW > 0, JSON.stringify(s));
+  check('B. self-lit: emissive map is the image, base colour white', s.emissiveMap && s.white === true, JSON.stringify(s));
+  await new Promise((r) => setTimeout(r, 1500));
+  if (process.env.PICTURE_SHOT) await pg.screenshot({ path: process.env.PICTURE_SHOT });
+  // E. late join: a second client gets the comp on join, before the GLB lands
+  const pg2 = await joinAs('latecomer');
+  const s2 = await until(pg2, (x) => x.hung && x.mapW > 0);
+  check('E. a late joiner hangs the picture once the part exists (pending path)', s2.hung && s2.cloned && s2.mapW > 0, JSON.stringify(s2));
+  await pg2.close();
+  // C. take it down
+  await pg.evaluate(() => import('/lib/net.js').then((n: any) => n.sendVerb('comp', { id: 'console', type: 'picture', data: null })));
+  s = await until(pg, (x) => !x.hung);
+  const sameObj = await pg.evaluate(async () => { const { entities, findPart } = await import('/lib/world.js'); return findPart(entities.get('console'), 'screenplane').material === (window as any).__origMat; });
+  check('C. taking it down restores the model\'s own material object', !s.hung && sameObj && s.restored, JSON.stringify(s));
+  // D. a URL source: refused at the meaning layer, nothing hung, material untouched
+  await pg.evaluate(() => import('/lib/net.js').then((n: any) => n.sendVerb('comp', { id: 'console', type: 'picture', data: { src: 'https://example.com/x.png', part: 'screenplane', look: 'smuggled' } })));
+  await new Promise((r) => setTimeout(r, 1500));
+  s = await state(pg);
+  const stillOrig = await pg.evaluate(async () => { const { entities, findPart } = await import('/lib/world.js'); return findPart(entities.get('console'), 'screenplane').material === (window as any).__origMat; });
+  check('D. a URL source hangs nothing and leaves the material alone', !s.hung && stillOrig, JSON.stringify(s));
+  check('no page errors across the cycle', errs.length === 0, errs.join(' | '));
+} finally {
+  await close(); await world.close();
+}
+done();

--- a/tools/picture-test.ts
+++ b/tools/picture-test.ts
@@ -1,0 +1,75 @@
+// The `picture` component's meaning + text-tier perception, without a browser.
+//
+//   bun tools/picture-test.ts
+//
+// Two legs:
+//   1. DECLARATION — the source allow-list (library-relative image under
+//      eidoverse/assets/, never a URL, never a path escape), the named part,
+//      the look line and its bound, unknown keys noted, and a `describe` that
+//      says what the author said and nothing about pixels.
+//   2. PERCEPTION  — what look() carries for a resident who reads: the line
+//      appears on the owning entity, tracks a replace, and is gone on removal;
+//      other component types still read as they did.
+// Every check fails on main by construction: `picture` did not exist.
+import { normalizePicture, describePicture, allowedPictureSrc, PICTURE_LOOK_MAX } from "../shared/picture.js";
+process.env.EW_EMITTER_COALESCE_SEC = "0.25";
+const { WorldAgent } = await import("../mcpl/agent.ts");
+
+let pass = 0, fail = 0;
+const check = (name: string, ok: boolean, detail = "") => { ok ? pass++ : fail++; console.log(`${ok ? "  ok" : "FAIL"}  ${name}${ok || !detail ? "" : ` — ${detail}`}`); };
+
+console.log("— 1. declaration —");
+const GOOD = "eidoverse/assets/pictures/hearth_at_dusk.png";
+for (const [src, expect] of [
+  [GOOD, true], ["eidoverse/assets/models/thing_preview.jpg", true], ["eidoverse/assets/x/y.webp", true],
+  ["https://example.com/x.png", false], ["http://x/y.jpg", false], ["data:image/png;base64,AAAA", false],
+  ["/eidoverse/assets/x.png", false], ["eidoverse/assets/../secret.png", false], ["eidoverse/assets/./x.png", false],
+  ["eidoverse/assets//x.png", false], ["other/x.png", false], ["eidoverse/assets/x.gif", false], ["eidoverse/assets/x.glb", false],
+  ["eidoverse\\assets\\x.png", false], ["", false], [null, false],
+] as [unknown, boolean][]) check(`allowedPictureSrc(${JSON.stringify(src)}) === ${expect}`, allowedPictureSrc(src) === expect);
+
+const n0 = normalizePicture({ src: GOOD, part: "screenplane", look: "a print of the hearth at dusk", lit: "self" });
+check("a well-formed bag normalizes", n0.ok && n0.picture.src === GOOD && n0.picture.part === "screenplane" && n0.picture.lit === "self" && n0.picture.flip === false, JSON.stringify(n0));
+check("…with no notes", n0.ok && n0.notes.length === 0, JSON.stringify(n0.ok && n0.notes));
+const nUrl = normalizePicture({ src: "https://example.com/x.png", part: "screenplane" });
+check("a URL source is refused, legibly, naming the rule", !nUrl.ok && /not an allowed picture source/.test(nUrl.why) && /no URLs/.test(nUrl.why), JSON.stringify(nUrl));
+const nPart = normalizePicture({ src: GOOD });
+check("a missing part is refused and points at measure", !nPart.ok && /measure/.test(nPart.why), JSON.stringify(nPart));
+check("an over-long part is refused", !normalizePicture({ src: GOOD, part: "x".repeat(65) }).ok);
+const nLook = normalizePicture({ src: GOOD, part: "p", look: "  many   spaces\n\nand " + "z".repeat(400) });
+check("look is whitespace-collapsed and clipped with a note", nLook.ok && nLook.picture.look.length === PICTURE_LOOK_MAX && nLook.picture.look.startsWith("many spaces and ") && nLook.notes.some((x) => /clipped/.test(x)), JSON.stringify(nLook.ok && nLook.notes));
+const nNoLook = normalizePicture({ src: GOOD, part: "p" });
+check("no look line is allowed but noted (text-tier sees only the file)", nNoLook.ok && !nNoLook.picture.look && nNoLook.notes.some((x) => /no look line/.test(x)));
+const nUnknown = normalizePicture({ src: GOOD, part: "p", look: "x", scale: 2, _private: 1, lit: "neon" });
+check("unknown keys and an unknown lit are noted, not fatal; _keys ignored silently", nUnknown.ok && nUnknown.notes.some((x) => /ignored by the evaluator: scale/.test(x) && !/_private/.test(x)) && nUnknown.notes.some((x) => /lit "neon" is unknown/.test(x)) && nUnknown.picture.lit === "scene", JSON.stringify(nUnknown.notes));
+check("malformed bags are refused", !normalizePicture(null).ok && !normalizePicture([]).ok && !normalizePicture("x").ok);
+
+check("describe: with a look line, says what the author said, on the part", describePicture({ src: GOOD, part: "screenplane", look: "a print of the hearth at dusk" }) === "a picture on its screenplane: a print of the hearth at dusk");
+check("describe: self-lit is named", /\(self-lit\)$/.test(describePicture({ src: GOOD, part: "p", look: "x", lit: "self" })));
+check("describe: without a look line, the file name", describePicture({ src: GOOD, part: "p" }) === "a picture on its p (hearth_at_dusk.png)");
+check("describe: an invalid declaration says it is not shown", /not shown: invalid declaration/.test(describePicture({ src: "https://x/y.png", part: "p", look: "x" })));
+check("describe: malformed", describePicture(null) === "a picture (malformed declaration)");
+check("describe never mentions pixels/colours (it carries the author's claim only)", !/pixel|colour|color/.test(describePicture({ src: GOOD, part: "p", look: "x" })));
+
+console.log("— 2. perception —");
+const T0 = 1_754_000_000_000;
+const ag = new WorldAgent({ name: "reader" });
+const A = ag as any;
+A.applyEntry({ verb: "spawn", args: { id: "console", lib: "scif_cyberpunk_crt_retro_computer_monitor_screen_keyboard_tower.glb", pos: [1, 0, 1] }, ts: T0, seq: 1, actor: "antra" }, false);
+A.applyEntry({ verb: "comp", args: { id: "console", type: "picture", data: { src: GOOD, part: "screenplane", look: "a print of the hearth at dusk" } }, ts: T0 + 1, seq: 2, actor: "antra" }, true);
+let out = ag.look();
+check("look() names the picture on the owning entity, by the author's line", /\[console\][^\n]*a picture on its screenplane: a print of the hearth at dusk/.test(out), out.split("\n").find((l) => l.includes("console")) ?? out);
+check("…and does not fall through to `components: picture`", !/components: picture/.test(out));
+A.applyEntry({ verb: "comp", args: { id: "console", type: "picture", data: { src: GOOD, part: "screenplane", look: "the same print, re-hung" } }, ts: T0 + 2, seq: 3, actor: "antra" }, true);
+out = ag.look();
+check("a replace reads as the new line, not both", /re-hung/.test(out) && !/hearth at dusk/.test(out));
+A.applyEntry({ verb: "comp", args: { id: "console", type: "picture", data: { src: "https://example.com/x.png", part: "screenplane", look: "smuggled" } }, ts: T0 + 3, seq: 4, actor: "antra" }, true);
+out = ag.look();
+check("an invalid source folds (blind fold) but reads as not shown", /smuggled/.test(out) && /not shown: invalid declaration/.test(out), out.split("\n").find((l) => l.includes("console")) ?? out);
+A.applyEntry({ verb: "comp", args: { id: "console", type: "picture", data: null }, ts: T0 + 4, seq: 5, actor: "antra" }, true);
+check("a removed picture is gone from look()", !/a picture/.test(ag.look()));
+A.applyEntry({ verb: "comp", args: { id: "console", type: "recipe", data: { x: 1 } }, ts: T0 + 5, seq: 6, actor: "antra" }, true);
+check("other component types still read as they did", /components: recipe/.test(ag.look()));
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What

`comp {id, type: "picture", data: {src, part, look?, lit?, flip?}}` — an image on one named node of the entity's model. Rung 1 of the projector ladder in the design note posted to #eidoverse_devchat on 9/9: the screen comp is a picture whose texture is a video, so this builds every seam the screen will reuse and exercises each on its own. It is also meant as a small worked example for the component-system conversation Rabscuttle asked for — one comp, the particles split, nothing invented.

## The seams

- **Source allow-list.** `src` is a library-relative `.png/.jpg/.webp` under `eidoverse/assets/` (the sequencer's own `/library/` route, `assets/opt` overlay included). Never a URL: a picture is a placed asset, not a fetch the world performs on someone's behalf. That is the whole content story for this rung; refusal is legible and names the rule.
- **Named part** (#167's shape): the comp names a GLB node, the host textures that node's material. `measure {id}` lists them.
- **The look line.** Text-tier residents perceive by reading. `look` (≤200 chars) is what `look()` carries — `a picture on its screenplane: <look>` — and nothing about pixels is ever claimed. Without it they see only the file name, and the evaluator says so in its notes.
- **Restore on remove.** The host never mutates the part's material (glTF materials are shared across primitives and instances — painting one screen would paint every screen). It clones, textures the clone, and puts the original object back when the picture comes down. The texture is cache-owned (`assets.js` pins it) and is never disposed here, same rule as emitter sprites.
- `lit: "self"` drives emissive from the image so it reads in the dark like a screen; base colour is set white so an authored tint doesn't colour the picture. `flip` is the escape hatch for a part whose UVs were exported the other way; glTF convention (`flipY:false`) is the default and is right for the CRT.

Split mirrors particles: `shared/picture.js` is the meaning (shared verbatim with the mcpl agent), `client/lib/pictures.js` is the host, `agent.ts` adds one line to `look()`. Hanging a picture has no live percept (only emitters carry a live sensory event); it appears in the next `look()`. If a generic "a comp changed near you" percept is the right systemic answer, that belongs to the component-system conversation, not this PR.

## Tests

- `tools/picture-test.ts` — serverless, **37/37**: the allow-list case by case (URLs, `data:`, absolute paths, dot segments, backslashes, wrong extensions), part/look/lit/unknown-key handling with notes, `describe` strings, and perception through the real `WorldAgent`: the line appears on the owning entity, tracks a replace, an invalid source folds (blind fold, as it must) but reads "not shown", removal clears it, other component types unchanged.
- `tools/picture-probe.ts` — owned browser, **8/8**: real sequencer + the CRT model from the library; the picture hangs on `screenplane` as a *cloned* material carrying the decoded image; self-lit sets `emissiveMap` and a white base; a **late joiner** (comp arrives before the GLB) hangs it through the pending path; taking it down restores the model's own material object (identity-checked); a URL source hangs nothing and leaves the material alone; no page errors.
- Orientation checked by eye: a card with a white bar along its top and a green bar along its left, hung from an `OPT_DIR` overlay (`OPT_DIR=… PICTURE_SRC=eidoverse/assets/pictures/orientation.png PICTURE_SHOT=out.png bun tools/picture-probe.ts`), renders upright with the bars where they belong.
- Neighbours: `particles-test` 93/93; `bun build mcpl/agent.ts` clean. Two environment notes, not this PR: `bun build mcpl/net-server.ts` fails identically on main here for want of `@animalabs/mcpl-core` (the sibling dependency closure), and `emitter-percept-test` hangs on this machine on main as well.

## Not in this rung

`fit`/aspect handling (the image is applied through the part's authored UVs as-is), a live percept for hanging, and any upload path for images — a builder drops files under the library overlay today. The music player (rung 2) is the caption bot without video; the screen (rung 3) is this comp with a `VideoTexture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoQK2cP55YhezE6ajSx58h
